### PR TITLE
Disable the default-on SDL hint to disable compositing on X11

### DIFF
--- a/src/window/sdl2/mod.rs
+++ b/src/window/sdl2/mod.rs
@@ -380,6 +380,17 @@ impl Sdl2WindowWrapper {
     }
 }
 
+fn allow_compositing() {
+    // This fixes any vestiges of https://github.com/Kethku/neovide/issues/370
+    // which is an issue where KDE and perhaps others misbehave when compositing is forced off for
+    // a window, as is done by default with SDL2. Since this just sets a hint that will be ignored
+    // if unsupported, it is OK to leave in for all platforms.
+    //
+    // This is `sdl2_sys::SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR`
+    let name = "SDL_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR";
+    sdl2::hint::set(name, "0");
+}
+
 pub fn start_loop(
     window_command_receiver: Receiver<WindowCommand>,
     ui_command_sender: TxUnbounded<UiCommand>,
@@ -390,6 +401,9 @@ pub fn start_loop(
     sdl2::hint::set("SDL_MOUSE_FOCUS_CLICKTHROUGH", "1");
 
     let context = sdl2::init().expect("Failed to initialize sdl2");
+
+    allow_compositing();
+
     let video_subsystem = context
         .video()
         .expect("Failed to create sdl video subsystem");


### PR DESCRIPTION
SDL tells the window manager to disable compositing for its windows by
default in order to somewhat improve rendering performance.  This is
unfortunate for a text editor one would be using concurrently with other
programs, because KDE misbehaves with its global taskbar if this is
done, and it also may freeze or otherwise break the display of running
Firefox windows. This misbehaviour affects all SDL windows including
e.g. games such as Factorio.

There is a global switch to ignore all applications making this request
in the KDE compositor settings called "Allow applications to block
compositing", as well as an option in the window rules dialog to do it
for individual windows by class, but we should try to do the right thing
by default. The user can decide to block compositing per-window with
these rules if they wish to preserve the previous behaviour.

Fixes #370.