### PR TITLE
get_or_load() works now without embedFont

### DIFF
--- a/src/renderer/caching_shaper.rs
+++ b/src/renderer/caching_shaper.rs
@@ -140,28 +140,21 @@ impl FontLoader {
         self.get(font_name)
     }
 
-    #[cfg(feature = "embed-fonts")]
     pub fn get_or_load(&mut self, font_name: &str, asset: bool) -> Option<ExtendedFontFamily> {
         if let Some(family) = self.get(font_name) {
             return Some(family);
         }
 
         if asset {
-            self.load_from_asset(font_name)
-        } else {
-            self.load(font_name)
-        }
-    }
-
-    #[cfg(not(feature = "embed-fonts"))]
-    pub fn get_or_load(&mut self, font_name: &str, asset: bool) -> Option<ExtendedFontFamily> {
-        if let Some(family) = self.get(font_name) {
-            return Some(family);
-        }
-
-        if asset {
-            warn!("Tried to load {} from assets but build didn't include embed-fonts feature",font_name);
-            None
+            #[cfg(not(feature = "embed-fonts"))]
+            {
+                warn!("Tried to load '{}' from assets but build didn't include embed-fonts feature", font_name);
+                None
+            }
+            #[cfg(feature = "embed-fonts")]
+            {
+                self.load_from_asset(font_name)
+            }
         } else {
             self.load(font_name)
         }

--- a/src/renderer/caching_shaper.rs
+++ b/src/renderer/caching_shaper.rs
@@ -140,6 +140,7 @@ impl FontLoader {
         self.get(font_name)
     }
 
+    #[cfg(feature = "embed-fonts")]
     pub fn get_or_load(&mut self, font_name: &str, asset: bool) -> Option<ExtendedFontFamily> {
         if let Some(family) = self.get(font_name) {
             return Some(family);
@@ -147,6 +148,20 @@ impl FontLoader {
 
         if asset {
             self.load_from_asset(font_name)
+        } else {
+            self.load(font_name)
+        }
+    }
+
+    #[cfg(not(feature = "embed-fonts"))]
+    pub fn get_or_load(&mut self, font_name: &str, asset: bool) -> Option<ExtendedFontFamily> {
+        if let Some(family) = self.get(font_name) {
+            return Some(family);
+        }
+
+        if asset {
+            warn!("Tried to load {} from assets but build didn't include embed-fonts feature",font_name);
+            None
         } else {
             self.load(font_name)
         }
@@ -195,7 +210,6 @@ pub fn build_collection_by_font_name(
             collection.add_family(family.to_normal_font_family());
         }
     }
-
     for font in &[EXTRA_SYMBOL_FONT, MISSING_GLYPH_FONT] {
         if let Some(family) = loader.get_or_load(font, true) {
             collection.add_family(family.to_normal_font_family());


### PR DESCRIPTION
This is the fix for #272

Because get_or_load defines "asset" as parameter in his public api I decided to create an copy of the original get_or_load that prints a warning if someone is using this option but haven't enabled `embed-fonts` it yet.

This is still WIP because there are two points that are debatable where I'm kinda indifferent.

1. I think it is better to have one `get_or_load()`, but for some reason I could not get the cfg! macro to work. More if's aren't a silver bulet but in the long them I think this would be easier to maintain. If someone can update me on the syntax on that and agrees on with that change I will add that.

2. Do we want the use of `asset` be a warning or a debug message? The problem in the first place is that `embed-fonts` can't be a feature anymore with get_or_load exposing it. The clean solution would be to refactor the code so `asset` isn't exposed anymore or drop `embed-fonts` as a feature completely. Also here input and feedback is wanted and very much appreciated.

As for now at least this version did fix the build and produced a functioning binary.