### PR TITLE
Add search for nvim in PATH

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
+name = "backtrace"
+version = "0.3.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
+dependencies = [
+ "backtrace-sys",
+ "cfg-if",
+ "libc",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18fbebbe1c9d1f383a9cc7e8ccdb471b91c8d024ee9c2ca5b5346121fe8b4399"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +672,15 @@ checksum = "658f19728920138342f68408b7cf7644d90d4784353d8ebc32e7e8663dbe45fa"
 dependencies = [
  "cmake",
  "pkg-config",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+dependencies = [
+ "backtrace",
 ]
 
 [[package]]
@@ -1309,6 +1340,7 @@ dependencies = [
  "skulpin",
  "tokio",
  "unicode-segmentation",
+ "which",
  "winapi 0.3.8",
  "winres",
 ]
@@ -1842,6 +1874,12 @@ checksum = "97655158074ccb2d2cfb1ccb4c956ef0f4054e43a2c1e71146d4991e6961e105"
 dependencies = [
  "walkdir",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
 name = "rustc-hash"
@@ -2468,6 +2506,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 dependencies = [
+ "failure",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ flexi_logger = { version = "0.14.6", default-features = false }
 anyhow = "1.0.26"
 parking_lot="0.10.0"
 cfg-if = "0.1.10"
+which = "3.1"
 
 [dev-dependencies]
 mockall = "0.7.0"

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -65,10 +65,13 @@ fn platform_build_nvim_cmd(bin: &str) -> Command {
 }
 
 fn build_nvim_cmd() -> Command {
-    let key = "NEOVIM_BIN";
-    match std::env::var_os(key) {
-        Some(path) => platform_build_nvim_cmd(&path.to_string_lossy()),
-        None => platform_build_nvim_cmd("nvim"),
+    if let Some(path) = std::env::var_os("NEOVIM_BIN") {
+        platform_build_nvim_cmd(&path.to_string_lossy())
+    } else if let Ok(path) = which::which("nvim") {
+        platform_build_nvim_cmd(path.to_str().unwrap())
+    } else {
+        error!("Neovim is not installed!");
+        std::process::exit(1);
     }
 }
 

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -70,7 +70,7 @@ fn build_nvim_cmd() -> Command {
     } else if let Ok(path) = which::which("nvim") {
         platform_build_nvim_cmd(path.to_str().unwrap())
     } else {
-        error!("Neovim is not installed!");
+        error!("nvim not found!");
         std::process::exit(1);
     }
 }


### PR DESCRIPTION
Defaults to searching in PATH if the NEOVIM_BIN variable is not provided. We can also do a check to see if NEOVIM_BIN points to a binary or not, but I think it's safe to assume that the user will manage this.