### PR TITLE
Neovide can now open files... with drag/drop

### DIFF
--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -21,6 +21,7 @@ pub enum UiCommand {
         position: (u32, u32),
     },
     Drag(u32, u32),
+    FileDrop(String),
     FocusLost,
     FocusGained,
     Quit,
@@ -74,6 +75,9 @@ impl UiCommand {
                 .expect("Focus Gained Failed"),
             UiCommand::Quit => {
                 nvim.command("qa!").await.ok(); // Ignoring result as it won't succeed since the app closed.
+            },
+            UiCommand::FileDrop(path) => {
+                nvim.command(format!("e {}", path).as_str()).await.ok();
             }
         }
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -454,6 +454,9 @@ pub fn ui_loop() {
         for event in event_pump.poll_iter() {
             match event {
                 Event::Quit { .. } => window.handle_quit(),
+                Event::DropFile { filename, ..} => {
+                    BRIDGE.queue_command(UiCommand::FileDrop(filename));
+                }
                 Event::KeyDown {
                     keycode: received_keycode,
                     ..


### PR DESCRIPTION
In order to open a file if there’s changes in current buffer, a user should have `set hidden` in his/her vimrc. This should fix #242

@Kethku i wonder why you stated that it isn't possible with sdl, just an oversight?