### PR TITLE
Port to nvim-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,16 @@ checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 
 [[package]]
 name = "bytes"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+dependencies = [
+ "byteorder",
+ "iovec",
+]
+
+[[package]]
+name = "bytes"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10004c15deb332055f7a4a208190aed362cf9a7c2f6ab70a305fba50e1105f38"
@@ -775,6 +785,105 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
+name = "futures"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
+
+[[package]]
+name = "futures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f16056ecbb57525ff698bb955162d0cd03bee84e6241c27ff75c08d8ca5987"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcae98ca17d102fd8a3603727b9259fcf7fa4239b603d2142926189bc8999b86"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79564c427afefab1dfb3298535b21eda083ef7935b4f0ecbfcb121f0aec10866"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e274736563f686a837a0568b478bdabfeaec2dca794b5649b04e2fe1627c231"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e676577d229e70952ab25f3945795ba5b16d63ca794ca9d2c860e5595d20b5ff"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e7c56c15537adb4f76d0b7a76ad131cb4d2f4f32d3b0bcabcbe1c7c5e87764"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2 1.0.7",
+ "quote 1.0.2",
+ "syn 1.0.13",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171be33efae63c2d59e6dbba34186fe0d6394fb378069a76dfd80fdcffd43c16"
+
+[[package]]
+name = "futures-task"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bae52d6b29cf440e298856fec3965ee6fa71b06aa7495178615953fd669e5f9"
+
+[[package]]
+name = "futures-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76"
+dependencies = [
+ "futures 0.1.29",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
+ "tokio-io",
+]
 
 [[package]]
 name = "gdk"
@@ -1482,16 +1591,16 @@ dependencies = [
 
 [[package]]
 name = "nvim-rs"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f920d183863ab5de29bf953921b286dc5d214620f385e1bfed82a2b0ec6f44"
+version = "0.1.1-alpha.0"
+source = "git+https://github.com/KillTheMule/nvim-rs?branch=futures#d2012790f7d3876f3bad88185d07a030e4933d37"
 dependencies = [
  "async-trait",
+ "futures 0.3.1",
  "log",
+ "pin-project",
  "rmp",
  "rmpv",
  "tokio",
- "unix_socket",
 ]
 
 [[package]]
@@ -1605,10 +1714,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pin-project"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b90146c7216e4cb534069fb91366de4ea0ea353105ee45ed297e2d1619e469"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44ca92f893f0656d3cba8158dd0f2b99b94de256a4a54e870bd6922fcc6c8355"
+dependencies = [
+ "proc-macro2 1.0.7",
+ "quote 1.0.2",
+ "syn 1.0.13",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8822eb8bb72452f038ebf6048efa02c3fe22bf83f76519c9583e47fc194a422"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 
 [[package]]
 name = "pkg-config"
@@ -1644,6 +1779,12 @@ dependencies = [
  "quote 1.0.2",
  "syn 1.0.13",
 ]
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
 
 [[package]]
 name = "proc-macro2"
@@ -2272,7 +2413,7 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffa2fdcfa937b20cb3c822a635ceecd5fc1a27a6a474527e5516aa24b8c8820a"
 dependencies = [
- "bytes",
+ "bytes 0.5.3",
  "fnv",
  "iovec",
  "lazy_static",
@@ -2286,6 +2427,17 @@ dependencies = [
  "signal-hook-registry",
  "tokio-macros",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "tokio-io"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
+dependencies = [
+ "bytes 0.4.12",
+ "futures 0.1.29",
+ "log",
 ]
 
 [[package]]
@@ -2339,16 +2491,6 @@ name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-
-[[package]]
-name = "unix_socket"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa2700417c405c38f5e6902d699345241c28c0b7ade4abaad71e35a87eb1564"
-dependencies = [
- "cfg-if",
- "libc",
-]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,7 +1369,6 @@ dependencies = [
  "image",
  "lru",
  "msgbox",
- "neovim-lib",
  "nvim-rs",
  "rmpv",
  "rust-embed",
@@ -1377,16 +1376,6 @@ dependencies = [
  "skulpin",
  "tokio",
  "winres",
-]
-
-[[package]]
-name = "neovim-lib"
-version = "0.6.0"
-source = "git+https://github.com/daa84/neovim-lib#5291bf754bcfa55dcf6332808f72d09ebd78ce90"
-dependencies = [
- "log",
- "rmpv",
- "unix_socket",
 ]
 
 [[package]]
@@ -1863,8 +1852,6 @@ checksum = "ff4792131b8bf59f4b49a546de03c004eb4b54468d4816044af12c3b7942df5b"
 dependencies = [
  "num-traits",
  "rmp",
- "serde",
- "serde_bytes",
 ]
 
 [[package]]
@@ -2012,15 +1999,6 @@ name = "serde"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325a073952621257820e7a3469f55ba4726d8b28657e7e36653d1c36dc2c84ae"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "serde_json"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ msgbox = "0.4.0"
 rust-embed = { version = "5.2.0", features = ["debug-embed"] }
 image = "0.22.3"
 nvim-rs = "0.1.0"
+#nvim-rs = { git = "https://github.com/KillTheMule/nvim-rs", branch = "master" }
 tokio = { version = "0.2.9", features = [ "blocking" ] }
 async-trait = "0.1.18"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ lru = "0.4.3"
 skulpin = "0.5"
 derive-new = "0.5"
 env_logger = "0.7.1"
-neovim-lib = { git = "https://github.com/daa84/neovim-lib", version = "0.6" }
+#neovim-lib = { git = "https://github.com/daa84/neovim-lib", version = "0.6" }
 rmpv = "0.4.2"
 msgbox = "0.4.0"
 rust-embed = { version = "5.2.0", features = ["debug-embed"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ rmpv = "0.4.2"
 msgbox = "0.4.0"
 rust-embed = { version = "5.2.0", features = ["debug-embed"] }
 image = "0.22.3"
-nvim-rs = "0.1.0"
-#nvim-rs = { git = "https://github.com/KillTheMule/nvim-rs", branch = "master" }
-tokio = { version = "0.2.9", features = [ "blocking" ] }
+#nvim-rs = "0.1.0"
+nvim-rs = { git = "https://github.com/KillTheMule/nvim-rs", branch = "futures", features = [ "use_tokio" ] }
+tokio = { version = "0.2.9", features = [ "blocking", "process" ] }
 async-trait = "0.1.18"
 
 [build-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,7 @@ fn main() {
     let editor = Arc::new(Mutex::new(Editor::new(INITIAL_WIDTH, INITIAL_HEIGHT)));
     let (sender, receiver) = channel::<UiCommand>();
     let editor_clone = editor.clone();
-    rt.spawn(async move {
+    rt.spawn_blocking(async move {
       start_nvim(editor_clone, receiver).await;
     });
     ui_loop(editor, sender, (INITIAL_WIDTH, INITIAL_HEIGHT));

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ struct NeovimHandler(Arc<Mutex<Editor>>);
 impl Handler for NeovimHandler {
     type Writer = ChildStdin;
 
-    async fn handle_request(&self, event_name: String, arguments: Vec<Value>, neovim: Neovim<ChildStdin>) -> Result<Value, Value> {
+    async fn handle_notify(&self, event_name: String, arguments: Vec<Value>, neovim: Neovim<ChildStdin>) {
         dbg!(&event_name);
         let parsed_events = parse_neovim_event(event_name, arguments)
             .unwrap_or_explained_panic("Could not parse event", "Could not parse event from neovim");
@@ -66,7 +66,6 @@ impl Handler for NeovimHandler {
             let mut editor = self.0.lock().unwrap();
             editor.handle_redraw_event(event);
         }
-        Ok(Value::Nil)
     }
 }
 

--- a/src/ui_commands.rs
+++ b/src/ui_commands.rs
@@ -1,5 +1,6 @@
 use nvim_rs::Neovim;
-use nvim_rs::runtime::ChildStdin;
+use nvim_rs::compat::tokio::Compat;
+use tokio::process::ChildStdin;
 
 #[derive(Debug)]
 pub enum UiCommand {
@@ -11,7 +12,7 @@ pub enum UiCommand {
 }
 
 impl UiCommand {
-    pub async fn execute(&self, nvim: &Neovim<ChildStdin>) {
+    pub async fn execute(&self, nvim: &Neovim<Compat<ChildStdin>>) {
         match self {
             UiCommand::Resize { width, height } => 
                 nvim.ui_try_resize(*width.max(&10), *height.max(&3)).await


### PR DESCRIPTION
Ok, here are the changes necessary to make it work, at least it compiles. At mentioned in https://github.com/Kethku/neovide/issues/20, I have no way to test if this works.

Key points:
- UI events are notifications. This was kind of hidden from you in neovim-lib by the channel handler, but it's always been this way :)
- I'm using the futures branch of nvim-rs, since that's the future of nvim-rs :) It comes with a tad more ceremony around using tokio, but at least somewhat enables other runtimes.
- I've restricted my changes to `main`, and I did not do error handling or something
- A main point to make the sync channel from std (necessary since you need it in the winit event loop) work with the async fn's is to have it owned by `main` at first, so we can send it off to `start_nvim` afterwards, which loops on reading from it
  - We could spawn off the await directly after reading, but that's a bit of a design question aroung `UiCommand`, so I didn't do it

All research points towards what I suspected from my knowledge of rust's async ecosystem: There's no way to integrate `winit`s event loop with the one from `tokio`. You can't run futures from one in the other and vice versa (also, winit needs it's own custom loop because of performance reasons afaik, so it will never just provide futures that might be run on a different executor). The same applies to glib/async-std as far as I know, so that's just no surprise. You will just have to live with 2 runtimes, or forego async communication with neovim (which in your case seems possible, since you're only receiving notifications anyways).