### PR TITLE
Fix nvim-rs dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,7 +1594,7 @@ dependencies = [
 [[package]]
 name = "nvim-rs"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/KillTheMule/nvim-rs?branch=futures#9efc7480f976d80f9e57443d62c1da2f37805186"
+source = "git+https://github.com/KillTheMule/nvim-rs#9efc7480f976d80f9e57443d62c1da2f37805186"
 dependencies = [
  "async-trait",
  "futures 0.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ env_logger = "0.7.1"
 rmpv = "0.4.2"
 rust-embed = { version = "5.2.0", features = ["debug-embed"] }
 image = "0.22.3"
-nvim-rs = { git = "https://github.com/KillTheMule/nvim-rs", branch = "futures", features = [ "use_tokio" ] }
+nvim-rs = { git = "https://github.com/KillTheMule/nvim-rs", features = [ "use_tokio" ] }
 tokio = { version = "0.2.9", features = [ "blocking", "process", "time" ] }
 async-trait = "0.1.18"
 lazy_static = "1.4.0"


### PR DESCRIPTION
Fixes #47.

Note that this error only comes up when translating HTTPS to SSH for git; nonetheless, good to fix (as the branch no longer exists).