### PR TITLE
Use interactive path for neovim resolution

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -34,7 +34,11 @@ fn set_windows_creation_flags(cmd: &mut Command) {
 fn platform_build_nvim_cmd(bin: &str) -> Option<Command> {
     if env::args().any(|arg| arg == "--wsl") {
         let mut cmd = Command::new("wsl");
-        cmd.arg(bin);
+        cmd.args(&[
+            bin.trim(),
+            "-c",
+            "let \\$PATH=system(\"bash -ic 'echo \\$PATH' 2>/dev/null\")",
+        ]);
         Some(cmd)
     } else if Path::new(&bin).exists() {
         Some(Command::new(bin))
@@ -69,7 +73,11 @@ fn build_nvim_cmd() -> Command {
             if output.status.success() {
                 let path = String::from_utf8(output.stdout).unwrap();
                 let mut cmd = Command::new("wsl");
-                cmd.arg(path.trim());
+                cmd.args(&[
+                    path.trim(),
+                    "-c",
+                    "let \\$PATH=system(\"bash -ic 'echo \\$PATH' 2>/dev/null\")",
+                ]);
                 return cmd;
             } else {
                 error!("nvim not found in WSL path");

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -63,8 +63,7 @@ fn build_nvim_cmd() -> Command {
     #[cfg(windows)]
     if env::args().any(|arg| arg == "--wsl") {
         if let Ok(output) = std::process::Command::new("wsl")
-            .arg("which")
-            .arg("nvim")
+            .args(&["bash", "-ic", "which nvim"])
             .output()
         {
             if output.status.success() {


### PR DESCRIPTION
This PR does two things:
1) It uses `bash -ic` to call `which` in WSL, which allows .bashrc env to be taken into account (resolves #647)
2) It adds a startup command to neovim to get the interactive PATH and set it, so that other things don't break (e.g. LSP which depends on the server being in the PATH)