### PR TITLE
solved the pathing issue with a bit less hacking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,28 +130,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
-name = "backtrace"
-version = "0.3.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
-dependencies = [
- "backtrace-sys",
- "cfg-if",
- "libc",
- "rustc-demangle",
-]
-
-[[package]]
-name = "backtrace-sys"
-version = "0.1.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fbebbe1c9d1f383a9cc7e8ccdb471b91c8d024ee9c2ca5b5346121fe8b4399"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,7 +156,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "which",
+ "which 3.1.1",
 ]
 
 [[package]]
@@ -678,15 +656,6 @@ checksum = "658f19728920138342f68408b7cf7644d90d4784353d8ebc32e7e8663dbe45fa"
 dependencies = [
  "cmake",
  "pkg-config",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
 ]
 
 [[package]]
@@ -1329,6 +1298,7 @@ dependencies = [
  "cargo-husky",
  "cfg-if",
  "derive-new",
+ "dirs",
  "euclid",
  "flexi_logger",
  "font-kit",
@@ -1347,7 +1317,7 @@ dependencies = [
  "skulpin",
  "tokio",
  "unicode-segmentation",
- "which",
+ "which 4.0.0",
  "winapi 0.3.8",
  "winres",
 ]
@@ -1883,12 +1853,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2272,6 +2236,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
+dependencies = [
+ "proc-macro2 1.0.12",
+ "quote 1.0.4",
+ "syn 1.0.19",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2513,8 +2497,17 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 dependencies = [
- "failure",
  "libc",
+]
+
+[[package]]
+name = "which"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd3edc3cf5458851a4d6a2329232bd5f42c7f9bbe4c4782c4ef9ce37e5d101b2"
+dependencies = [
+ "libc",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,8 @@ flexi_logger = { version = "0.14.6", default-features = false }
 anyhow = "1.0.26"
 parking_lot="0.10.0"
 cfg-if = "0.1.10"
-which = "3.1"
+which = "4"
+dirs = "2"
 
 [dev-dependencies]
 mockall = "0.7.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,22 @@ fn main() {
         eprintln!("{}", err);
         process::exit(1);
     };
+
+    #[cfg(target_os = "macos")]
+    {
+        use std::env;
+        let mut profile_path = dirs::home_dir().unwrap();
+        profile_path.push(".profile");
+        let shell = env::var("SHELL").unwrap();
+        let cmd = format!(
+            "(source /etc/profile && source {} && echo $PATH)",
+            profile_path.to_str().unwrap()
+        );
+        if let Ok(path) = process::Command::new(shell).arg("-c").arg(cmd).output() {
+            env::set_var("PATH", std::str::from_utf8(&path.stdout).unwrap());
+        }
+    }
+
     window::initialize_settings();
     redraw_scheduler::initialize_settings();
     renderer::cursor_renderer::initialize_settings();


### PR DESCRIPTION
Hopes to resolve #308. This fix is a bit hacky in the sense that it assumes that $HOME/.profile and /etc/profile will exist, which is a safe bet, but doesn't implement a failsafes against those files not existing, and also the OSX specific code might be extracted to a separate function, though it is not strictly necessary.