### PR TITLE
added version info and exit on unknown command line option

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -132,6 +132,11 @@ async fn start_process(mut receiver: UnboundedReceiver<UiCommand>) {
             .await
             .unwrap_or_explained_panic("Could not locate or start the neovim process");
 
+    if nvim.get_api_info().await.is_err() {
+        error!("Cannot get neovim api info, either neovide is launched with an unknown command line option or neovim version not supported!");
+        std::process::exit(-1);
+    }
+
     tokio::spawn(async move {
         info!("Close watcher started");
         match io_handler.await {

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -71,6 +71,12 @@ impl Settings {
                 if arg == "--log" {
                     log_to_file = true;
                     false
+                } else if arg == "--version" || arg == "-v" {
+                    println!("Neovide version: {}", env!("CARGO_PKG_VERSION"));
+                    std::process::exit(0);
+                } else if arg == "--help" || arg == "-h" {
+                    println!("neovide : {}", env!("CARGO_PKG_DESCRIPTION"));
+                    std::process::exit(0);
                 } else {
                     !(arg.starts_with("--geometry=") || arg == "--wsl")
                 }


### PR DESCRIPTION
the issue arises mainly because `-h ` or `--version` quits the `neovim` instance immediately. Since the user already have `neovim` installed, so echoing neovim version back is not logical when user supplies `[-v | --version]`, instead `[-v | --version]`  should print `neovide`'s version and help. Other thing is to check if we can access `neovim` API before executing any commands on `neovim` instance, because then we can be sure we are accessing a valid instance.