### PR TITLE
Idea for linearization of the Editor grid storage

### DIFF
--- a/src/editor/grid.rs
+++ b/src/editor/grid.rs
@@ -78,11 +78,10 @@ impl CharacterGrid {
         self.dirty.resize_with((self.width * self.height) as usize, || value);
     }
 
-    pub fn rows<'a>(&'a self) -> Vec<&'a [GridCell]> {
+    pub fn rows<'a>(&'a self) -> impl Iterator<Item=&'a[GridCell]> {
         (0..self.height)
-            .map(|row| {
+            .map(move |row| {
                 &self.characters[(row * self.width) as usize..((row + 1) * self.width) as usize]
             })
-            .collect()
     }
 }

--- a/src/editor/grid.rs
+++ b/src/editor/grid.rs
@@ -1,0 +1,75 @@
+use std::sync::Arc;
+
+use super::style::Style;
+
+type GridCell = Option<(String, Option<Arc<Style>>)>;
+
+pub struct CharacterGrid {
+    pub characters: Vec<GridCell>,
+    pub width: u64,
+    pub height: u64,
+    pub should_clear: bool,
+
+    dirty: Vec<bool>,
+}
+
+impl CharacterGrid {
+    pub fn new() -> CharacterGrid {
+        CharacterGrid {
+            characters: vec![],
+            dirty: vec![],
+            width: 0,
+            height: 0,
+            should_clear: true,
+        }
+    }
+
+    pub fn resize(&mut self, new_size: (u64, u64)) {
+        trace!("Editor resized");
+        self.width = new_size.0;
+        self.height = new_size.1;
+        self.clear();
+    }
+
+    pub fn clear(&mut self) {
+        trace!("Editor cleared");
+        let cell_count = (self.width * self.height) as usize;
+        self.characters = vec![None; cell_count];
+        self.dirty = vec![true; cell_count];
+        self.should_clear = true;
+    }
+
+    pub fn cell_index(&self, x: u64, y: u64) -> Option<usize> {
+        if x >= self.width || y >= self.height {
+            None
+        } else {
+            Some((x + y * self.width) as usize)
+        }
+    }
+
+    pub fn is_dirty_cell(&self, x: u64, y: u64) -> bool {
+        if let Some(idx) = self.cell_index(x, y) {
+            self.dirty[idx]
+        } else {
+            false
+        }
+    }
+
+    pub fn set_dirty_cell(&mut self, x: u64, y: u64) {
+        if let Some(idx) = self.cell_index(x, y) {
+            self.dirty[idx] = true;
+        }
+    }
+
+    pub fn set_dirty_all(&mut self, value: bool) {
+        self.dirty.resize(self.dirty.len(), value);
+    }
+
+    pub fn rows<'a>(&'a self) -> Vec<&'a [GridCell]> {
+        (0..self.height)
+            .map(|row| {
+                &self.characters[(row * self.width) as usize..((row + 1) * self.width) as usize]
+            })
+            .collect()
+    }
+}

--- a/src/editor/grid.rs
+++ b/src/editor/grid.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use log::trace;
 
 use super::style::Style;
 

--- a/src/editor/grid.rs
+++ b/src/editor/grid.rs
@@ -15,14 +15,17 @@ pub struct CharacterGrid {
 }
 
 impl CharacterGrid {
-    pub fn new() -> CharacterGrid {
-        CharacterGrid {
+    pub fn new(size: (u64, u64)) -> CharacterGrid {
+        let mut result = CharacterGrid {
             characters: vec![],
             dirty: vec![],
             width: 0,
             height: 0,
             should_clear: true,
-        }
+        };
+
+        result.resize(size.0, size.1);
+        result
     }
 
     pub fn resize(&mut self, width: u64, height: u64) {

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -33,7 +33,6 @@ pub struct DrawCommand {
 pub struct Editor {
     pub grid: CharacterGrid,
     pub title: String,
-    pub size: (u64, u64),
     pub font_name: Option<String>,
     pub font_size: Option<f32>,
     pub cursor: Cursor,
@@ -45,10 +44,8 @@ pub struct Editor {
 impl Editor {
     pub fn new() -> Editor {
         let mut editor = Editor {
-            grid: CharacterGrid::new(),
-
+            grid: CharacterGrid::new(INITIAL_DIMENSIONS),
             title: "Neovide".to_string(),
-            size: INITIAL_DIMENSIONS,
             font_name: None,
             font_size: None,
             cursor: Cursor::new(),
@@ -216,11 +213,9 @@ impl Editor {
             Box::new((top as i64 .. (bot as i64 + rows)).rev())
         };
 
-        let (_, height) = self.size;
-
         for y in y_iter {
             let dest_y = y - rows;
-            if dest_y >= 0 && dest_y < height as i64 {
+            if dest_y >= 0 && dest_y < self.grid.height as i64 {
 
                 let x_iter : Box<dyn Iterator<Item=i64>> = if cols > 0 {
                     Box::new((left as i64 + cols) .. right as i64)

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -93,7 +93,7 @@ impl Editor {
 
     pub fn build_draw_commands(&mut self) -> (Vec<DrawCommand>, bool) {
         let mut draw_commands = Vec::new();
-        for (row_index, row) in self.grid.rows().iter().enumerate() {
+        for (row_index, row) in self.grid.rows().enumerate() {
             let mut command = None;
 
             fn add_command(commands_list: &mut Vec<DrawCommand>, command: Option<DrawCommand>) {

--- a/src/renderer/cursor_renderer.rs
+++ b/src/renderer/cursor_renderer.rs
@@ -201,16 +201,13 @@ impl CursorRenderer {
 
         let (character, font_dimensions): (String, Point) = {
             let editor = EDITOR.lock().unwrap();
-            let character = editor.grid
-                .get(grid_y as usize)
-                .and_then(|row| row.get(grid_x as usize).cloned())
-                .flatten()
-                .map(|(character, _)| character)
-                .unwrap_or(' '.to_string());
-            let is_double = editor.grid
-                .get(grid_y as usize)
-                .and_then(|row| row.get(grid_x as usize + 1).cloned())
-                .flatten()
+            let character = editor.cell_index(grid_x, grid_y)
+                .and_then(|idx| editor.grid[idx].as_ref())
+                .map(|(character, _)| character.clone())
+                .unwrap_or_else(|| ' '.to_string());
+            
+            let is_double = editor.cell_index(grid_x + 1, grid_y)
+                .and_then(|idx| editor.grid[idx].as_ref())
                 .map(|(character, _)| character.is_empty())
                 .unwrap_or(false);
 

--- a/src/renderer/cursor_renderer.rs
+++ b/src/renderer/cursor_renderer.rs
@@ -201,13 +201,13 @@ impl CursorRenderer {
 
         let (character, font_dimensions): (String, Point) = {
             let editor = EDITOR.lock().unwrap();
-            let character = editor.cell_index(grid_x, grid_y)
-                .and_then(|idx| editor.grid[idx].as_ref())
+            let character = editor.grid.cell_index(grid_x, grid_y)
+                .and_then(|idx| editor.grid.characters[idx].as_ref())
                 .map(|(character, _)| character.clone())
                 .unwrap_or_else(|| ' '.to_string());
             
-            let is_double = editor.cell_index(grid_x + 1, grid_y)
-                .and_then(|idx| editor.grid[idx].as_ref())
+            let is_double = editor.grid.cell_index(grid_x + 1, grid_y)
+                .and_then(|idx| editor.grid.characters[idx].as_ref())
                 .map(|(character, _)| character.is_empty())
                 .unwrap_or(false);
 

--- a/src/renderer/cursor_renderer.rs
+++ b/src/renderer/cursor_renderer.rs
@@ -201,15 +201,15 @@ impl CursorRenderer {
 
         let (character, font_dimensions): (String, Point) = {
             let editor = EDITOR.lock().unwrap();
-            let character = editor.grid.cell_index(grid_x, grid_y)
-                .and_then(|idx| editor.grid.characters[idx].as_ref())
-                .map(|(character, _)| character.clone())
-                .unwrap_or_else(|| ' '.to_string());
+            let character = match editor.grid.get_cell(grid_x, grid_y) {
+                Some(Some((character, _))) => character.clone(),
+                _ => ' '.to_string(),
+            };
             
-            let is_double = editor.grid.cell_index(grid_x + 1, grid_y)
-                .and_then(|idx| editor.grid.characters[idx].as_ref())
-                .map(|(character, _)| character.is_empty())
-                .unwrap_or(false);
+            let is_double = match editor.grid.get_cell(grid_x + 1, grid_y) {
+                Some(Some((character, _))) => character.is_empty(),
+                _ => false,
+            };
 
             let font_width = match (is_double, &cursor.shape) {
                 (true, CursorShape::Block) => font_width * 2.0,

--- a/src/renderer/cursor_renderer.rs
+++ b/src/renderer/cursor_renderer.rs
@@ -182,8 +182,7 @@ impl CursorRenderer {
             let editor = EDITOR.lock().unwrap();
             let (_, grid_y) = cursor.position;
             let (_, previous_y) = self.previous_position;
-            let (_, height) = editor.size;
-            if grid_y == height - 1 && previous_y != grid_y {
+            if grid_y == editor.grid.height - 1 && previous_y != grid_y {
                 self.command_line_delay = self.command_line_delay + 1;
                 if self.command_line_delay < COMMAND_LINE_DELAY_FRAMES {
                     self.previous_position


### PR DESCRIPTION
Converts `Editor::grid` from a nested `Vec<Vec<GridCell>>` to a `Vec<GridCell>` structure.
Does the same thing with `Editor::dirty`.

I'm opening this pull request just to discuss this as a possible approach. I believe this specific implementation can be improved (maybe by encapsulating a bit more the `grid` itself? Maybe extract `grid` and `dirty` into a separate struct?), but I also think it shows promise.