### PR TITLE
Allow font fallback

### DIFF
--- a/src/renderer/font_options.rs
+++ b/src/renderer/font_options.rs
@@ -32,7 +32,7 @@ impl FontOptions {
                 .map(|fallback| fallback.to_string())
                 .collect();
 
-            if parsed_fallback_list.is_empty() && self.fallback_list != parsed_fallback_list {
+            if !parsed_fallback_list.is_empty() && self.fallback_list != parsed_fallback_list {
                 self.fallback_list = parsed_fallback_list;
                 updated = true;
             }


### PR DESCRIPTION
When debugging a font issue, I noticed that fallbacks are not set correctly. Seems we dropped a `!` in a recent refactor.