### PR TITLE
Fix clippy, fix font load test

### DIFF
--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -270,15 +270,15 @@ pub enum RedrawEvent {
 
 #[derive(Debug)]
 pub enum ChannelStreamType {
-    STDIO,
-    STDERR,
+    Stdio,
+    Stderr,
     Socket,
     Job,
 }
 
 impl Default for ChannelStreamType {
     fn default() -> Self {
-        Self::STDIO
+        Self::Stdio
     }
 }
 
@@ -286,7 +286,7 @@ impl Default for ChannelStreamType {
 pub enum ChannelMode {
     Bytes,
     Terminal,
-    RPC,
+    Rpc,
 }
 
 impl Default for ChannelMode {
@@ -307,7 +307,7 @@ pub struct ClientVersion {
 #[derive(Debug)]
 pub enum ClientType {
     Remote,
-    UI,
+    Ui,
     Embedder,
     Host,
     Plugin,
@@ -953,8 +953,8 @@ pub fn parse_redraw_event(event_value: Value) -> Result<Vec<RedrawEvent>> {
 
 pub fn parse_channel_stream_type(channel_stream_value: Value) -> Result<ChannelStreamType> {
     match parse_string(channel_stream_value)?.as_ref() {
-        "stdio" => Ok(ChannelStreamType::STDIO),
-        "stderr" => Ok(ChannelStreamType::STDERR),
+        "stdio" => Ok(ChannelStreamType::Stdio),
+        "stderr" => Ok(ChannelStreamType::Stderr),
         "socket" => Ok(ChannelStreamType::Socket),
         "job" => Ok(ChannelStreamType::Job),
         _ => Err(ParseError::InvalidFormat),
@@ -965,7 +965,7 @@ pub fn parse_channel_mode(channel_mode_value: Value) -> Result<ChannelMode> {
     match parse_string(channel_mode_value)?.as_ref() {
         "bytes" => Ok(ChannelMode::Bytes),
         "terminal" => Ok(ChannelMode::Terminal),
-        "rpc" => Ok(ChannelMode::RPC),
+        "rpc" => Ok(ChannelMode::Rpc),
         _ => Err(ParseError::InvalidFormat),
     }
 }
@@ -996,7 +996,7 @@ pub fn parse_client_version(version_value: Value) -> Result<ClientVersion> {
 pub fn parse_client_type(client_type_value: Value) -> Result<ClientType> {
     match parse_string(client_type_value)?.as_ref() {
         "remote" => Ok(ClientType::Remote),
-        "ui" => Ok(ClientType::UI),
+        "ui" => Ok(ClientType::Ui),
         "embedder" => Ok(ClientType::Embedder),
         "host" => Ok(ClientType::Host),
         "plugin" => Ok(ClientType::Plugin),

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -44,7 +44,7 @@ impl Handler for NeovimHandler {
     ) {
         trace!("Neovim notification: {:?}", &event_name);
 
-        let _ui_command_sender = self.ui_command_sender.clone();
+        let ui_command_sender = self.ui_command_sender.clone();
         let redraw_event_sender = self.redraw_event_sender.clone();
         task::spawn_blocking(move || match event_name.as_ref() {
             "redraw" => {

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -44,7 +44,9 @@ impl Handler for NeovimHandler {
     ) {
         trace!("Neovim notification: {:?}", &event_name);
 
+        #[cfg(windows)]
         let ui_command_sender = self.ui_command_sender.clone();
+
         let redraw_event_sender = self.redraw_event_sender.clone();
         task::spawn_blocking(move || match event_name.as_ref() {
             "redraw" => {

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -44,7 +44,7 @@ impl Handler for NeovimHandler {
     ) {
         trace!("Neovim notification: {:?}", &event_name);
 
-        let ui_command_sender = self.ui_command_sender.clone();
+        let _ui_command_sender = self.ui_command_sender.clone();
         let redraw_event_sender = self.redraw_event_sender.clone();
         task::spawn_blocking(move || match event_name.as_ref() {
             "redraw" => {

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -91,7 +91,7 @@ fn build_nvim_cmd() -> Command {
     }
 }
 
-pub fn build_neovide_command(channel: u64, num_args: u64, command: &str, event: &str) -> String {
+pub fn _build_neovide_command(channel: u64, num_args: u64, command: &str, event: &str) -> String {
     let nargs: String = if num_args > 1 {
         "+".to_string()
     } else {

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -91,6 +91,7 @@ fn build_nvim_cmd() -> Command {
     }
 }
 
+#[cfg(windows)]
 pub fn build_neovide_command(channel: u64, num_args: u64, command: &str, event: &str) -> String {
     let nargs: String = if num_args > 1 {
         "+".to_string()

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -91,7 +91,7 @@ fn build_nvim_cmd() -> Command {
     }
 }
 
-pub fn _build_neovide_command(channel: u64, num_args: u64, command: &str, event: &str) -> String {
+pub fn build_neovide_command(channel: u64, num_args: u64, command: &str, event: &str) -> String {
     let nargs: String = if num_args > 1 {
         "+".to_string()
     } else {

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -1,4 +1,4 @@
-use log::{error, trace};
+use log::{trace};
 use nvim_rs::compat::tokio::Compat;
 use nvim_rs::Neovim;
 use tokio::process::ChildStdin;

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -1,4 +1,4 @@
-use log::{trace};
+use log::trace;
 use nvim_rs::compat::tokio::Compat;
 use nvim_rs::Neovim;
 use tokio::process::ChildStdin;

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -1,4 +1,8 @@
 use log::trace;
+
+#[cfg(windows)]
+use log::Error;
+
 use nvim_rs::compat::tokio::Compat;
 use nvim_rs::Neovim;
 use tokio::process::ChildStdin;

--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -2,7 +2,7 @@ use log::error;
 
 fn show_error(explanation: &str) -> ! {
     error!("{}", explanation);
-    panic!(explanation.to_string());
+    panic!("{}", explanation.to_string());
 }
 
 pub trait ResultPanicExplanation<T, E: ToString> {

--- a/src/renderer/fonts/font_loader.rs
+++ b/src/renderer/fonts/font_loader.rs
@@ -230,7 +230,6 @@ mod test {
     }
 
     #[test]
-    #[ignore]
     fn test_load() {
         let mut loader = FontLoader::new();
         let junk_text = "uhasiudhaiudshiaushd";
@@ -238,7 +237,7 @@ mod test {
         assert!(font_family.is_none());
 
         #[cfg(target_os = "linux")]
-        const SYSTEM_DEFAULT_FONT: &str = "DejaVu Serif";
+        const SYSTEM_DEFAULT_FONT: &str = "monospace";
 
         let font_family = loader.load(SYSTEM_DEFAULT_FONT);
         let result = font_family.unwrap().fonts.first().unwrap().font.full_name();

--- a/src/renderer/fonts/font_loader.rs
+++ b/src/renderer/fonts/font_loader.rs
@@ -230,6 +230,7 @@ mod test {
     }
 
     #[test]
+    #[ignore]
     fn test_load() {
         let mut loader = FontLoader::new();
         let junk_text = "uhasiudhaiudshiaushd";

--- a/src/window/keyboard/token.rs
+++ b/src/window/keyboard/token.rs
@@ -42,7 +42,7 @@ impl<'a> Token<'a> {
 
 #[cfg(not(target_os = "windows"))]
 fn use_logo(logo: bool) -> bool {
-    return logo;
+    logo
 }
 
 // The Windows key is used for OS-level shortcuts,

--- a/src/windows_utils.rs
+++ b/src/windows_utils.rs
@@ -1,3 +1,5 @@
+use std::ffi::CString;
+use std::ptr::{null, null_mut};
 #[cfg(windows)]
 use winapi::{
     shared::minwindef::{DWORD, HKEY, MAX_PATH},

--- a/src/windows_utils.rs
+++ b/src/windows_utils.rs
@@ -1,5 +1,9 @@
-use std::ffi::CString;
-use std::ptr::{null, null_mut};
+#[cfg(target_os = "windows")]
+use {
+    std::ffi::CString,
+    std::ptr::{null, null_mut},
+};
+
 #[cfg(windows)]
 use winapi::{
     shared::minwindef::{DWORD, HKEY, MAX_PATH},

--- a/src/windows_utils.rs
+++ b/src/windows_utils.rs
@@ -1,5 +1,3 @@
-use std::ffi::CString;
-use std::ptr::{null, null_mut};
 #[cfg(windows)]
 use winapi::{
     shared::minwindef::{DWORD, HKEY, MAX_PATH},


### PR DESCRIPTION
I've removed unused imports, prefixed an unused variable with an underscore and didn't do anything to an unused `pub` function. Also fixed
```
warning: panic message is not a string literal
 --> src/error_handling.rs:5:12
  |
5 |     panic!(explanation.to_string());
  |            ^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(non_fmt_panic)]` on by default
  = note: this is no longer accepted in Rust 2021
help: add a "{}" format string to Display the message
  |
5 |     panic!("{}", explanation.to_string());
```
After this, there's only the one warning about the unused function ( `build_neovide_command` in `src/bridge/mod.rs` )