### PR TITLE
Version and help without opening the program

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -104,11 +104,13 @@ fn main() {
     if std::env::args().any(|arg| arg == "--version" || arg == "-v") {
         attach_parent_console();
         println!("Neovide version: {}", env!("CARGO_PKG_VERSION"));
+        return;
     }
 
     if std::env::args().any(|arg| arg == "--help" || arg == "-h") {
         attach_parent_console();
         println!("Neovide: {}", env!("CARGO_PKG_DESCRIPTION"));
+        return;
     }
 
     if let Err(err) = window_geometry() {


### PR DESCRIPTION
Now we can see the version and use the help command without opening the neovide GUI. 
If i need to confirm my neovide version it will open the neovide and i dont want it. I just want to see the version.