### PR TITLE
Add all environment variables from .profile

### DIFF
--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -6,7 +6,9 @@ use tokio::process::ChildStdin;
 use tokio::task;
 
 use super::events::handle_redraw_event_group;
+#[cfg(windows)]
 use super::ui_commands::UiCommand;
+#[cfg(windows)]
 use super::BRIDGE;
 use crate::settings::SETTINGS;
 
@@ -31,9 +33,11 @@ impl Handler for NeovimHandler {
             "setting_changed" => {
                 SETTINGS.handle_changed_notification(arguments);
             }
+            #[cfg(windows)]
             "neovide.register_right_click" => {
                 BRIDGE.queue_command(UiCommand::RegisterRightClick);
             }
+            #[cfg(windows)]
             "neovide.unregister_right_click" => {
                 BRIDGE.queue_command(UiCommand::UnregisterRightClick);
             }

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -80,6 +80,7 @@ fn build_nvim_cmd() -> Command {
     }
 }
 
+#[cfg(windows)]
 pub fn build_neovide_command(channel: u64, num_args: u64, command: &str, event: &str) -> String {
     let nargs: String = if num_args > 1 {
         "+".to_string()

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -1,4 +1,4 @@
-use log::{error, trace};
+use log::trace;
 use nvim_rs::compat::tokio::Compat;
 use nvim_rs::Neovim;
 use tokio::process::ChildStdin;

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -11,6 +11,8 @@ use parking_lot::RwLock;
 pub use rmpv::Value;
 mod from_value;
 pub use from_value::FromValue;
+
+#[cfg(windows)]
 pub mod windows_registry;
 
 use tokio::process::ChildStdin;

--- a/src/settings/windows_registry.rs
+++ b/src/settings/windows_registry.rs
@@ -1,6 +1,5 @@
 use std::ffi::CString;
 use std::ptr::{null, null_mut};
-#[cfg(windows)]
 use winapi::{
     shared::minwindef::{DWORD, HKEY, MAX_PATH},
     um::{
@@ -10,7 +9,6 @@ use winapi::{
     },
 };
 
-#[cfg(target_os = "windows")]
 fn get_binary_path() -> String {
     let mut buffer = vec![0u8; MAX_PATH];
     unsafe {
@@ -27,7 +25,6 @@ fn get_binary_path() -> String {
     }
 }
 
-#[cfg(target_os = "windows")]
 pub fn unregister_rightclick() -> bool {
     let str_registry_path_1 = CString::new("Directory\\Background\\shell\\Neovide").unwrap();
     let str_registry_path_2 = CString::new("*\\shell\\Neovide").unwrap();
@@ -38,7 +35,6 @@ pub fn unregister_rightclick() -> bool {
     }
 }
 
-#[cfg(target_os = "windows")]
 pub fn register_rightclick_directory() -> bool {
     let neovide_path = get_binary_path();
     let mut registry_key: HKEY = null_mut();
@@ -126,7 +122,6 @@ pub fn register_rightclick_directory() -> bool {
     true
 }
 
-#[cfg(target_os = "windows")]
 pub fn register_rightclick_file() -> bool {
     let neovide_path = get_binary_path();
     let mut registry_key: HKEY = null_mut();


### PR DESCRIPTION
Fixes this: https://github.com/Kethku/neovide/issues/308#issuecomment-679125311

There is a possibility to add shell environment support by sourcing .zshrc or .bashrc, nut I will only add this on request, since these are dependent on a user's personal environment.