### PR TITLE
Remote TCP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,6 +1577,7 @@ dependencies = [
  "euclid",
  "flexi_logger",
  "font-kit",
+ "futures 0.3.12",
  "image",
  "lazy_static",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,6 +1585,7 @@ dependencies = [
  "neovide-derive",
  "nvim-rs",
  "parking_lot 0.10.2",
+ "pin-project",
  "rand",
  "rmpv",
  "rust-embed",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ dirs = "2"
 rand = "0.7"
 skia-safe = "0.32.1"
 pin-project = "0.4.27"
+futures = "0.3.12"
 
 [dev-dependencies]
 mockall = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ which = "4"
 dirs = "2"
 rand = "0.7"
 skia-safe = "0.32.1"
+pin-project = "0.4.27"
 
 [dev-dependencies]
 mockall = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rmpv = "0.4.4"
 rust-embed = { version = "5.2.0", features = ["debug-embed"] }
 image = "0.22.3"
 nvim-rs = { git = "https://github.com/kethku/nvim-rs", features = [ "use_tokio" ] }
-tokio = { version = "0.2.9", features = [ "blocking", "process", "time" ] }
+tokio = { version = "0.2.9", features = [ "blocking", "process", "time", "tcp" ] }
 async-trait = "0.1.18"
 crossfire = "0.1"
 lazy_static = "1.4.0"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,28 @@ Font fallback supports rendering of emoji not contained in the configured font.
 
 Neovide supports displaying a full gui window from inside wsl via the `--wsl` command argument. Communication is passed via standard io into the wsl copy of neovim providing identical experience similar to visual studio code's remote editing https://code.visualstudio.com/docs/remote/remote-overview.
 
+### Remote TCP Support
+
+Neovide supports connecting to a remote instance of Neovim over a TCP socket via the `--remote-tcp` command argument. This would allow you to run Neovim on a remote machine and use the GUI on your local machine, connecting over the network.
+
+Launch Neovim as a TCP server (on port 6666) by running:
+
+```sh
+nvim --headless --listen localhost:6666
+```
+
+And then connect to it using:
+
+```sh
+/path/to/neovide --remote-tcp=localhost:6666
+```
+
+By specifying to listen on localhost, you only allow connections from your local computer. If you are actually doing this over a network you will want to use SSH port forwarding for security, and then connect as before.
+
+```sh
+ssh -L 6666:localhost:6666 ip.of.other.machine nvim --headless --listen localhost:6666
+```
+
 ### Some Nonsense ;)
 
 ```

--- a/src/bridge/create.rs
+++ b/src/bridge/create.rs
@@ -1,14 +1,17 @@
+//! This module contains adaptations of the functions found in
+//! https://github.com/KillTheMule/nvim-rs/blob/master/src/create/tokio.rs
+
 use std::{
-  io::{self, Error, ErrorKind},
-  process::Stdio,
+    io::{self, Error, ErrorKind},
+    process::Stdio,
 };
 
 use tokio::{
-  io::split,
-  net::{TcpStream, ToSocketAddrs},
-  process::Command,
-  spawn,
-  task::JoinHandle,
+    io::split,
+    net::{TcpStream, ToSocketAddrs},
+    process::Command,
+    spawn,
+    task::JoinHandle,
 };
 
 use nvim_rs::compat::tokio::{Compat, TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
@@ -18,56 +21,56 @@ use crate::bridge::{TxWrapper, WrapTx};
 
 /// Connect to a neovim instance via tcp
 pub async fn new_tcp<A, H>(
-  addr: A,
-  handler: H,
+    addr: A,
+    handler: H,
 ) -> io::Result<(
-  Neovim<Compat<TxWrapper>>,
-  JoinHandle<Result<(), Box<LoopError>>>,
+    Neovim<Compat<TxWrapper>>,
+    JoinHandle<Result<(), Box<LoopError>>>,
 )>
 where
-  A: ToSocketAddrs,
-  H: Handler<Writer = Compat<TxWrapper>>,
+    A: ToSocketAddrs,
+    H: Handler<Writer = Compat<TxWrapper>>,
 {
-  let stream = TcpStream::connect(addr).await?;
-  let (reader, writer) = split(stream);
-  let (neovim, io) = Neovim::<Compat<TxWrapper>>::new(
-    reader.compat_read(),
-    writer.wrap_tx().compat_write(),
-    handler,
-  );
-  let io_handle = spawn(io);
+    let stream = TcpStream::connect(addr).await?;
+    let (reader, writer) = split(stream);
+    let (neovim, io) = Neovim::<Compat<TxWrapper>>::new(
+        reader.compat_read(),
+        writer.wrap_tx().compat_write(),
+        handler,
+    );
+    let io_handle = spawn(io);
 
-  Ok((neovim, io_handle))
+    Ok((neovim, io_handle))
 }
 
 /// Connect to a neovim instance by spawning a new one
 ///
 /// stdin/stdout will be rewritten to `Stdio::piped()`
 pub async fn new_child_cmd<H>(
-  cmd: &mut Command,
-  handler: H,
+    cmd: &mut Command,
+    handler: H,
 ) -> io::Result<(
-  Neovim<Compat<TxWrapper>>,
-  JoinHandle<Result<(), Box<LoopError>>>,
+    Neovim<Compat<TxWrapper>>,
+    JoinHandle<Result<(), Box<LoopError>>>,
 )>
 where
-  H: Handler<Writer = Compat<TxWrapper>>,
+    H: Handler<Writer = Compat<TxWrapper>>,
 {
-  let mut child = cmd.stdin(Stdio::piped()).stdout(Stdio::piped()).spawn()?;
-  let stdout = child
-    .stdout
-    .take()
-    .ok_or_else(|| Error::new(ErrorKind::Other, "Can't open stdout"))?
-    .compat_read();
-  let stdin = child
-    .stdin
-    .take()
-    .ok_or_else(|| Error::new(ErrorKind::Other, "Can't open stdin"))?
-    .wrap_tx()
-    .compat_write();
+    let mut child = cmd.stdin(Stdio::piped()).stdout(Stdio::piped()).spawn()?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| Error::new(ErrorKind::Other, "Can't open stdout"))?
+        .compat_read();
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| Error::new(ErrorKind::Other, "Can't open stdin"))?
+        .wrap_tx()
+        .compat_write();
 
-  let (neovim, io) = Neovim::<Compat<TxWrapper>>::new(stdout, stdin, handler);
-  let io_handle = spawn(io);
+    let (neovim, io) = Neovim::<Compat<TxWrapper>>::new(stdout, stdin, handler);
+    let io_handle = spawn(io);
 
-  Ok((neovim, io_handle))
+    Ok((neovim, io_handle))
 }

--- a/src/bridge/create.rs
+++ b/src/bridge/create.rs
@@ -1,0 +1,73 @@
+use std::{
+  io::{self, Error, ErrorKind},
+  process::Stdio,
+};
+
+use tokio::{
+  io::split,
+  net::{TcpStream, ToSocketAddrs},
+  process::Command,
+  spawn,
+  task::JoinHandle,
+};
+
+use nvim_rs::compat::tokio::{Compat, TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+use nvim_rs::{error::LoopError, neovim::Neovim, Handler};
+
+use crate::bridge::{TxWrapper, WrapTx};
+
+/// Connect to a neovim instance via tcp
+pub async fn new_tcp<A, H>(
+  addr: A,
+  handler: H,
+) -> io::Result<(
+  Neovim<Compat<TxWrapper>>,
+  JoinHandle<Result<(), Box<LoopError>>>,
+)>
+where
+  A: ToSocketAddrs,
+  H: Handler<Writer = Compat<TxWrapper>>,
+{
+  let stream = TcpStream::connect(addr).await?;
+  let (reader, writer) = split(stream);
+  let (neovim, io) = Neovim::<Compat<TxWrapper>>::new(
+    reader.compat_read(),
+    writer.wrap_tx().compat_write(),
+    handler,
+  );
+  let io_handle = spawn(io);
+
+  Ok((neovim, io_handle))
+}
+
+/// Connect to a neovim instance by spawning a new one
+///
+/// stdin/stdout will be rewritten to `Stdio::piped()`
+pub async fn new_child_cmd<H>(
+  cmd: &mut Command,
+  handler: H,
+) -> io::Result<(
+  Neovim<Compat<TxWrapper>>,
+  JoinHandle<Result<(), Box<LoopError>>>,
+)>
+where
+  H: Handler<Writer = Compat<TxWrapper>>,
+{
+  let mut child = cmd.stdin(Stdio::piped()).stdout(Stdio::piped()).spawn()?;
+  let stdout = child
+    .stdout
+    .take()
+    .ok_or_else(|| Error::new(ErrorKind::Other, "Can't open stdout"))?
+    .compat_read();
+  let stdin = child
+    .stdin
+    .take()
+    .ok_or_else(|| Error::new(ErrorKind::Other, "Can't open stdin"))?
+    .wrap_tx()
+    .compat_write();
+
+  let (neovim, io) = Neovim::<Compat<TxWrapper>>::new(stdout, stdin, handler);
+  let io_handle = spawn(io);
+
+  Ok((neovim, io_handle))
+}

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use crossfire::mpsc::TxUnbounded;
 use log::trace;
-use nvim_rs::{compat::tokio::Compat, Handler, Neovim};
+use nvim_rs::{Handler, Neovim};
 use parking_lot::Mutex;
 use rmpv::Value;
 use tokio::task;
@@ -34,13 +34,13 @@ impl NeovimHandler {
 
 #[async_trait]
 impl Handler for NeovimHandler {
-    type Writer = Compat<TxWrapper>;
+    type Writer = TxWrapper;
 
     async fn handle_notify(
         &self,
         event_name: String,
         arguments: Vec<Value>,
-        _neovim: Neovim<Compat<TxWrapper>>,
+        _neovim: Neovim<TxWrapper>,
     ) {
         trace!("Neovim notification: {:?}", &event_name);
 

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -8,6 +8,8 @@ use parking_lot::Mutex;
 use rmpv::Value;
 use tokio::process::ChildStdin;
 use tokio::task;
+use tokio::io::WriteHalf;
+use tokio::net::TcpStream;
 
 use super::events::{parse_redraw_event, RedrawEvent};
 use super::ui_commands::UiCommand;
@@ -34,13 +36,13 @@ impl NeovimHandler {
 
 #[async_trait]
 impl Handler for NeovimHandler {
-    type Writer = Compat<ChildStdin>;
+    type Writer = Compat<WriteHalf<TcpStream>>;
 
     async fn handle_notify(
         &self,
         event_name: String,
         arguments: Vec<Value>,
-        _neovim: Neovim<Compat<ChildStdin>>,
+        _neovim: Neovim<Compat<WriteHalf<TcpStream>>>,
     ) {
         trace!("Neovim notification: {:?}", &event_name);
 

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -6,13 +6,11 @@ use log::trace;
 use nvim_rs::{compat::tokio::Compat, Handler, Neovim};
 use parking_lot::Mutex;
 use rmpv::Value;
-use tokio::process::ChildStdin;
 use tokio::task;
-use tokio::io::WriteHalf;
-use tokio::net::TcpStream;
 
 use super::events::{parse_redraw_event, RedrawEvent};
 use super::ui_commands::UiCommand;
+use crate::bridge::TxWrapper;
 use crate::error_handling::ResultPanicExplanation;
 use crate::settings::SETTINGS;
 
@@ -36,13 +34,13 @@ impl NeovimHandler {
 
 #[async_trait]
 impl Handler for NeovimHandler {
-    type Writer = Compat<WriteHalf<TcpStream>>;
+    type Writer = Compat<TxWrapper>;
 
     async fn handle_notify(
         &self,
         event_name: String,
         arguments: Vec<Value>,
-        _neovim: Neovim<Compat<WriteHalf<TcpStream>>>,
+        _neovim: Neovim<Compat<TxWrapper>>,
     ) {
         trace!("Neovim notification: {:?}", &event_name);
 

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use crossfire::mpsc::{RxUnbounded, TxUnbounded};
 use log::{error, info, warn};
-use nvim_rs::{create::tokio as create, UiAttachOptions};
+use nvim_rs::{create::tokio as create, neovim::Neovim, UiAttachOptions};
 use rmpv::Value;
 use tokio::process::Command;
 use tokio::runtime::Runtime;
@@ -137,9 +137,19 @@ async fn start_neovim_runtime(
 ) {
     let (width, height) = window_geometry_or_default();
     let handler = NeovimHandler::new(ui_command_sender.clone(), redraw_event_sender.clone());
-    let (mut nvim, io_handler, _) = create::new_child_cmd(&mut create_nvim_command(), handler)
+    // let (mut nvim, io_handler, _) = create::new_child_cmd(&mut create_nvim_command(), handler)
+    //     .await
+    //     .unwrap_or_explained_panic("Could not locate or start neovim process");
+
+    let (mut nvim, io_handler) = create::new_tcp("localhost:6666", handler)
         .await
-        .unwrap_or_explained_panic("Could not locate or start neovim process");
+        .unwrap_or_explained_panic("Could not locate neovim process");
+
+    // let tcp = std::net::TcpStream::connect("127.0.0.1:6666").unwrap();
+    // let reader = tokio::io::BufReader::new(tcp);
+    // let writer = tokio::io::BufWriter::new(tcp);
+    // let (mut nvim, io) = Neovim::<tokio_util::compat::Compat<std::net::TcpStream>>::new(tcp, tcp, handler);
+    // let io_handler = tokio::spawn(io);
 
     if nvim.get_api_info().await.is_err() {
         error!("Cannot get neovim api info, either neovide is launched with an unknown command line option or neovim version not supported!");

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -132,6 +132,22 @@ pub fn create_nvim_command() -> Command {
     cmd
 }
 
+enum ConnectionMode {
+    Child,
+    RemoteTcp(String),
+}
+
+fn connection_mode() -> ConnectionMode {
+    let tcp_prefix = "--remote-tcp=";
+
+    if let Some(arg) = std::env::args().find(|arg| arg.starts_with(tcp_prefix)) {
+        let input = &arg[tcp_prefix.len()..];
+        ConnectionMode::RemoteTcp(input.to_owned())
+    } else {
+        ConnectionMode::Child
+    }
+}
+
 async fn start_neovim_runtime(
     ui_command_sender: TxUnbounded<UiCommand>,
     ui_command_receiver: RxUnbounded<UiCommand>,
@@ -140,15 +156,11 @@ async fn start_neovim_runtime(
 ) {
     let (width, height) = window_geometry_or_default();
     let handler = NeovimHandler::new(ui_command_sender.clone(), redraw_event_sender.clone());
-    let (mut nvim, io_handler) = if false {
-        create::new_child_cmd(&mut create_nvim_command(), handler)
-            .await
-            .unwrap_or_explained_panic("Could not locate or start neovim process")
-    } else {
-        create::new_tcp("localhost:6666", handler)
-            .await
-            .unwrap_or_explained_panic("Could not locate or start neovim process")
-    };
+    let (mut nvim, io_handler) = match connection_mode() {
+        ConnectionMode::Child => create::new_child_cmd(&mut create_nvim_command(), handler).await,
+        ConnectionMode::RemoteTcp(address) => create::new_tcp(address, handler).await,
+    }
+    .unwrap_or_explained_panic("Could not locate or start neovim process");
 
     if nvim.get_api_info().await.is_err() {
         error!("Cannot get neovim api info, either neovide is launched with an unknown command line option or neovim version not supported!");

--- a/src/bridge/tx_wrapper.rs
+++ b/src/bridge/tx_wrapper.rs
@@ -3,56 +3,56 @@ use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::{
-  io::{AsyncWrite, WriteHalf},
-  net::TcpStream,
-  process::ChildStdin,
+    io::{AsyncWrite, WriteHalf},
+    net::TcpStream,
+    process::ChildStdin,
 };
 
 #[pin_project(project = TxProj)]
 pub enum TxWrapper {
-  Child(#[pin] ChildStdin),
-  Tcp(#[pin] WriteHalf<TcpStream>),
+    Child(#[pin] ChildStdin),
+    Tcp(#[pin] WriteHalf<TcpStream>),
 }
 
 impl AsyncWrite for TxWrapper {
-  fn poll_write(
-    self: Pin<&mut Self>,
-    cx: &mut Context<'_>,
-    buf: &[u8],
-  ) -> Poll<Result<usize, io::Error>> {
-    match self.project() {
-      TxProj::Child(inner) => inner.poll_write(cx, buf),
-      TxProj::Tcp(inner) => inner.poll_write(cx, buf),
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        match self.project() {
+            TxProj::Child(inner) => inner.poll_write(cx, buf),
+            TxProj::Tcp(inner) => inner.poll_write(cx, buf),
+        }
     }
-  }
 
-  fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-    match self.project() {
-      TxProj::Child(inner) => inner.poll_flush(cx),
-      TxProj::Tcp(inner) => inner.poll_flush(cx),
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        match self.project() {
+            TxProj::Child(inner) => inner.poll_flush(cx),
+            TxProj::Tcp(inner) => inner.poll_flush(cx),
+        }
     }
-  }
 
-  fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-    match self.project() {
-      TxProj::Child(inner) => inner.poll_flush(cx),
-      TxProj::Tcp(inner) => inner.poll_flush(cx),
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        match self.project() {
+            TxProj::Child(inner) => inner.poll_flush(cx),
+            TxProj::Tcp(inner) => inner.poll_flush(cx),
+        }
     }
-  }
 }
 
 pub trait WrapTx {
-  fn wrap_tx(self) -> TxWrapper;
+    fn wrap_tx(self) -> TxWrapper;
 }
 
 impl WrapTx for ChildStdin {
-  fn wrap_tx(self) -> TxWrapper {
-    TxWrapper::Child(self)
-  }
+    fn wrap_tx(self) -> TxWrapper {
+        TxWrapper::Child(self)
+    }
 }
 
 impl WrapTx for WriteHalf<TcpStream> {
-  fn wrap_tx(self) -> TxWrapper {
-    TxWrapper::Tcp(self)
-  }
+    fn wrap_tx(self) -> TxWrapper {
+        TxWrapper::Tcp(self)
+    }
 }

--- a/src/bridge/tx_wrapper.rs
+++ b/src/bridge/tx_wrapper.rs
@@ -1,0 +1,58 @@
+use pin_project::pin_project;
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::{
+  io::{AsyncWrite, WriteHalf},
+  net::TcpStream,
+  process::ChildStdin,
+};
+
+#[pin_project(project = TxProj)]
+pub enum TxWrapper {
+  Child(#[pin] ChildStdin),
+  Tcp(#[pin] WriteHalf<TcpStream>),
+}
+
+impl AsyncWrite for TxWrapper {
+  fn poll_write(
+    self: Pin<&mut Self>,
+    cx: &mut Context<'_>,
+    buf: &[u8],
+  ) -> Poll<Result<usize, io::Error>> {
+    match self.project() {
+      TxProj::Child(inner) => inner.poll_write(cx, buf),
+      TxProj::Tcp(inner) => inner.poll_write(cx, buf),
+    }
+  }
+
+  fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+    match self.project() {
+      TxProj::Child(inner) => inner.poll_flush(cx),
+      TxProj::Tcp(inner) => inner.poll_flush(cx),
+    }
+  }
+
+  fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+    match self.project() {
+      TxProj::Child(inner) => inner.poll_flush(cx),
+      TxProj::Tcp(inner) => inner.poll_flush(cx),
+    }
+  }
+}
+
+pub trait WrapTx {
+  fn wrap_tx(self) -> TxWrapper;
+}
+
+impl WrapTx for ChildStdin {
+  fn wrap_tx(self) -> TxWrapper {
+    TxWrapper::Child(self)
+  }
+}
+
+impl WrapTx for WriteHalf<TcpStream> {
+  fn wrap_tx(self) -> TxWrapper {
+    TxWrapper::Tcp(self)
+  }
+}

--- a/src/bridge/tx_wrapper.rs
+++ b/src/bridge/tx_wrapper.rs
@@ -14,7 +14,7 @@ pub enum TxWrapper {
     Tcp(#[pin] WriteHalf<TcpStream>),
 }
 
-impl AsyncWrite for TxWrapper {
+impl futures::io::AsyncWrite for TxWrapper {
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -33,10 +33,10 @@ impl AsyncWrite for TxWrapper {
         }
     }
 
-    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         match self.project() {
-            TxProj::Child(inner) => inner.poll_flush(cx),
-            TxProj::Tcp(inner) => inner.poll_flush(cx),
+            TxProj::Child(inner) => inner.poll_shutdown(cx),
+            TxProj::Tcp(inner) => inner.poll_shutdown(cx),
         }
     }
 }

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -5,9 +5,8 @@ use log::error;
 
 use nvim_rs::compat::tokio::Compat;
 use nvim_rs::Neovim;
-use tokio::process::ChildStdin;
-use tokio::net::TcpStream;
-use tokio::io::WriteHalf;
+
+use crate::bridge::TxWrapper;
 
 #[cfg(windows)]
 use crate::windows_utils::{
@@ -45,7 +44,7 @@ pub enum UiCommand {
 }
 
 impl UiCommand {
-    pub async fn execute(self, nvim: &Neovim<Compat<WriteHalf<TcpStream>>>) {
+    pub async fn execute(self, nvim: &Neovim<Compat<TxWrapper>>) {
         match self {
             UiCommand::Resize { width, height } => nvim
                 .ui_try_resize(width.max(10) as i64, height.max(3) as i64)

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -6,6 +6,8 @@ use log::error;
 use nvim_rs::compat::tokio::Compat;
 use nvim_rs::Neovim;
 use tokio::process::ChildStdin;
+use tokio::net::TcpStream;
+use tokio::io::WriteHalf;
 
 #[cfg(windows)]
 use crate::windows_utils::{
@@ -43,7 +45,7 @@ pub enum UiCommand {
 }
 
 impl UiCommand {
-    pub async fn execute(self, nvim: &Neovim<Compat<ChildStdin>>) {
+    pub async fn execute(self, nvim: &Neovim<Compat<WriteHalf<TcpStream>>>) {
         match self {
             UiCommand::Resize { width, height } => nvim
                 .ui_try_resize(width.max(10) as i64, height.max(3) as i64)

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -3,7 +3,6 @@ use log::trace;
 #[cfg(windows)]
 use log::error;
 
-use nvim_rs::compat::tokio::Compat;
 use nvim_rs::Neovim;
 
 use crate::bridge::TxWrapper;
@@ -44,7 +43,7 @@ pub enum UiCommand {
 }
 
 impl UiCommand {
-    pub async fn execute(self, nvim: &Neovim<Compat<TxWrapper>>) {
+    pub async fn execute(self, nvim: &Neovim<TxWrapper>) {
         match self {
             UiCommand::Resize { width, height } => nvim
                 .ui_try_resize(width.max(10) as i64, height.max(3) as i64)

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -12,8 +12,8 @@ use nvim_rs::Neovim;
 use parking_lot::RwLock;
 pub use rmpv::Value;
 
-use crate::error_handling::ResultPanicExplanation;
 use crate::bridge::TxWrapper;
+use crate::error_handling::ResultPanicExplanation;
 
 lazy_static! {
     pub static ref SETTINGS: Settings = Settings::new();
@@ -51,6 +51,7 @@ impl Settings {
                     false
                 } else {
                     !(arg.starts_with("--geometry=")
+                        || arg.starts_with("--remote-tcp=")
                         || arg == "--version"
                         || arg == "-v"
                         || arg == "--help"
@@ -188,7 +189,7 @@ mod tests {
     use tokio;
 
     use super::*;
-    use crate::bridge::{create_nvim_command, create};
+    use crate::bridge::{create, create_nvim_command};
 
     #[derive(Clone)]
     pub struct NeovimHandler();

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -7,7 +7,6 @@ use flexi_logger::{Cleanup, Criterion, Duplicate, Logger, Naming};
 mod from_value;
 pub use from_value::FromValue;
 use log::warn;
-use nvim_rs::compat::tokio::Compat;
 use nvim_rs::Neovim;
 use parking_lot::RwLock;
 pub use rmpv::Value;
@@ -130,7 +129,7 @@ impl Settings {
         (*value).clone()
     }
 
-    pub async fn read_initial_values(&self, nvim: &Neovim<Compat<TxWrapper>>) {
+    pub async fn read_initial_values(&self, nvim: &Neovim<TxWrapper>) {
         let keys: Vec<String> = self.listeners.read().keys().cloned().collect();
 
         for name in keys {
@@ -148,7 +147,7 @@ impl Settings {
         }
     }
 
-    pub async fn setup_changed_listeners(&self, nvim: &Neovim<Compat<TxWrapper>>) {
+    pub async fn setup_changed_listeners(&self, nvim: &Neovim<TxWrapper>) {
         let keys: Vec<String> = self.listeners.read().keys().cloned().collect();
 
         for name in keys {
@@ -185,7 +184,7 @@ impl Settings {
 #[cfg(test)]
 mod tests {
     use async_trait::async_trait;
-    use nvim_rs::{compat::tokio::Compat, Handler, Neovim};
+    use nvim_rs::{Handler, Neovim};
     use tokio;
 
     use super::*;
@@ -196,13 +195,13 @@ mod tests {
 
     #[async_trait]
     impl Handler for NeovimHandler {
-        type Writer = Compat<TxWrapper>;
+        type Writer = TxWrapper;
 
         async fn handle_notify(
             &self,
             _event_name: String,
             _arguments: Vec<Value>,
-            _neovim: Neovim<Compat<TxWrapper>>,
+            _neovim: Neovim<TxWrapper>,
         ) {
         }
     }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -12,6 +12,8 @@ use nvim_rs::Neovim;
 use parking_lot::RwLock;
 pub use rmpv::Value;
 use tokio::process::ChildStdin;
+use tokio::net::TcpStream;
+use tokio::io::WriteHalf;
 
 use crate::error_handling::ResultPanicExplanation;
 
@@ -129,7 +131,7 @@ impl Settings {
         (*value).clone()
     }
 
-    pub async fn read_initial_values(&self, nvim: &Neovim<Compat<ChildStdin>>) {
+    pub async fn read_initial_values(&self, nvim: &Neovim<Compat<WriteHalf<TcpStream>>>) {
         let keys: Vec<String> = self.listeners.read().keys().cloned().collect();
 
         for name in keys {
@@ -147,7 +149,7 @@ impl Settings {
         }
     }
 
-    pub async fn setup_changed_listeners(&self, nvim: &Neovim<Compat<ChildStdin>>) {
+    pub async fn setup_changed_listeners(&self, nvim: &Neovim<Compat<WriteHalf<TcpStream>>>) {
         let keys: Vec<String> = self.listeners.read().keys().cloned().collect();
 
         for name in keys {
@@ -196,13 +198,13 @@ mod tests {
 
     #[async_trait]
     impl Handler for NeovimHandler {
-        type Writer = Compat<ChildStdin>;
+        type Writer = Compat<WriteHalf<TcpStream>>;
 
         async fn handle_notify(
             &self,
             _event_name: String,
             _arguments: Vec<Value>,
-            _neovim: Neovim<Compat<ChildStdin>>,
+            _neovim: Neovim<Compat<WriteHalf<TcpStream>>>,
         ) {
         }
     }


### PR DESCRIPTION
Allows the user to connect to a remote instance of Neovim over TCP using the `--remote-tcp` flag.

Because rust does not have full support for polymorphism, I created the enum type `TxWrapper` to allow either `ChildStdin` or `WriteHalf<TcpStream>` to be used for the connection stream, while avoiding a complicated mess of type parameters. To do this I had to turn some of our implicit dependencies (ie. dependencies of dependencies) into explicit dependencies, but there are no new dependencies. I also adapted some of the functions from `nvim_rs::create::tokio` to work with this new general type.

I have also tried to make it clear in the readme that, without SSH port forwarding or similar, TCP sockets are not secure.

I think that this fixes #50 