### PR TITLE
Switch to parking_lot::Mutex. It is faster and has a better API than the std one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,6 +1234,7 @@ dependencies = [
  "log",
  "lru",
  "nvim-rs",
+ "parking_lot",
  "rmpv",
  "rust-embed",
  "skribo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ log = "0.4.8"
 flexi_logger = { version = "0.14.6", default-features = false }
 anyhow = "1.0.26"
 crossbeam = "0.7"
+parking_lot="0.10.0"
 
 [build-dependencies]
 winres = "0.1.11"

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -20,7 +20,7 @@ impl NeovimHandler {
 
         tokio::spawn(async move {
             while let Some(event) = receiver.recv().await {
-                let mut editor = EDITOR.lock().unwrap();
+                let mut editor = EDITOR.lock();
                 editor.handle_redraw_event(event);
             }
         });

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -3,8 +3,9 @@ mod style;
 mod grid;
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
+use parking_lot::Mutex;
 use skulpin::skia_safe::colors;
 use unicode_segmentation::UnicodeSegmentation;
 use log::trace;

--- a/src/renderer/cursor_renderer.rs
+++ b/src/renderer/cursor_renderer.rs
@@ -179,7 +179,7 @@ impl CursorRenderer {
         let render = self.blink_status.update_status(&cursor);
 
         self.previous_position = {
-            let editor = EDITOR.lock().unwrap();
+            let editor = EDITOR.lock();
             let (_, grid_y) = cursor.position;
             let (_, previous_y) = self.previous_position;
             if grid_y == editor.grid.height - 1 && previous_y != grid_y {
@@ -199,7 +199,7 @@ impl CursorRenderer {
         let (grid_x, grid_y) = self.previous_position;
 
         let (character, font_dimensions): (String, Point) = {
-            let editor = EDITOR.lock().unwrap();
+            let editor = EDITOR.lock();
             let character = match editor.grid.get_cell(grid_x, grid_y) {
                 Some(Some((character, _))) => character.clone(),
                 _ => ' '.to_string(),

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -101,7 +101,7 @@ impl Renderer {
     pub fn draw(&mut self, gpu_canvas: &mut Canvas, coordinate_system_helper: &CoordinateSystemHelper) -> bool {
         trace!("Rendering");
         let ((draw_commands, should_clear), default_style, cursor, font_name, font_size) = {
-            let mut editor = EDITOR.lock().unwrap();
+            let mut editor = EDITOR.lock();
             (
                 editor.build_draw_commands(), 
                 editor.default_style.clone(), 

--- a/src/window.rs
+++ b/src/window.rs
@@ -182,7 +182,7 @@ pub fn ui_loop() {
             Event::RedrawRequested { .. } => {
                 let frame_start = Instant::now();
 
-                let editor_title = { EDITOR.lock().unwrap().title.clone() };
+                let editor_title = { EDITOR.lock().title.clone() };
                 if title != editor_title {
                     title = editor_title;
                     window.set_title(&title);


### PR DESCRIPTION
Also, no possibility of poisoning, so it removes a bunch of unwraps.
parking_lot is already a transitive dependency for neovide, so this is not adding more dependencies, really.