### PR TITLE
macos neovide disown from terminal #402

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
     {
         // incase of app bundle, we can just pass --disowned option straight away to bypass this check
         #[cfg(not(debug_assertions))]
-        if std::env::args().find(|f| f == "--disowned").is_none() {
+        if !std::env::args().any(|f| f == "--disowned") {
             if let Ok(curr_exe) = std::env::current_exe() {
                 assert!(std::process::Command::new(curr_exe)
                     .args(std::env::args().skip(1))

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,21 @@ fn main() {
 
     #[cfg(target_os = "macos")]
     {
+        // incase of app bundle, we can just pass --disowned option straight away to bypass this check
+        #[cfg(not(debug_assertions))]
+        if std::env::args().find(|f| f == "--disowned").is_none() {
+            if let Ok(curr_exe) = std::env::current_exe() {
+                assert!(std::process::Command::new(curr_exe)
+                    .args(std::env::args().skip(1))
+                    .arg("--disowned")
+                    .spawn()
+                    .is_ok());
+                std::process::exit(0);
+            } else {
+                eprintln!("error in disowning process, cannot obtain the path for the current executable, continuing without disowning...");
+            }
+        }
+
         use std::env;
         if env::var_os("TERM").is_none() {
             let mut profile_path = dirs::home_dir().unwrap();

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -78,7 +78,7 @@ impl Settings {
                     println!("neovide : {}", env!("CARGO_PKG_DESCRIPTION"));
                     std::process::exit(0);
                 } else {
-                    !(arg.starts_with("--geometry=") || arg == "--wsl")
+                    !(arg.starts_with("--geometry=") || arg == "--wsl" || arg == "--disowned")
                 }
             })
             .collect::<Vec<String>>();


### PR DESCRIPTION
nevoid can now be run on macOS without spawning a new terminal, it will disown itself on the first run.