### PR TITLE
Update Cargo Resolver Version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["keith <keith@the-simmons.net>"]
 edition = "2018"
 build = "build.rs"
 description = "A simple GUI for Neovim."
+resolver = "2"
 
 [workspace]
 members = [


### PR DESCRIPTION
Update cargo resolver to version 2 to avoid unwanted feature activation.

The package sdl2-sys has features bundled and static-link for target
linux activated, since the cargo resolver version 1 aggregates all
possible features. The newer version avoids this behaviour.

See also:
https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2