### PR TITLE
Remove RAlt as a modifier in non-iso layouts.

### DIFF
--- a/src/window/sdl2/layouts/mod.rs
+++ b/src/window/sdl2/layouts/mod.rs
@@ -7,11 +7,10 @@ pub use qwerty::handle_qwerty_layout;
 
 impl From<Mod> for Modifiers {
     fn from(mods: Mod) -> Modifiers {
-        let iso_layout = SETTINGS.get::<WindowSettings>().iso_layout;
         Modifiers {
             shift: mods.contains(Mod::LSHIFTMOD) || mods.contains(Mod::RSHIFTMOD),
             control: mods.contains(Mod::LCTRLMOD) || mods.contains(Mod::RCTRLMOD),
-            meta: mods.contains(Mod::LALTMOD) || (!iso_layout && mods.contains(Mod::RALTMOD)),
+            meta: mods.contains(Mod::LALTMOD),
             logo: mods.contains(Mod::LGUIMOD) || mods.contains(Mod::RGUIMOD),
         }
     }


### PR DESCRIPTION
In ABNT2 brazilian portuguese keyboard layout RAlt (or AltGr in ABNT2)
does not work the same as LAlt and should not be used as a modifier in
Neovim. It is used to enable typing special characters in combination
with Shift, such as ?`´~^ºª etc, either as the only way for typing them
or as a faster way combining with other keys.
Using Neovim in xterm, kitty, gnome-terminal etc has the expected
behavior, as using in other places in the system as well (e.g. browsers)