### PR TITLE
use recv character event instead of keyboard input

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -79,16 +79,11 @@ pub fn ui_loop(editor: Arc<Mutex<Editor>>, nvim: Neovim, initial_size: (u64, u64
             },
 
             Event::WindowEvent {
-                event: WindowEvent::KeyboardInput {
-                    input,
-                    ..
-                },
+                event: WindowEvent::ReceivedCharacter(c),
                 ..
             } => {
-                if let Some(string) = construct_keybinding_string(input) {
-                    nvim.input(&string).expect("Input call failed...");
-                }
-            },
+                nvim.input(&c.to_string()).expect("Input call failed...");
+            }
 
             Event::WindowEvent {
                 event: WindowEvent::CursorMoved {


### PR DESCRIPTION
I was checking [alacritty](https://github.com/jwilm/alacritty/blob/1cfb0740bc530da3162292bbf682a234240f26a3/alacritty/src/event.rs#L511) and see they use ReceivedCharacter to send to tty and only use KeyboardInput for hotkey.
This is because for my keyboard, the Colon key is comprise from:
```
Construct keybinding: KeyboardInput { scancode: 39, state: Released, virtual_keycode: Some(Colon), modifiers: ModifiersState { shift: true, ctrl: false, alt: false, logo: false } }
```
and not `Semicolon` with shift modifier, same for most of other shift-based character like `*`, `(`, `)`, ..