### PR TITLE
Round up font size to account for draw_image_rect not doing subpixel copying

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -62,7 +62,9 @@ impl Renderer {
         let mut paint = Paint::new(colors::WHITE, None);
         paint.set_anti_alias(false);
         let mut shaper = CachingShaper::new();
-        let (font_width, font_height) = shaper.font_base_dimensions();
+        let (font_width_raw, font_height_raw) = shaper.font_base_dimensions();
+        let font_width = font_width_raw;
+        let font_height = font_height_raw.ceil();
         let default_style = Arc::new(Style::new(Colors::new(
             Some(colors::WHITE),
             Some(colors::BLACK),


### PR DESCRIPTION
This is a bit of a hack to fix #436, there's surely a better solution but I'm not sure what it is right now.
Rounding the width breaks some drawing of text (one case being where there's a combination of underlined and non-underlined text in a line), possibly due to one system using font shaping for width and another using a constant font width, would require more investigation to track down.