### PR TITLE
Fix underscores not displayed on every line

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -51,7 +51,7 @@ impl Renderer {
         if updated {
             let (font_width, font_height) = self.shaper.font_base_dimensions();
             self.font_width = font_width;
-            self.font_height = font_height;
+            self.font_height = font_height.ceil();
         }
         updated
     }


### PR DESCRIPTION
With certain font-configurations, underscores are not drawn on every line.

Locally, setting `set guifont=Deja\ for\ Powerline\ Medium:h11` caused underscores to be hidden on two lines and then displayed on the following three:
![example of underscores not displayed](https://user-images.githubusercontent.com/123140/85402067-5a4f0180-b55b-11ea-9631-7a4414798184.png)

Fixing the line height to the nearest integer seems to alleviate the issue.