### PR TITLE
Shaper includes system symbol fonts into cache

### DIFF
--- a/src/renderer/caching_shaper.rs
+++ b/src/renderer/caching_shaper.rs
@@ -17,6 +17,15 @@ const WIDE_FONT: &str = "NotoSansMonoCJKjp-Regular.otf";
 const WIDE_BOLD_FONT: &str = "NotoSansMonoCJKjp-Bold.otf";
 
 #[cfg(target_os = "windows")]
+const SYSTEM_SYMBOL_FONT: &str = "Segoe UI Symbol";
+
+#[cfg(target_os = "linux")]
+const SYSTEM_SYMBOL_FONT: &str = "Unifont";
+
+#[cfg(target_os = "macos")]
+const SYSTEM_SYMBOL_FONT: &str = "Apple Symbols";
+
+#[cfg(target_os = "windows")]
 const SYSTEM_EMOJI_FONT: &str = "Segoe UI Emoji";
 
 #[cfg(target_os = "macos")]
@@ -24,6 +33,7 @@ const SYSTEM_EMOJI_FONT: &str = "Apple Color Emoji";
 
 #[cfg(target_os = "linux")]
 const SYSTEM_EMOJI_FONT: &str = "Noto Color Emoji";
+
 
 #[derive(RustEmbed)]
 #[folder = "assets/fonts/"]
@@ -83,6 +93,11 @@ fn build_collection_by_font_name(font_name: Option<&str>, bold: bool, italic: bo
 
     if let Ok(emoji) = source.select_family_by_name(SYSTEM_EMOJI_FONT) {
         let font = emoji.fonts()[0].load().unwrap();
+        collection.add_family(FontFamily::new_from_font(font));
+    }
+
+    if let Ok(sys_symbol) = source.select_family_by_name(SYSTEM_SYMBOL_FONT) {
+        let font = sys_symbol.fonts()[0].load().unwrap();
         collection.add_family(FontFamily::new_from_font(font));
     }
 


### PR DESCRIPTION
This should fix #153 on Windows but needs testing on Linux and macOS.

This is how it looks on Windows:

![b](https://user-images.githubusercontent.com/1042414/75461445-1835fa80-5983-11ea-9c38-97ec1ad8efa1.PNG)

I can test this branch on on macOS later if you want. On Linux I don't even know if I can run something using Vulkan thanks to Nvidia 👍 

I also did a test with Quiva as default font for symbols but it didn't mesh well with monospaced fonts.