### PR TITLE
Fix warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,10 @@ jobs:
       run: |
         cargo fmt --all -- --check
 
+    - name: Lint with Clippy
+      run: |
+        cargo clippy --all -- -D warnings
+
     - name: Install Neovim
       run: |
         choco install -y neovim
@@ -48,6 +52,11 @@ jobs:
       run: |
         rustup component add rustfmt --toolchain stable-x86_64-apple-darwin
         cargo fmt --all -- --check
+
+    - name: Lint with Clippy
+      run: |
+        rustup component add clippy --toolchain stable-x86_64-apple-darwin
+        cargo clippy --all -- -D warnings
 
     - name: Uninstall Conflicting LLVM
       run: |
@@ -110,6 +119,10 @@ jobs:
     - name: Check formatting
       run: |
         cargo fmt --all -- --check
+
+    - name: Lint with Clippy
+      run: |
+        cargo clippy --all -- -D warnings
 
     - name: Install Neovim
       run: |

--- a/neovide-derive/src/lib.rs
+++ b/neovide-derive/src/lib.rs
@@ -7,12 +7,12 @@ pub fn setting_group(item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as DeriveInput);
     let prefix = setting_prefix(input.attrs.as_ref())
         .map(|p| format!("{}_", p))
-        .unwrap_or("".to_string());
+        .unwrap_or_else(|| "".to_string());
     stream(input, prefix)
 }
 
 fn stream(input: DeriveInput, prefix: String) -> TokenStream {
-    const ERR_MSG: &'static str = "Derive macro expects a struct";
+    const ERR_MSG: &str = "Derive macro expects a struct";
     match input.data {
         Data::Struct(ref data) => struct_stream(input.ident, prefix, data),
         Data::Enum(data) => Error::new_spanned(data.enum_token, ERR_MSG)

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -20,8 +20,8 @@ const DEFAULT_CELL_PERCENTAGE: f32 = 1.0 / 8.0;
 
 const STANDARD_CORNERS: &[(f32, f32); 4] = &[(-0.5, -0.5), (0.5, -0.5), (0.5, 0.5), (-0.5, 0.5)];
 
-#[setting_prefix = "cursor"]
 #[derive(Clone, SettingGroup)]
+#[setting_prefix = "cursor"]
 pub struct CursorSettings {
     antialiasing: bool,
     animation_length: f32,

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -19,8 +19,8 @@ use crate::editor::{Colors, DrawCommand, Style, WindowDrawCommand};
 use crate::settings::*;
 use cursor_renderer::CursorRenderer;
 
-#[setting_prefix = "window"]
 #[derive(Clone, SettingGroup)]
+#[setting_prefix = "window"]
 pub struct RendererSettings {
     position_animation_length: f32,
     scroll_animation_length: f32,

--- a/src/window/keyboard/settings.rs
+++ b/src/window/keyboard/settings.rs
@@ -1,8 +1,8 @@
 use super::KeyboardLayout;
 use crate::settings::FromValue;
 
-#[setting_prefix = "keyboard"]
 #[derive(Clone, SettingGroup)]
+#[setting_prefix = "keyboard"]
 pub struct KeyboardSettings {
     pub layout: KeyboardLayout,
 }

--- a/src/window/sdl2/mod.rs
+++ b/src/window/sdl2/mod.rs
@@ -47,7 +47,6 @@ pub struct Sdl2WindowWrapper {
     grid_id_under_mouse: u64,
     title: String,
     previous_size: LogicalSize,
-    transparency: f32,
     fullscreen: bool,
     cached_size: (u32, u32),
     cached_position: (i32, i32),
@@ -115,7 +114,6 @@ impl Sdl2WindowWrapper {
         if let Ok(opacity) = self.window.opacity() {
             if (opacity - transparency).abs() > std::f32::EPSILON {
                 self.window.set_opacity(transparency).ok();
-                self.transparency = transparency;
             }
         }
 
@@ -477,7 +475,6 @@ pub fn start_loop(
         grid_id_under_mouse: 0,
         title: String::from("Neovide"),
         previous_size: logical_size,
-        transparency: 1.0,
         fullscreen: false,
         cached_size: (0, 0),
         cached_position: (0, 0),


### PR DESCRIPTION
Fix some small problems that appeared as warnings in the `cargo build` output, and were causing the pre-commit git hook (which I had disabled locally) to fail. These were mostly just unused code and improper attribute order.

Of note is `Sdl2WindowWrapper.transparency`, which was set whenever `WindowSettings.transparency` is out of sync with the window's actual opacity, but was never read from so I removed it.