### PR TITLE
Fixes win32 input for Danish keyboard layout

### DIFF
--- a/src/bridge/layouts/mod.rs
+++ b/src/bridge/layouts/mod.rs
@@ -64,20 +64,20 @@ fn append_modifiers(
     if result == "<" {
         result = "lt".to_string();
         special = true;
-    }
+    }    
 
     if shift {
         special = true;
         result = format!("S-{}", result);
     }
-    if ctrl {
+	if ctrl && !alt {
         special = true;
         result = format!("C-{}", result);
     }
-    if alt {
+    if alt && !ctrl {
         special = true;
         result = format!("M-{}", result);
-    }
+	}
     if cfg!(not(target_os = "windows")) && gui {
         special = true;
         result = format!("D-{}", result);


### PR DESCRIPTION
I've made a small change to the input handling to match that of neovim-qt which handles characters "[", "]", "@" and "\\" properly on my Danish keyboard layout which neovide didn't. 

Since I am largely unfamiliar with vim and its input model, I don't know if this breaks other layouts but I would assume not since neovim-qt uses this logic. In any case I thought I would open this PR in case you want to merge it.

The change is taken from [input_win32.cpp](https://github.com/equalsraf/neovim-qt/blob/master/src/gui/input_win32.cpp) lines 28-37 and is a minor change from what already existed in the codebase.