### PR TITLE
Initial Implementation for #622

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,6 +1516,8 @@ dependencies = [
  "regex",
  "rmpv",
  "rust-embed",
+ "serde",
+ "serde_json",
  "skia-safe",
  "swash",
  "tokio",
@@ -2196,6 +2198,20 @@ name = "serde"
 version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+dependencies = [
+ "proc-macro2 1.0.26",
+ "quote 1.0.9",
+ "syn 1.0.72",
+]
 
 [[package]]
 name = "serde_json"
@@ -2868,6 +2884,7 @@ dependencies = [
  "parking_lot 0.11.1",
  "percent-encoding",
  "raw-window-handle",
+ "serde",
  "smithay-client-toolkit",
  "wayland-client",
  "winapi 0.3.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ default = []
 embed-fonts = []
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 neovide-derive = { path = "neovide-derive" }
 euclid = "0.20.7"
 lru = "0.4.3"
@@ -37,7 +39,7 @@ dirs = "2"
 rand = "0.7"
 pin-project = "0.4.27"
 futures = "0.3.12"
-glutin = "0.26"
+glutin = {version = "0.26", features = ["serde"]}
 gl = "0.14.0"
 regex = "1.5.4"
 swash = "0.1.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,7 @@ fn main() {
         return;
     }
 
-    if let Err(err) = window_geometry() {
+    if let Err(err) = window_geometry(Err("do not load saved window settings yet".into())) {
         eprintln!("{}", err);
         return;
     }

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -9,6 +9,7 @@ pub struct WindowSettings {
     pub transparency: f32,
     pub fullscreen: bool,
     pub iso_layout: bool,
+    pub remember_dimension: bool,
 }
 
 impl Default for WindowSettings {
@@ -21,6 +22,7 @@ impl Default for WindowSettings {
             no_idle: SETTINGS
                 .neovim_arguments
                 .contains(&String::from("--noIdle")),
+            remember_dimension: false,
         }
     }
 }

--- a/src/window/window_wrapper/mod.rs
+++ b/src/window/window_wrapper/mod.rs
@@ -3,6 +3,7 @@ mod layouts;
 mod renderer;
 
 use super::{handle_new_grid_size, keyboard::neovim_keybinding_string, settings::WindowSettings};
+use crate::settings::maybe_save_window_size;
 use crate::{
     bridge::UiCommand, editor::WindowCommand, error_handling::ResultPanicExplanation,
     redraw_scheduler::REDRAW_SCHEDULER, renderer::Renderer, settings::SETTINGS,
@@ -461,6 +462,7 @@ pub fn start_loop(
 
     event_loop.run(move |e, _window_target, control_flow| {
         if !running.load(Ordering::Relaxed) {
+            maybe_save_window_size(window_wrapper.previous_size, &window_wrapper.renderer);
             std::process::exit(0);
         }
 


### PR DESCRIPTION
Hey there!

So I tried to call neovim to get the standard path as suggested by Pangoraw in #622 , but because of the way this code is structured, it causes the following problem:
1. We would need to extract a neovim handle from "start_bridge" and pass it on to "create_window", since both functions call "window_geometry_or_default". That is sort of ugly.
2. If we instead just make the call to neovim just inside "start_bridge" and writing to the SETTINGS global variable, "start_bridge" would need to be synchronized with "create_window". But that's not good as we don't want to block.

So, I just hardcoded the respective paths for unix and windows. If neovim does decide to change what `:call stdpath("data")` evaluates to, we can just change it with a simple commit.

I used serde as @Kethku suggested, but as of now the code assumes the neovide-settings.txt file only contains the last window size, rather than being some sort of general json structure. I think once that is done, we can just read the settings file in main, and pass the json object on to "start_bridge" and "create_window"?(Since right now I reread the file in each of those functions) 

(All changes in the 2 renderer files was because of rustfmt.)
(Also, as an aside, is there a way for me to temporarily turn off CI when making commits? I would like to make a bunch of smaller commits as I work, and then squash when I finally finish.)