### PR TITLE
Toggleable fullscreen (Alt+Enter)

### DIFF
--- a/src/bridge/layouts/mod.rs
+++ b/src/bridge/layouts/mod.rs
@@ -70,14 +70,14 @@ fn append_modifiers(
         special = true;
         result = format!("S-{}", result);
     }
-	if ctrl && !alt {
+    if ctrl {
         special = true;
         result = format!("C-{}", result);
     }
-    if alt && !ctrl {
+    if alt {
         special = true;
         result = format!("M-{}", result);
-	}
+    }
     if cfg!(not(target_os = "windows")) && gui {
         special = true;
         result = format!("D-{}", result);

--- a/src/bridge/layouts/mod.rs
+++ b/src/bridge/layouts/mod.rs
@@ -64,20 +64,20 @@ fn append_modifiers(
     if result == "<" {
         result = "lt".to_string();
         special = true;
-    }
+    }    
 
     if shift {
         special = true;
         result = format!("S-{}", result);
     }
-    if ctrl {
+	if ctrl && !alt {
         special = true;
         result = format!("C-{}", result);
     }
-    if alt {
+    if alt && !ctrl {
         special = true;
         result = format!("M-{}", result);
-    }
+	}
     if cfg!(not(target_os = "windows")) && gui {
         special = true;
         result = format!("D-{}", result);

--- a/src/window.rs
+++ b/src/window.rs
@@ -135,13 +135,13 @@ impl WindowWrapper {
 
         let window = video_subsystem
             .window("Neovide", logical_size.width, logical_size.height)
+            .position_centered()
             .allow_highdpi()
             .resizable()
             .vulkan()
             .build()
             .expect("Failed to create window");
         info!("window created");
-
 
         let skulpin_renderer = RendererBuilder::new()
             .prefer_integrated_gpu()

--- a/src/window.rs
+++ b/src/window.rs
@@ -5,8 +5,8 @@ use std::time::{Duration, Instant};
 use log::{debug, error, info, trace};
 use skulpin::sdl2;
 use skulpin::sdl2::event::{Event, WindowEvent};
-use skulpin::sdl2::keyboard::Keycode;
-use skulpin::sdl2::video::{FullscreenType, Window};
+use skulpin::sdl2::keyboard::{Keycode, Mod};
+use skulpin::sdl2::video::{Window};
 use skulpin::sdl2::Sdl;
 use skulpin::{dpis, CoordinateSystem, PresentMode, Renderer as SkulpinRenderer, RendererBuilder};
 use skulpin::{LogicalSize, PhysicalSize};
@@ -55,6 +55,9 @@ struct WindowWrapper {
     previous_dpis: (f32, f32),
     transparency: f32,
     fullscreen: bool,
+    cached_width: i32,
+    cached_height: i32,
+    cached_position: (i32, i32)
 }
 
 pub fn window_geometry() -> Result<(u64, u64), String> {
@@ -133,13 +136,13 @@ impl WindowWrapper {
 
         let window = video_subsystem
             .window("Neovide", logical_size.width, logical_size.height)
-            .position_centered()
             .allow_highdpi()
             .resizable()
             .vulkan()
             .build()
             .expect("Failed to create window");
         info!("window created");
+
 
         let skulpin_renderer = RendererBuilder::new()
             .prefer_integrated_gpu()
@@ -168,7 +171,44 @@ impl WindowWrapper {
             previous_dpis,
             transparency: 1.0,
             fullscreen: false,
+            cached_width: 0,
+            cached_height: 0,
+            cached_position: (0, 0)
         }
+    }
+
+    pub fn toggle_fullscreen(&mut self) {
+        unsafe {
+            let raw_handle = self.window.raw();
+            let display_index = sdl2::sys::SDL_GetWindowDisplayIndex(raw_handle);
+
+            if let Ok(rect) = self.window.subsystem().display_bounds(display_index) {    
+                if self.fullscreen {
+                    // Set window back to resizable
+                    sdl2::sys::SDL_SetWindowResizable(raw_handle, sdl2::sys::SDL_bool::SDL_TRUE);
+
+                    // Use cached size and position
+                    self.window.set_size(self.cached_width as u32, self.cached_height as u32).unwrap();
+                    self.window.set_position(
+                        sdl2::video::WindowPos::Positioned(self.cached_position.0), 
+                        sdl2::video::WindowPos::Positioned(self.cached_position.1)
+                    );
+                    self.window.set_bordered(true);
+                }
+                else {
+                    // Cache the size and position
+                    sdl2::sys::SDL_GetWindowSize(raw_handle, &mut self.cached_width, &mut self.cached_height);
+                    sdl2::sys::SDL_GetWindowPosition(raw_handle, &mut self.cached_position.0, &mut self.cached_position.1);
+                    sdl2::sys::SDL_SetWindowResizable(raw_handle, sdl2::sys::SDL_bool::SDL_FALSE);
+
+                    // Set window to fullscreen
+                    self.window.set_size(rect.width(), rect.height()).unwrap();   
+                    self.window.set_position(sdl2::video::WindowPos::Positioned(0), sdl2::video::WindowPos::Positioned(0));
+                    self.window.set_bordered(true);
+                }
+            }
+        }
+        self.fullscreen = !self.fullscreen;
     }
 
     pub fn synchronize_settings(&mut self) {
@@ -187,16 +227,6 @@ impl WindowWrapper {
                 self.transparency = transparency;
             }
         }
-
-        let fullscreen = { SETTINGS.get::<WindowSettings>().fullscreen };
-        if self.fullscreen != fullscreen {
-            let state = match fullscreen {
-                true => FullscreenType::Desktop,
-                false => FullscreenType::Off,
-            };
-            self.window.set_fullscreen(state).ok();
-            self.fullscreen = fullscreen;
-        }
     }
 
     pub fn handle_quit(&mut self) {
@@ -205,6 +235,12 @@ impl WindowWrapper {
 
     pub fn handle_keyboard_input(&mut self, keycode: Option<Keycode>, text: Option<String>) {
         let modifiers = self.context.keyboard().mod_state();
+
+        if let Some(key) = keycode {
+            if key == Keycode::Return && modifiers.contains(Mod::LALTMOD) {
+                self.toggle_fullscreen();
+            }
+        }
 
         if keycode.is_some() || text.is_some() {
             trace!(
@@ -373,6 +409,10 @@ pub fn initialize_settings() {
 
 pub fn ui_loop() {
     let mut window = WindowWrapper::new();
+    
+    if SETTINGS.get::<WindowSettings>().fullscreen {
+        window.toggle_fullscreen();
+    }
 
     info!("Starting window event loop");
     let mut event_pump = window

--- a/src/window.rs
+++ b/src/window.rs
@@ -239,6 +239,7 @@ impl WindowWrapper {
         if let Some(key) = keycode {
             if key == Keycode::Return && modifiers.contains(Mod::LALTMOD) {
                 self.toggle_fullscreen();
+                return;
             }
         }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -203,7 +203,7 @@ impl WindowWrapper {
 
                     // Set window to fullscreen
                     self.window.set_size(rect.width(), rect.height()).unwrap();   
-                    self.window.set_position(sdl2::video::WindowPos::Positioned(0), sdl2::video::WindowPos::Positioned(0));
+                    self.window.set_position(sdl2::video::WindowPos::Positioned(rect.x()), sdl2::video::WindowPos::Positioned(rect.y()));
                     self.window.set_bordered(true);
                 }
             }


### PR DESCRIPTION
I had a few issues with the way the fullscreen behaviour worked so I made this PR to try and improve it.

I've improved the borderless fullscreen behaviour loosely based on https://discourse.libsdl.org/t/true-borderless-fullscreen-behaviour/24622/11. It works seamlessly on my multi-monitor Windows 10 setup. 

I also added toggleability with Alt+Enter.