### PR TITLE
Cargo bundle for macOS

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,11 +23,23 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install Vulkan SDK
-      run: |
-        brew cask install apenngrace/vulkan/vulkan-sdk
+      run: brew cask install apenngrace/vulkan/vulkan-sdk
     - name: Build
-      run: cargo build --release
+      run: |
+        cargo install cargo-bundle
+        cargo bundle --release
+    - name: Update Bundle
+      run: |
+        cd target/release/bundle/osx/Neovide.app/Contents
+        mkdir Frameworks
+        cp /usr/local/lib/libvulkan.dylib ./Frameworks/
+        cp /usr/local/lib/libMoltenVK.dylib ./Frameworks/
+        mkdir -p Resources/vulkan
+        cp -r /usr/local/share/vulkan/icd.d ./Resources/vulkan/
+        jq '.ICD.library_path = "../../../Frameworks/libMoltenVK.dylib"' ./Resources/vulkan/icd.d/MoltenVK_icd.json > MoltenVK_icd.json
+        mv MoltenVK_icd.json ./Resources/vulkan/icd.d/
+        install_name_tool -add_rpath "@executable_path/../Frameworks" ./MacOS/neovide
     - uses: actions/upload-artifact@v1
       with:
-        name: neovide-macos
-        path: ./target/release/neovide
+        name: Neovide.app
+        path: ./target/release/bundle/osx/Neovide.app

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,4 +42,4 @@ jobs:
     - uses: actions/upload-artifact@v1
       with:
         name: Neovide.app
-        path: ./target/release/bundle/osx/Neovide.app
+        path: ./target/release/bundle/osx

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "neovide"
-version = "0.1.0"
+version = "0.4.0"
 authors = ["keith <keith@the-simmons.net>"]
 edition = "2018"
 build = "build.rs"
+description = "A simple GUI for Neovim."
 
 [dependencies]
 euclid = "0.20.7"
@@ -31,3 +32,16 @@ winres = "0.1.11"
 
 [profile.release]
 debug = true
+
+[package.metadata.bundle]
+name = "Neovide"
+identifier = "com.kethku.neovide"
+icon = ["assets/nvim.ico"]
+version = "0.4.0"
+resources = []
+copyright = "Copyright (c) keith 2020. All rights reserved."
+category = "Productivity"
+short_description = "A simple GUI for Neovim."
+long_description = """
+This is a simple graphical user interface for Neovim. Where possible there are some graphical improvements, but it should act functionally like the terminal UI.
+"""


### PR DESCRIPTION
- Should fix #105 for macOS
- `Neovide.app` available as an artifact to be downloaded
- `nvim` binary should available in path while executing the App
- Need to run `chmod +x Neovide.app/Contents/MacOS/neovide` after downloading the artifact. Open issue in Github's [upload-artifact](https://github.com/actions/upload-artifact/issues/38) action