### PR TITLE
Remove unnecessary clones and allocations from bridge module

### DIFF
--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -159,95 +159,97 @@ fn unpack_color(packed_color: u64) -> Color4f {
     }
 }
 
-fn parse_array(array_value: &Value) -> Result<Vec<Value>> {
-    if let Value::Array(content) = array_value.clone() {
-        Ok(content.to_vec())
+fn parse_array(array_value: &Value) -> Result<&[Value]> {
+    if let Value::Array(content) = array_value {
+        Ok(&content[..])
     } else {
         Err(EventParseError::InvalidArray(array_value.clone()))
     }
 }
 
-fn parse_map(map_value: &Value) -> Result<Vec<(Value, Value)>> {
-    if let Value::Map(content) = map_value.clone() {
-        Ok(content)
+fn parse_map(map_value: &Value) -> Result<&[(Value, Value)]> {
+    if let Value::Map(content) = map_value {
+        Ok(&content[..])
     } else {
         Err(EventParseError::InvalidMap(map_value.clone()))
     }
 }
 
-fn parse_string(string_value: &Value) -> Result<String> {
-    if let Value::String(content) = string_value.clone() {
-        Ok(content.into_str().ok_or(EventParseError::InvalidString(string_value.clone()))?)
+fn parse_string(string_value: &Value) -> Result<&str> {
+    if let Value::String(content) = string_value {
+        content.as_str().ok_or_else(|| EventParseError::InvalidString(string_value.clone()))
     } else {
         Err(EventParseError::InvalidString(string_value.clone()))
     }
 }
 
 fn parse_u64(u64_value: &Value) -> Result<u64> {
-    if let Value::Integer(content) = u64_value.clone() {
-        Ok(content.as_u64().ok_or(EventParseError::InvalidU64(u64_value.clone()))?)
+    if let Value::Integer(content) = u64_value {
+        Ok(content.as_u64().ok_or_else(|| EventParseError::InvalidU64(u64_value.clone()))?)
     } else {
         Err(EventParseError::InvalidU64(u64_value.clone()))
     }
 }
 
 fn parse_i64(i64_value: &Value) -> Result<i64> {
-    if let Value::Integer(content) = i64_value.clone() {
-        Ok(content.as_i64().ok_or(EventParseError::InvalidI64(i64_value.clone()))?)
+    if let Value::Integer(content) = i64_value {
+        Ok(content.as_i64().ok_or_else(|| EventParseError::InvalidI64(i64_value.clone()))?)
     } else {
         Err(EventParseError::InvalidI64(i64_value.clone()))
     }
 }
 
 fn parse_bool(bool_value: &Value) -> Result<bool> {
-    if let Value::Boolean(content) = bool_value.clone() {
-        Ok(content)
+    if let Value::Boolean(content) = bool_value {
+        Ok(*content)
     } else {
         Err(EventParseError::InvalidBool(bool_value.clone()))
     }
 }
 
-fn parse_set_title(set_title_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [title] = set_title_arguments.as_slice() {
+fn parse_set_title(set_title_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [title] = set_title_arguments {
         Ok(RedrawEvent::SetTitle {
-            title: parse_string(title)?
+            title: parse_string(title)?.to_string()
         })
     } else {
         Err(EventParseError::InvalidEventFormat)
     }
 }
 
-fn parse_mode_info_set(mode_info_set_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [_cursor_style_enabled, mode_info] = mode_info_set_arguments.as_slice() {
+fn parse_mode_info_set(mode_info_set_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [_cursor_style_enabled, mode_info] = mode_info_set_arguments {
         let mode_info_values = parse_array(mode_info)?;
-        let mut cursor_modes = Vec::new();
+        let mut cursor_modes = Vec::with_capacity(mode_info_values.len());
+
         for mode_info_value in mode_info_values {
-            let info_map = parse_map(&mode_info_value)?;
+            let info_map = parse_map(mode_info_value)?;
             let mut mode_info = CursorMode::default();
+
             for (name, value) in info_map {
-                let name = parse_string(&name)?;
-                match name.as_ref() {
+                match parse_string(name)? {
                     "cursor_shape" => {
-                        mode_info.shape = CursorShape::from_type_name(&parse_string(&value)?);
+                        mode_info.shape = CursorShape::from_type_name(parse_string(value)?);
                     },
                     "cell_percentage" => {
-                        mode_info.cell_percentage = Some(parse_u64(&value)? as f32 / 100.0);
+                        mode_info.cell_percentage = Some(parse_u64(value)? as f32 / 100.0);
                     },
                     "blinkwait" => {
-                        mode_info.blinkwait = Some(parse_u64(&value)?);
+                        mode_info.blinkwait = Some(parse_u64(value)?);
                     },
                     "blinkon" => {
-                        mode_info.blinkon = Some(parse_u64(&value)?);
+                        mode_info.blinkon = Some(parse_u64(value)?);
                     },
                     "blinkoff" => {
-                        mode_info.blinkoff = Some(parse_u64(&value)?);
+                        mode_info.blinkoff = Some(parse_u64(value)?);
                     }
                     "attr_id" => {
-                        mode_info.style_id = Some(parse_u64(&value)?);
+                        mode_info.style_id = Some(parse_u64(value)?);
                     },
                     _ => {}
                 }
             }
+
             cursor_modes.push(mode_info);
         }
         Ok(RedrawEvent::ModeInfoSet {
@@ -258,20 +260,20 @@ fn parse_mode_info_set(mode_info_set_arguments: Vec<Value>) -> Result<RedrawEven
     }
 }
 
-fn parse_option_set(option_set_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [name, value] = option_set_arguments.as_slice() {
+fn parse_option_set(option_set_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [name, value] = option_set_arguments {
         Ok(RedrawEvent::OptionSet {
-            gui_option: match parse_string(&name)?.as_ref() {
-                "arabicshape" => GuiOption::AribicShape(parse_bool(&value)?),
-                "ambiwidth" => GuiOption::AmbiWidth(parse_string(&value)?),
-                "emoji" => GuiOption::Emoji(parse_bool(&value)?),
-                "guifont" => GuiOption::GuiFont(parse_string(&value)?),
-                "guifontset" => GuiOption::GuiFontSet(parse_string(&value)?),
-                "guifontwide" => GuiOption::GuiFontWide(parse_string(&value)?),
-                "linespace" => GuiOption::LineSpace(parse_u64(&value)?),
-                "pumblend" => GuiOption::Pumblend(parse_u64(&value)?),
-                "showtabline" => GuiOption::ShowTabLine(parse_u64(&value)?),
-                "termguicolors" => GuiOption::TermGuiColors(parse_bool(&value)?),
+            gui_option: match parse_string(name)? {
+                "arabicshape" => GuiOption::AribicShape(parse_bool(value)?),
+                "ambiwidth" => GuiOption::AmbiWidth(parse_string(value)?.to_string()),
+                "emoji" => GuiOption::Emoji(parse_bool(value)?),
+                "guifont" => GuiOption::GuiFont(parse_string(value)?.to_string()),
+                "guifontset" => GuiOption::GuiFontSet(parse_string(value)?.to_string()),
+                "guifontwide" => GuiOption::GuiFontWide(parse_string(value)?.to_string()),
+                "linespace" => GuiOption::LineSpace(parse_u64(value)?),
+                "pumblend" => GuiOption::Pumblend(parse_u64(value)?),
+                "showtabline" => GuiOption::ShowTabLine(parse_u64(value)?),
+                "termguicolors" => GuiOption::TermGuiColors(parse_bool(value)?),
                 unknown_option => GuiOption::Unknown(unknown_option.to_string(), value.clone())
             }
         })
@@ -280,34 +282,34 @@ fn parse_option_set(option_set_arguments: Vec<Value>) -> Result<RedrawEvent> {
     }
 }
 
-fn parse_mode_change(mode_change_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [_mode, mode_index] = mode_change_arguments.as_slice() {
+fn parse_mode_change(mode_change_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [_mode, mode_index] = mode_change_arguments {
         Ok(RedrawEvent::ModeChange {
-            mode_index: parse_u64(&mode_index)?
+            mode_index: parse_u64(mode_index)?
         })
     } else {
         Err(EventParseError::InvalidEventFormat)
     }
 }
 
-fn parse_grid_resize(grid_resize_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [grid_id, width, height] = grid_resize_arguments.as_slice() {
+fn parse_grid_resize(grid_resize_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [grid_id, width, height] = grid_resize_arguments {
         Ok(RedrawEvent::Resize { 
-            grid: parse_u64(&grid_id)?, width: parse_u64(&width)?, height: parse_u64(&height)?
+            grid: parse_u64(grid_id)?, width: parse_u64(width)?, height: parse_u64(height)?
         })
     } else {
         Err(EventParseError::InvalidEventFormat)
     }
 }
 
-fn parse_default_colors(default_colors_arguments: Vec<Value>) -> Result<RedrawEvent> {
+fn parse_default_colors(default_colors_arguments: &[Value]) -> Result<RedrawEvent> {
     if let [
         foreground, background, special, _term_foreground, _term_background
-    ] = default_colors_arguments.as_slice() {
+    ] = default_colors_arguments {
         Ok(RedrawEvent::DefaultColorsSet {
             colors: Colors {
-                foreground: Some(unpack_color(parse_u64(&foreground)?)),
-                background: Some(unpack_color(parse_u64(&background)?)),
+                foreground: Some(unpack_color(parse_u64(foreground)?)),
+                background: Some(unpack_color(parse_u64(background)?)),
                 special: Some(unpack_color(parse_u64(special)?)),
             }
         })
@@ -319,6 +321,7 @@ fn parse_default_colors(default_colors_arguments: Vec<Value>) -> Result<RedrawEv
 fn parse_style(style_map: &Value) -> Result<Style> {
     if let Value::Map(attributes) = style_map {
         let mut style = Style::new(Colors::new(None, None, None));
+
         for attribute in attributes {
             if let (Value::String(name), value) = attribute {
                 match (name.as_str().unwrap(), value) {
@@ -338,39 +341,40 @@ fn parse_style(style_map: &Value) -> Result<Style> {
                 println!("Invalid attribute format");
             }
         }
+
         Ok(style)
     } else {
         Err(EventParseError::InvalidMap(style_map.clone()))
     }
 }
 
-fn parse_hl_attr_define(hl_attr_define_arguments: Vec<Value>) -> Result<RedrawEvent> {
+fn parse_hl_attr_define(hl_attr_define_arguments: &[Value]) -> Result<RedrawEvent> {
     if let [
         id, attributes, _terminal_attributes, _info
-    ] = hl_attr_define_arguments.as_slice() {
+    ] = hl_attr_define_arguments {
         let style = parse_style(attributes)?;
-        Ok(RedrawEvent::HighlightAttributesDefine { id: parse_u64(&id)?, style })
+        Ok(RedrawEvent::HighlightAttributesDefine { id: parse_u64(id)?, style })
     } else {
         Err(EventParseError::InvalidEventFormat)
     }
 }
 
-fn parse_grid_line_cell(grid_line_cell: Value) -> Result<GridLineCell> {
-    let cell_contents = parse_array(&grid_line_cell)?;
+fn parse_grid_line_cell(grid_line_cell: &Value) -> Result<GridLineCell> {
+    let cell_contents = parse_array(grid_line_cell)?;
     let text_value = cell_contents.get(0).ok_or(EventParseError::InvalidEventFormat)?;
     Ok(GridLineCell {
-        text: parse_string(&text_value)?,
-        highlight_id: cell_contents.get(1).map(|highlight_id| parse_u64(highlight_id)).transpose()?,
-        repeat: cell_contents.get(2).map(|repeat| parse_u64(repeat)).transpose()?
+        text: parse_string(text_value)?.to_string(),
+        highlight_id: cell_contents.get(1).map(parse_u64).transpose()?,
+        repeat: cell_contents.get(2).map(parse_u64).transpose()?
     })
 }
 
-fn parse_grid_line(grid_line_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [grid_id, row, column_start, cells] = grid_line_arguments.as_slice() {
+fn parse_grid_line(grid_line_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [grid_id, row, column_start, cells] = grid_line_arguments {
         Ok(RedrawEvent::GridLine {
-            grid: parse_u64(&grid_id)?, 
-            row: parse_u64(&row)?, column_start: parse_u64(&column_start)?,
-            cells: parse_array(&cells)?
+            grid: parse_u64(grid_id)?,
+            row: parse_u64(row)?, column_start: parse_u64(column_start)?,
+            cells: parse_array(cells)?
                 .into_iter()
                 .map(parse_grid_line_cell)
                 .collect::<Result<Vec<GridLineCell>>>()?
@@ -380,46 +384,46 @@ fn parse_grid_line(grid_line_arguments: Vec<Value>) -> Result<RedrawEvent> {
     }
 }
 
-fn parse_clear(clear_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [grid_id] = clear_arguments.as_slice() {
-        Ok(RedrawEvent::Clear { grid: parse_u64(&grid_id)? })
+fn parse_clear(clear_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [grid_id] = clear_arguments {
+        Ok(RedrawEvent::Clear { grid: parse_u64(grid_id)? })
     } else {
         Err(EventParseError::InvalidEventFormat)
     }
 }
 
-fn parse_cursor_goto(cursor_goto_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [grid_id, column, row] = cursor_goto_arguments.as_slice() {
+fn parse_cursor_goto(cursor_goto_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [grid_id, column, row] = cursor_goto_arguments {
         Ok(RedrawEvent::CursorGoto { 
-            grid: parse_u64(&grid_id)?, row: parse_u64(&row)?, column: parse_u64(&column)?
+            grid: parse_u64(grid_id)?, row: parse_u64(row)?, column: parse_u64(column)?
         })
     } else {
         Err(EventParseError::InvalidEventFormat)
     }
 }
 
-fn parse_grid_scroll(grid_scroll_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [grid_id, top, bottom, left, right, rows, columns] = grid_scroll_arguments.as_slice() {
+fn parse_grid_scroll(grid_scroll_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [grid_id, top, bottom, left, right, rows, columns] = grid_scroll_arguments {
         Ok(RedrawEvent::Scroll {
-            grid: parse_u64(&grid_id)?, 
-            top: parse_u64(&top)?, bottom: parse_u64(&bottom)?,
-            left: parse_u64(&left)?, right: parse_u64(&right)?,
-            rows: parse_i64(&rows)?, columns: parse_i64(&columns)?
+            grid: parse_u64(grid_id)?,
+            top: parse_u64(top)?, bottom: parse_u64(bottom)?,
+            left: parse_u64(left)?, right: parse_u64(right)?,
+            rows: parse_i64(rows)?, columns: parse_i64(columns)?
         })
     } else {
         Err(EventParseError::InvalidEventFormat)
     }
 }
 
-fn parse_win_pos(win_pos_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [grid, window, start_row, start_column, width, height] = win_pos_arguments.as_slice() {
+fn parse_win_pos(win_pos_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [grid, window, start_row, start_column, width, height] = win_pos_arguments {
         Ok(RedrawEvent::WindowPosition {
-            grid: parse_u64(&grid)?,
-            window: parse_u64(&window)?,
-            start_row: parse_u64(&start_row)?,
-            start_column: parse_u64(&start_column)?,
-            width: parse_u64(&width)?,
-            height: parse_u64(&height)?
+            grid: parse_u64(grid)?,
+            window: parse_u64(window)?,
+            start_row: parse_u64(start_row)?,
+            start_column: parse_u64(start_column)?,
+            width: parse_u64(width)?,
+            height: parse_u64(height)?
         })
     } else {
         Err(EventParseError::InvalidEventFormat)
@@ -427,7 +431,7 @@ fn parse_win_pos(win_pos_arguments: Vec<Value>) -> Result<RedrawEvent> {
 }
 
 fn parse_window_anchor(value: &Value) -> Result<WindowAnchor> {
-    match parse_string(value).ok().as_deref() {
+    match parse_string(value).ok() {
         Some("NW") => Ok(WindowAnchor::NorthWest),
         Some("NE") => Ok(WindowAnchor::NorthEast),
         Some("SW") => Ok(WindowAnchor::SouthWest),
@@ -436,60 +440,60 @@ fn parse_window_anchor(value: &Value) -> Result<WindowAnchor> {
     }
 }
 
-fn parse_win_float_pos(win_float_pos_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [grid, window, anchor, anchor_grid, anchor_row, anchor_column, focusable] = win_float_pos_arguments.as_slice() {
+fn parse_win_float_pos(win_float_pos_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [grid, window, anchor, anchor_grid, anchor_row, anchor_column, focusable] = win_float_pos_arguments {
         Ok(RedrawEvent::WindowFloatPosition {
-            grid: parse_u64(&grid)?,
-            window: parse_u64(&window)?,
-            anchor: parse_window_anchor(&anchor)?,
-            anchor_grid: parse_u64(&anchor_grid)?,
-            anchor_row: parse_u64(&anchor_row)?,
-            anchor_column: parse_u64(&anchor_column)?,
-            focusable: parse_bool(&focusable)?
+            grid: parse_u64(grid)?,
+            window: parse_u64(window)?,
+            anchor: parse_window_anchor(anchor)?,
+            anchor_grid: parse_u64(anchor_grid)?,
+            anchor_row: parse_u64(anchor_row)?,
+            anchor_column: parse_u64(anchor_column)?,
+            focusable: parse_bool(focusable)?
         })
     } else {
         Err(EventParseError::InvalidEventFormat)
     }
 }
 
-fn parse_win_external_pos(win_external_pos_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [grid, window] = win_external_pos_arguments.as_slice() {
+fn parse_win_external_pos(win_external_pos_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [grid, window] = win_external_pos_arguments {
         Ok(RedrawEvent::WindowExternalPosition {
-            grid: parse_u64(&grid)?,
-            window: parse_u64(&window)?
+            grid: parse_u64(grid)?,
+            window: parse_u64(window)?
         })
     } else {
         Err(EventParseError::InvalidEventFormat)
     }
 }
 
-fn parse_win_hide(win_hide_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [grid] = win_hide_arguments.as_slice() {
+fn parse_win_hide(win_hide_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [grid] = win_hide_arguments {
         Ok(RedrawEvent::WindowHide {
-            grid: parse_u64(&grid)?
+            grid: parse_u64(grid)?
         })
     } else {
         Err(EventParseError::InvalidEventFormat)
     }
 }
 
-fn parse_win_close(win_close_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [grid] = win_close_arguments.as_slice() {
+fn parse_win_close(win_close_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [grid] = win_close_arguments {
         Ok(RedrawEvent::WindowClose {
-            grid: parse_u64(&grid)?
+            grid: parse_u64(grid)?
         })
     } else {
         Err(EventParseError::InvalidEventFormat)
     }
 }
 
-fn parse_msg_set_pos(msg_set_pos_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [grid, row, scrolled, separator_character] = msg_set_pos_arguments.as_slice() {
+fn parse_msg_set_pos(msg_set_pos_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [grid, row, scrolled, separator_character] = msg_set_pos_arguments {
         Ok(RedrawEvent::MessageSetPosition {
-            grid: parse_u64(&grid)?,
-            row: parse_u64(&row)?,
-            scrolled: parse_bool(&scrolled)?,
-            separator_character: parse_string(&separator_character)?
+            grid: parse_u64(grid)?,
+            row: parse_u64(row)?,
+            scrolled: parse_bool(scrolled)?,
+            separator_character: parse_string(separator_character)?.to_string()
         })
     } else {
         Err(EventParseError::InvalidEventFormat)
@@ -498,67 +502,67 @@ fn parse_msg_set_pos(msg_set_pos_arguments: Vec<Value>) -> Result<RedrawEvent> {
 
 fn parse_styled_content(line: &Value) -> Result<StyledContent> {
     parse_array(line)?.iter().map(|tuple| {
-        if let [style_id, text] = parse_array(tuple)?.as_slice() {
-            Ok((parse_u64(style_id)?, parse_string(text)?))
+        if let [style_id, text] = parse_array(tuple)? {
+            Ok((parse_u64(style_id)?, parse_string(text)?.to_string()))
         } else {
             Err(EventParseError::InvalidEventFormat)
         }
-    }).collect::<Result<StyledContent>>()
+    }).collect()
 }
 
-fn parse_cmdline_show(cmdline_show_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [content, position, first_character, prompt, indent, level] = cmdline_show_arguments.as_slice() {
+fn parse_cmdline_show(cmdline_show_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [content, position, first_character, prompt, indent, level] = cmdline_show_arguments {
         Ok(RedrawEvent::CommandLineShow {
-            content: parse_styled_content(&content)?,
-            position: parse_u64(&position)?,
-            first_character: parse_string(&first_character)?,
-            prompt: parse_string(&prompt)?,
-            indent: parse_u64(&indent)?,
-            level: parse_u64(&level)?
+            content: parse_styled_content(content)?,
+            position: parse_u64(position)?,
+            first_character: parse_string(first_character)?.to_string(),
+            prompt: parse_string(prompt)?.to_string(),
+            indent: parse_u64(indent)?,
+            level: parse_u64(level)?
         })
     } else {
         Err(EventParseError::InvalidEventFormat)
     }
 }
 
-fn parse_cmdline_pos(cmdline_pos_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [position, level] = cmdline_pos_arguments.as_slice() {
+fn parse_cmdline_pos(cmdline_pos_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [position, level] = cmdline_pos_arguments {
         Ok(RedrawEvent::CommandLinePosition {
-            position: parse_u64(&position)?,
-            level: parse_u64(&level)?
+            position: parse_u64(position)?,
+            level: parse_u64(level)?
         })
     } else {
         Err(EventParseError::InvalidEventFormat)
     }
 }
 
-fn parse_cmdline_special_char(cmdline_special_char_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [character, shift, level] = cmdline_special_char_arguments.as_slice() {
+fn parse_cmdline_special_char(cmdline_special_char_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [character, shift, level] = cmdline_special_char_arguments {
         Ok(RedrawEvent::CommandLineSpecialCharacter {
-            character: parse_string(&character)?,
-            shift: parse_bool(&shift)?,
-            level: parse_u64(&level)?
+            character: parse_string(character)?.to_string(),
+            shift: parse_bool(shift)?,
+            level: parse_u64(level)?
         })
     } else {
         Err(EventParseError::InvalidEventFormat)
     }
 }
 
-fn parse_cmdline_block_show(cmdline_block_show_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [lines] = cmdline_block_show_arguments.as_slice() {
+fn parse_cmdline_block_show(cmdline_block_show_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [lines] = cmdline_block_show_arguments {
         Ok(RedrawEvent::CommandLineBlockShow {
             lines: parse_array(lines)?
                 .iter()
                 .map(parse_styled_content)
-                .collect::<Result<Vec<StyledContent>>>()?
+                .collect::<Result<_>>()?
         })
     } else {
         Err(EventParseError::InvalidEventFormat)
     }
 }
 
-fn parse_cmdline_block_append(cmdline_block_append_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [line] = cmdline_block_append_arguments.as_slice() {
+fn parse_cmdline_block_append(cmdline_block_append_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [line] = cmdline_block_append_arguments {
         Ok(RedrawEvent::CommandLineBlockAppend {
             line: parse_styled_content(line)?
         })
@@ -567,42 +571,42 @@ fn parse_cmdline_block_append(cmdline_block_append_arguments: Vec<Value>) -> Res
     }
 }
 
-fn parse_msg_show(msg_show_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [kind, content, replace_last] = msg_show_arguments.as_slice() {
+fn parse_msg_show(msg_show_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [kind, content, replace_last] = msg_show_arguments {
         Ok(RedrawEvent::MessageShow {
-            kind: MessageKind::parse(&parse_string(&kind)?),
-            content: parse_styled_content(&content)?,
-            replace_last: parse_bool(&replace_last)?
+            kind: MessageKind::parse(parse_string(kind)?),
+            content: parse_styled_content(content)?,
+            replace_last: parse_bool(replace_last)?
         })
     } else {
         Err(EventParseError::InvalidEventFormat)
     }
 }
 
-fn parse_msg_showmode(msg_showmode_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [content] = msg_showmode_arguments.as_slice() {
+fn parse_msg_showmode(msg_showmode_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [content] = msg_showmode_arguments {
         Ok(RedrawEvent::MessageShowMode {
-            content: parse_styled_content(&content)?,
+            content: parse_styled_content(content)?,
         })
     } else {
         Err(EventParseError::InvalidEventFormat)
     }
 }
 
-fn parse_msg_showcmd(msg_showcmd_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [content] = msg_showcmd_arguments.as_slice() {
+fn parse_msg_showcmd(msg_showcmd_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [content] = msg_showcmd_arguments {
         Ok(RedrawEvent::MessageShowCommand {
-            content: parse_styled_content(&content)?,
+            content: parse_styled_content(content)?,
         })
     } else {
         Err(EventParseError::InvalidEventFormat)
     }
 }
 
-fn parse_msg_ruler(msg_ruler_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [content] = msg_ruler_arguments.as_slice() {
+fn parse_msg_ruler(msg_ruler_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [content] = msg_ruler_arguments {
         Ok(RedrawEvent::MessageRuler {
-            content: parse_styled_content(&content)?,
+            content: parse_styled_content(content)?,
         })
     } else {
         Err(EventParseError::InvalidEventFormat)
@@ -610,9 +614,9 @@ fn parse_msg_ruler(msg_ruler_arguments: Vec<Value>) -> Result<RedrawEvent> {
 }
 
 fn parse_msg_history_entry(entry: &Value) -> Result<(MessageKind, StyledContent)> {
-    if let [kind, content] = parse_array(entry)?.as_slice() {
+    if let [kind, content] = parse_array(entry)?{
         Ok((
-            MessageKind::parse(&parse_string(kind)?),
+            MessageKind::parse(parse_string(kind)?),
             parse_styled_content(content)?
         ))
     } else {
@@ -620,29 +624,29 @@ fn parse_msg_history_entry(entry: &Value) -> Result<(MessageKind, StyledContent)
     }
 }
 
-fn parse_msg_history_show(msg_history_show_arguments: Vec<Value>) -> Result<RedrawEvent> {
-    if let [entries] = msg_history_show_arguments.as_slice() {
+fn parse_msg_history_show(msg_history_show_arguments: &[Value]) -> Result<RedrawEvent> {
+    if let [entries] = msg_history_show_arguments {
         Ok(RedrawEvent::MessageHistoryShow {
             entries: parse_array(entries)?
                 .iter()
                 .map(parse_msg_history_entry)
-                .collect::<Result<Vec<(MessageKind, StyledContent)>>>()?
+                .collect::<Result<_>>()?
         })
     } else {
         Err(EventParseError::InvalidEventFormat)
     }
 }
 
-pub fn parse_redraw_event(event_value: Value) -> Result<Vec<RedrawEvent>> {
-    let event_contents = parse_array(&event_value)?.to_vec();
+pub fn parse_redraw_event(event_value: &Value) -> Result<Vec<RedrawEvent>> {
+    let event_contents = parse_array(event_value)?;
     let name_value = event_contents.get(0).ok_or(EventParseError::InvalidEventFormat)?;
-    let event_name = parse_string(&name_value)?;
+    let event_name = parse_string(name_value)?;
     let events = event_contents;
-    let mut parsed_events = Vec::new();
+    let mut parsed_events = Vec::with_capacity(events.len());
 
     for event in &events[1..] {
         let event_parameters = parse_array(&event)?;
-        let possible_parsed_event = match event_name.clone().as_ref() {
+        let possible_parsed_event = match event_name {
             "set_title" => Some(parse_set_title(event_parameters)?),
             "set_icon" => None, // Ignore set icon for now
             "mode_info_set" => Some(parse_mode_info_set(event_parameters)?),
@@ -688,8 +692,8 @@ pub fn parse_redraw_event(event_value: Value) -> Result<Vec<RedrawEvent>> {
     Ok(parsed_events)
 }
 
-pub fn parse_neovim_event(event_name: String, arguments: Vec<Value>) -> Result<Vec<RedrawEvent>> {
-    let mut resulting_events = Vec::new();
+pub(in super) fn parse_neovim_event(event_name: &str, arguments: &[Value]) -> Result<Vec<RedrawEvent>> {
+    let mut resulting_events = Vec::with_capacity(arguments.len());
     if event_name == "redraw" {
         for event in arguments {
             resulting_events.append(&mut parse_redraw_event(event)?);

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -43,7 +43,7 @@ impl Handler for NeovimHandler {
     type Writer = Compat<ChildStdin>;
 
     async fn handle_notify(&self, event_name: String, arguments: Vec<Value>, _neovim: Neovim<Compat<ChildStdin>>) {
-        let parsed_events = parse_neovim_event(event_name, arguments)
+        let parsed_events = parse_neovim_event(&event_name, &arguments)
             .unwrap_or_explained_panic("Could not parse event", "Could not parse event from neovim");
         for event in parsed_events {
             self.handle_redraw_event(event);

--- a/src/bridge/keybindings.rs
+++ b/src/bridge/keybindings.rs
@@ -1,153 +1,157 @@
 use skulpin::winit::event::{KeyboardInput, ElementState, ModifiersState, VirtualKeyCode};
 
-fn parse_keycode(keycode: VirtualKeyCode) -> Option<(String, bool)> {
+fn parse_keycode(keycode: VirtualKeyCode) -> Option<(&'static str, bool)> {
     match keycode {
-        VirtualKeyCode::Key1 => Some(("1".to_string(), false)),
-        VirtualKeyCode::Key2 => Some(("2".to_string(), false)),
-        VirtualKeyCode::Key3 => Some(("3".to_string(), false)),
-        VirtualKeyCode::Key4 => Some(("4".to_string(), false)),
-        VirtualKeyCode::Key5 => Some(("5".to_string(), false)),
-        VirtualKeyCode::Key6 => Some(("6".to_string(), false)),
-        VirtualKeyCode::Key7 => Some(("7".to_string(), false)),
-        VirtualKeyCode::Key8 => Some(("8".to_string(), false)),
-        VirtualKeyCode::Key9 => Some(("9".to_string(), false)),
-        VirtualKeyCode::Key0 => Some(("0".to_string(), false)),
-        VirtualKeyCode::A => Some(("a".to_string(), false)),
-        VirtualKeyCode::B => Some(("b".to_string(), false)),
-        VirtualKeyCode::C => Some(("c".to_string(), false)),
-        VirtualKeyCode::D => Some(("d".to_string(), false)),
-        VirtualKeyCode::E => Some(("e".to_string(), false)),
-        VirtualKeyCode::F => Some(("f".to_string(), false)),
-        VirtualKeyCode::G => Some(("g".to_string(), false)),
-        VirtualKeyCode::H => Some(("h".to_string(), false)),
-        VirtualKeyCode::I => Some(("i".to_string(), false)),
-        VirtualKeyCode::J => Some(("j".to_string(), false)),
-        VirtualKeyCode::K => Some(("k".to_string(), false)),
-        VirtualKeyCode::L => Some(("l".to_string(), false)),
-        VirtualKeyCode::M => Some(("m".to_string(), false)),
-        VirtualKeyCode::N => Some(("n".to_string(), false)),
-        VirtualKeyCode::O => Some(("o".to_string(), false)),
-        VirtualKeyCode::P => Some(("p".to_string(), false)),
-        VirtualKeyCode::Q => Some(("q".to_string(), false)),
-        VirtualKeyCode::R => Some(("r".to_string(), false)),
-        VirtualKeyCode::S => Some(("s".to_string(), false)),
-        VirtualKeyCode::T => Some(("t".to_string(), false)),
-        VirtualKeyCode::U => Some(("u".to_string(), false)),
-        VirtualKeyCode::V => Some(("v".to_string(), false)),
-        VirtualKeyCode::W => Some(("w".to_string(), false)),
-        VirtualKeyCode::X => Some(("x".to_string(), false)),
-        VirtualKeyCode::Y => Some(("y".to_string(), false)),
-        VirtualKeyCode::Z => Some(("z".to_string(), false)),
-        VirtualKeyCode::Escape => Some(("ESC".to_string(), true)),
-        VirtualKeyCode::F1 => Some(("F1".to_string(), true)),
-        VirtualKeyCode::F2 => Some(("F2".to_string(), true)),
-        VirtualKeyCode::F3 => Some(("F3".to_string(), true)),
-        VirtualKeyCode::F4 => Some(("F4".to_string(), true)),
-        VirtualKeyCode::F5 => Some(("F5".to_string(), true)),
-        VirtualKeyCode::F6 => Some(("F6".to_string(), true)),
-        VirtualKeyCode::F7 => Some(("F7".to_string(), true)),
-        VirtualKeyCode::F8 => Some(("F8".to_string(), true)),
-        VirtualKeyCode::F9 => Some(("F9".to_string(), true)),
-        VirtualKeyCode::F10 => Some(("F10".to_string(), true)),
-        VirtualKeyCode::F11 => Some(("F11".to_string(), true)),
-        VirtualKeyCode::F12 => Some(("F12".to_string(), true)),
-        VirtualKeyCode::F13 => Some(("F13".to_string(), true)),
-        VirtualKeyCode::F14 => Some(("F14".to_string(), true)),
-        VirtualKeyCode::F15 => Some(("F15".to_string(), true)),
-        VirtualKeyCode::F16 => Some(("F16".to_string(), true)),
-        VirtualKeyCode::F17 => Some(("F17".to_string(), true)),
-        VirtualKeyCode::F18 => Some(("F18".to_string(), true)),
-        VirtualKeyCode::F19 => Some(("F19".to_string(), true)),
-        VirtualKeyCode::F20 => Some(("F20".to_string(), true)),
-        VirtualKeyCode::F21 => Some(("F21".to_string(), true)),
-        VirtualKeyCode::F22 => Some(("F22".to_string(), true)),
-        VirtualKeyCode::F23 => Some(("F23".to_string(), true)),
-        VirtualKeyCode::F24 => Some(("F24".to_string(), true)),
-        VirtualKeyCode::Insert => Some(("Insert".to_string(), true)),
-        VirtualKeyCode::Home => Some(("Home".to_string(), true)),
-        VirtualKeyCode::Delete => Some(("Delete".to_string(), true)),
-        VirtualKeyCode::End => Some(("End".to_string(), true)),
-        VirtualKeyCode::PageDown => Some(("PageDown".to_string(), true)),
-        VirtualKeyCode::PageUp => Some(("PageUp".to_string(), true)),
-        VirtualKeyCode::Left => Some(("Left".to_string(), true)),
-        VirtualKeyCode::Up => Some(("Up".to_string(), true)),
-        VirtualKeyCode::Right => Some(("Right".to_string(), true)),
-        VirtualKeyCode::Down => Some(("Down".to_string(), true)),
-        VirtualKeyCode::Back => Some(("BS".to_string(), true)),
-        VirtualKeyCode::Return => Some(("Enter".to_string(), true)),
-        VirtualKeyCode::Space => Some(("Space".to_string(), true)),
-        VirtualKeyCode::Caret => Some(("^".to_string(), false)),
-        VirtualKeyCode::Apostrophe => Some(("'".to_string(), false)),
-        VirtualKeyCode::Backslash => Some(("Bslash".to_string(), true)),
-        VirtualKeyCode::Colon => Some((":".to_string(), false)),
-        VirtualKeyCode::Comma => Some((",".to_string(), false)),
-        VirtualKeyCode::Equals => Some(("=".to_string(), false)),
-        VirtualKeyCode::Grave => Some(("`".to_string(), false)),
-        VirtualKeyCode::LBracket => Some(("[".to_string(), false)),
-        VirtualKeyCode::Minus => Some(("-".to_string(), false)),
-        VirtualKeyCode::Period => Some((".".to_string(), false)),
-        VirtualKeyCode::RBracket => Some(("]".to_string(), false)),
-        VirtualKeyCode::Semicolon => Some((";".to_string(), false)),
-        VirtualKeyCode::Slash => Some(("/".to_string(), false)),
-        VirtualKeyCode::Tab => Some(("Tab".to_string(), true)),
+        VirtualKeyCode::Key1 => Some(("1", false)),
+        VirtualKeyCode::Key2 => Some(("2", false)),
+        VirtualKeyCode::Key3 => Some(("3", false)),
+        VirtualKeyCode::Key4 => Some(("4", false)),
+        VirtualKeyCode::Key5 => Some(("5", false)),
+        VirtualKeyCode::Key6 => Some(("6", false)),
+        VirtualKeyCode::Key7 => Some(("7", false)),
+        VirtualKeyCode::Key8 => Some(("8", false)),
+        VirtualKeyCode::Key9 => Some(("9", false)),
+        VirtualKeyCode::Key0 => Some(("0", false)),
+        VirtualKeyCode::A => Some(("a", false)),
+        VirtualKeyCode::B => Some(("b", false)),
+        VirtualKeyCode::C => Some(("c", false)),
+        VirtualKeyCode::D => Some(("d", false)),
+        VirtualKeyCode::E => Some(("e", false)),
+        VirtualKeyCode::F => Some(("f", false)),
+        VirtualKeyCode::G => Some(("g", false)),
+        VirtualKeyCode::H => Some(("h", false)),
+        VirtualKeyCode::I => Some(("i", false)),
+        VirtualKeyCode::J => Some(("j", false)),
+        VirtualKeyCode::K => Some(("k", false)),
+        VirtualKeyCode::L => Some(("l", false)),
+        VirtualKeyCode::M => Some(("m", false)),
+        VirtualKeyCode::N => Some(("n", false)),
+        VirtualKeyCode::O => Some(("o", false)),
+        VirtualKeyCode::P => Some(("p", false)),
+        VirtualKeyCode::Q => Some(("q", false)),
+        VirtualKeyCode::R => Some(("r", false)),
+        VirtualKeyCode::S => Some(("s", false)),
+        VirtualKeyCode::T => Some(("t", false)),
+        VirtualKeyCode::U => Some(("u", false)),
+        VirtualKeyCode::V => Some(("v", false)),
+        VirtualKeyCode::W => Some(("w", false)),
+        VirtualKeyCode::X => Some(("x", false)),
+        VirtualKeyCode::Y => Some(("y", false)),
+        VirtualKeyCode::Z => Some(("z", false)),
+        VirtualKeyCode::Escape => Some(("ESC", true)),
+        VirtualKeyCode::F1 => Some(("F1", true)),
+        VirtualKeyCode::F2 => Some(("F2", true)),
+        VirtualKeyCode::F3 => Some(("F3", true)),
+        VirtualKeyCode::F4 => Some(("F4", true)),
+        VirtualKeyCode::F5 => Some(("F5", true)),
+        VirtualKeyCode::F6 => Some(("F6", true)),
+        VirtualKeyCode::F7 => Some(("F7", true)),
+        VirtualKeyCode::F8 => Some(("F8", true)),
+        VirtualKeyCode::F9 => Some(("F9", true)),
+        VirtualKeyCode::F10 => Some(("F10", true)),
+        VirtualKeyCode::F11 => Some(("F11", true)),
+        VirtualKeyCode::F12 => Some(("F12", true)),
+        VirtualKeyCode::F13 => Some(("F13", true)),
+        VirtualKeyCode::F14 => Some(("F14", true)),
+        VirtualKeyCode::F15 => Some(("F15", true)),
+        VirtualKeyCode::F16 => Some(("F16", true)),
+        VirtualKeyCode::F17 => Some(("F17", true)),
+        VirtualKeyCode::F18 => Some(("F18", true)),
+        VirtualKeyCode::F19 => Some(("F19", true)),
+        VirtualKeyCode::F20 => Some(("F20", true)),
+        VirtualKeyCode::F21 => Some(("F21", true)),
+        VirtualKeyCode::F22 => Some(("F22", true)),
+        VirtualKeyCode::F23 => Some(("F23", true)),
+        VirtualKeyCode::F24 => Some(("F24", true)),
+        VirtualKeyCode::Insert => Some(("Insert", true)),
+        VirtualKeyCode::Home => Some(("Home", true)),
+        VirtualKeyCode::Delete => Some(("Delete", true)),
+        VirtualKeyCode::End => Some(("End", true)),
+        VirtualKeyCode::PageDown => Some(("PageDown", true)),
+        VirtualKeyCode::PageUp => Some(("PageUp", true)),
+        VirtualKeyCode::Left => Some(("Left", true)),
+        VirtualKeyCode::Up => Some(("Up", true)),
+        VirtualKeyCode::Right => Some(("Right", true)),
+        VirtualKeyCode::Down => Some(("Down", true)),
+        VirtualKeyCode::Back => Some(("BS", true)),
+        VirtualKeyCode::Return => Some(("Enter", true)),
+        VirtualKeyCode::Space => Some(("Space", true)),
+        VirtualKeyCode::Caret => Some(("^", false)),
+        VirtualKeyCode::Apostrophe => Some(("'", false)),
+        VirtualKeyCode::Backslash => Some(("Bslash", true)),
+        VirtualKeyCode::Colon => Some((":", false)),
+        VirtualKeyCode::Comma => Some((",", false)),
+        VirtualKeyCode::Equals => Some(("=", false)),
+        VirtualKeyCode::Grave => Some(("`", false)),
+        VirtualKeyCode::LBracket => Some(("[", false)),
+        VirtualKeyCode::Minus => Some(("-", false)),
+        VirtualKeyCode::Period => Some((".", false)),
+        VirtualKeyCode::RBracket => Some(("]", false)),
+        VirtualKeyCode::Semicolon => Some((";", false)),
+        VirtualKeyCode::Slash => Some(("/", false)),
+        VirtualKeyCode::Tab => Some(("Tab", true)),
         _ => None
     }
 }
 
-fn append_modifiers(modifiers: ModifiersState, keycode_text: String, special: bool) -> String {
-    let mut result = keycode_text;
+fn append_modifiers(modifiers: ModifiersState, keycode_text: &str, special: bool) -> String {
+    let mut result = String::with_capacity(10 + keycode_text.len()); // Add 10 due to modifiers terms.
     let mut special = special;
 
-    if modifiers.shift() {
-        result = match result.as_ref() {
-            "1" => "!".to_string(),
-            "2" => "@".to_string(),
-            "3" => "#".to_string(),
-            "4" => "$".to_string(),
-            "5" => "%".to_string(),
-            "6" => "^".to_string(),
-            "7" => "&".to_string(),
-            "8" => "*".to_string(),
-            "9" => "(".to_string(),
-            "0" => ")".to_string(),
-            "'" => "\"".to_string(),
-            "Bslash" => {
-                special = false;
-                "|".to_string()
-            },
-            "," => {
-                special = true;
-                "lt".to_string()
-            },
-            "=" => "+".to_string(),
-            "`" => "~".to_string(),
-            "[" => "{".to_string(),
-            "-" => "_".to_string(),
-            "." => ">".to_string(),
-            "]" => "}".to_string(),
-            ";" => ":".to_string(),
-            "/" => "?".to_string(),
-            other => {
-                special = true;
-                format!("S-{}", other)
-            }
-        };
-    }
-    if modifiers.ctrl() {
+    if modifiers.logo() {
         special = true;
-        result = format!("C-{}", result);
+        result.push_str("D-");
     }
     if modifiers.alt() {
         special = true;
-        result = format!("M-{}", result);
+        result.push_str("M-");
     }
-    if modifiers.logo() {
+    if modifiers.ctrl() {
         special = true;
-        result = format!("D-{}", result);
+        result.push_str("C-");
+    }
+
+    if modifiers.shift() {
+        match keycode_text {
+            "1" => result.push('!'),
+            "2" => result.push('@'),
+            "3" => result.push('#'),
+            "4" => result.push('$'),
+            "5" => result.push('%'),
+            "6" => result.push('^'),
+            "7" => result.push('&'),
+            "8" => result.push('*'),
+            "9" => result.push('('),
+            "0" => result.push(')'),
+            "'" => result.push('"'),
+            "Bslash" => {
+                special = false;
+                result.push('|');
+            },
+            "," => {
+                special = true;
+                result.push_str("lt");
+            },
+            "=" => result.push('+'),
+            "`" => result.push('~'),
+            "[" => result.push('{'),
+            "-" => result.push('_'),
+            "." => result.push('>'),
+            "]" => result.push('}'),
+            ";" => result.push(':'),
+            "/" => result.push('?'),
+            other => {
+                special = true;
+
+                result.push_str("S-");
+                result.push_str(other);
+            }
+        };
     }
 
     if special {
-        result = format!("<{}>", result);
+        result.insert(0, '<');
+        result.push('>');
     }
 
     result


### PR DESCRIPTION
Thanks for writing this awesome project! 

Exploring the code I saw that the `bridge` module make a lot of `.clone`s and owned values when references are enough. This PR fixes what I found.

The commits are very isolated and can be reviewed in isolation.

As a tip, dunno if you knew the tool but [clippy](https://github.com/rust-lang/rust-clippy) pointed many of the issues that this PR fixes.