### PR TITLE
feat: add desktop entry for linux systems

### DIFF
--- a/assets/neovide.desktop
+++ b/assets/neovide.desktop
@@ -1,8 +1,9 @@
 [Desktop Entry]
 Type=Application
-Exec=neovide
+Exec=neovide %F
 Icon=neovide
 Name=Neovide (nvim)
 Keywords=Text;Editor;
 Categories=Utility;TextEditor;
 Comment=No Nonsense Neovim Client in Rust
+MimeType=text/english;text/plain;text/x-makefile;text/x-c++hdr;text/x-c++src;text/x-chdr;text/x-csrc;text/x-java;text/x-moc;text/x-pascal;text/x-tcl;text/x-tex;application/x-shellscript;text/x-c;text/x-c++;

--- a/assets/neovide.desktop
+++ b/assets/neovide.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Exec=neovide
+Icon=neovide
+Name=Neovide (nvim)
+Keywords=Text;Editor;
+Categories=Utility;TextEditor;
+Comment=No Nonsense Neovim Client in Rust


### PR DESCRIPTION
This PR just adds a `.desktop` file that Linux users can use to start Neovide from their Desktop manager.

We can add this to the AUR for Linux so it's installed there.