### PR TITLE
Add vim setting for ISO layout compatibility (sdl2)

### DIFF
--- a/src/window/sdl2/layouts/mod.rs
+++ b/src/window/sdl2/layouts/mod.rs
@@ -1,16 +1,17 @@
 mod qwerty;
 
-use crate::window::keyboard::Modifiers;
+use crate::{settings::SETTINGS, window::keyboard::Modifiers, WindowSettings};
 use skulpin::sdl2::keyboard::Mod;
 
 pub use qwerty::handle_qwerty_layout;
 
 impl From<Mod> for Modifiers {
     fn from(mods: Mod) -> Modifiers {
+        let iso_layout = SETTINGS.get::<WindowSettings>().iso_layout;
         Modifiers {
             shift: mods.contains(Mod::LSHIFTMOD) || mods.contains(Mod::RSHIFTMOD),
             control: mods.contains(Mod::LCTRLMOD) || mods.contains(Mod::RCTRLMOD),
-            meta: mods.contains(Mod::LALTMOD) || mods.contains(Mod::RALTMOD),
+            meta: mods.contains(Mod::LALTMOD) || (!iso_layout && mods.contains(Mod::RALTMOD)),
             logo: mods.contains(Mod::LGUIMOD) || mods.contains(Mod::RGUIMOD),
         }
     }

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -8,6 +8,7 @@ pub struct WindowSettings {
     pub transparency: f32,
     pub no_idle: bool,
     pub fullscreen: bool,
+    pub iso_layout: bool
 }
 
 impl Default for WindowSettings {
@@ -19,6 +20,7 @@ impl Default for WindowSettings {
                 .neovim_arguments
                 .contains(&String::from("--noIdle")),
             fullscreen: false,
+            iso_layout: false
         }
     }
 }


### PR DESCRIPTION
As discussed in #388, I have created a new vim setting to differentiate between ANSI and ISO layout to handle the Right Alt/Alt Gr key properly. I added an optional setting `neovide_iso_layout` that can be set to true when necessary.

At the moment, the fix only applies to sdl2. Winit doesn't differentiate between left and right Alt and I don't know how to fix this problem without heavily modifying how the input is handled. 

Because this is potentially affecting many users, I opened a PR with only the sdl2 fix. That way, at least, will be solved for some people. 

Let me know if you have any suggestion.