### PR TITLE
Better symbol font for linux

### DIFF
--- a/src/renderer/caching_shaper.rs
+++ b/src/renderer/caching_shaper.rs
@@ -22,7 +22,7 @@ define! {
         const SYSTEM_EMOJI_FONT: &str = "Segoe UI Emoji";
     } else if #[cfg(target_os = "linux")] {
         const SYSTEM_DEFAULT_FONT: &str = "Droid Sans Mono";
-        const SYSTEM_SYMBOL_FONT: &str = "Unifont";
+        const SYSTEM_SYMBOL_FONT: &str = "Noto Sans Mono";
         const SYSTEM_EMOJI_FONT: &str = "Noto Color Emoji";
     } else if #[cfg(target_os = "macos")] {
         const SYSTEM_DEFAULT_FONT: &str = "Menlo";


### PR DESCRIPTION
Instead of using unifont we can use noto sans mono for better unicode support

With `Unifont`
![image](https://user-images.githubusercontent.com/4239625/80053873-8694d480-8550-11ea-86ee-0afa4fb6d028.png)

With `Noto Sans`
![image](https://user-images.githubusercontent.com/4239625/80053907-98767780-8550-11ea-8bc4-7c344f922b34.png)

