### PR TITLE
Implement CLI parsing with clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,6 +1495,7 @@ version = "0.7.0"
 dependencies = [
  "async-trait",
  "cfg-if 0.1.10",
+ "clap",
  "crossfire",
  "derive-new",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ glutin = "0.26"
 gl = "0.14.0"
 regex = "1.5.4"
 swash = "0.1.2"
+clap="2.33.3"
 
 [dev-dependencies]
 mockall = "0.7.0"

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -119,7 +119,8 @@ pub fn create_nvim_command() -> Command {
     let mut cmd = build_nvim_cmd();
 
     cmd.arg("--embed")
-        .args(SETTINGS.get::<CmdLineSettings>().neovim_args.iter());
+        .args(SETTINGS.get::<CmdLineSettings>().neovim_args.iter())
+        .args(SETTINGS.get::<CmdLineSettings>().files_to_open.iter());
 
     info!("Starting neovim with: {:?}", cmd);
 

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -119,7 +119,9 @@ pub fn create_nvim_command() -> Command {
     let mut cmd = build_nvim_cmd();
 
     cmd.arg("--embed")
-        .args(SETTINGS.get::<CmdLineSettings>().neovim_args.iter().skip(1));
+        .args(SETTINGS.get::<CmdLineSettings>().neovim_args.iter());
+
+    info!("Starting neovim with: {:?}", cmd);
 
     #[cfg(not(debug_assertions))]
     cmd.stderr(Stdio::piped());

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -17,9 +17,9 @@ use rmpv::Value;
 use tokio::process::Command;
 use tokio::runtime::Runtime;
 
-use crate::error_handling::ResultPanicExplanation;
 use crate::settings::*;
 use crate::window::window_geometry_or_default;
+use crate::{cmd_line::CmdLineSettings, error_handling::ResultPanicExplanation};
 pub use events::*;
 use handler::NeovimHandler;
 use regex::Regex;
@@ -119,7 +119,7 @@ pub fn create_nvim_command() -> Command {
     let mut cmd = build_nvim_cmd();
 
     cmd.arg("--embed")
-        .args(SETTINGS.neovim_arguments.iter().skip(1));
+        .args(SETTINGS.get::<CmdLineSettings>().neovim_args.iter().skip(1));
 
     #[cfg(not(debug_assertions))]
     cmd.stderr(Stdio::piped());

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -33,7 +33,7 @@ fn set_windows_creation_flags(cmd: &mut Command) {
 
 #[cfg(windows)]
 fn platform_build_nvim_cmd(bin: &str) -> Option<Command> {
-    if env::args().any(|arg| arg == "--wsl") {
+    if SETTINGS.get::<CmdLineSettings>().wsl {
         let mut cmd = Command::new("wsl");
         cmd.arg(bin);
         Some(cmd)
@@ -62,7 +62,7 @@ fn build_nvim_cmd() -> Command {
         }
     }
     #[cfg(windows)]
-    if env::args().any(|arg| arg == "--wsl") {
+    if SETTINGS.get::<CmdLineSettings>().wsl {
         if let Ok(output) = std::process::Command::new("wsl")
             .arg("which")
             .arg("nvim")
@@ -142,11 +142,8 @@ enum ConnectionMode {
 }
 
 fn connection_mode() -> ConnectionMode {
-    let tcp_prefix = "--remote-tcp=";
-
-    if let Some(arg) = std::env::args().find(|arg| arg.starts_with(tcp_prefix)) {
-        let input = &arg[tcp_prefix.len()..];
-        ConnectionMode::RemoteTcp(input.to_owned())
+    if let Some(arg) = SETTINGS.get::<CmdLineSettings>().remote_tcp {
+        ConnectionMode::RemoteTcp(arg)
     } else {
         ConnectionMode::Child
     }
@@ -274,7 +271,8 @@ async fn start_neovim_runtime(
 
     let mut options = UiAttachOptions::new();
     options.set_linegrid_external(true);
-    if env::args().any(|arg| arg == "--multiGrid") || env::var("NeovideMultiGrid").is_ok() {
+
+    if SETTINGS.get::<CmdLineSettings>().multi_grid || env::var("NeovideMultiGrid").is_ok() {
         options.set_multigrid_external(true);
     }
     options.set_rgb(true);

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -4,7 +4,6 @@ mod handler;
 mod tx_wrapper;
 mod ui_commands;
 
-use std::env;
 use std::path::Path;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -54,7 +53,7 @@ fn platform_build_nvim_cmd(bin: &str) -> Option<Command> {
 }
 
 fn build_nvim_cmd() -> Command {
-    if let Ok(path) = env::var("NEOVIM_BIN") {
+    if let Some(path) = SETTINGS.get::<CmdLineSettings>().neovim_bin {
         if let Some(cmd) = platform_build_nvim_cmd(&path) {
             return cmd;
         } else {
@@ -272,7 +271,7 @@ async fn start_neovim_runtime(
     let mut options = UiAttachOptions::new();
     options.set_linegrid_external(true);
 
-    if SETTINGS.get::<CmdLineSettings>().multi_grid || env::var("NeovideMultiGrid").is_ok() {
+    if SETTINGS.get::<CmdLineSettings>().multi_grid {
         options.set_multigrid_external(true);
     }
     options.set_rgb(true);

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -2,11 +2,12 @@ use crate::settings::*;
 
 use clap::{App, Arg};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct CmdLineSettings {
     pub verbosity: u64,
     pub log_to_file: bool,
     pub neovim_args: Vec<String>,
+    pub neovim_bin: Option<String>,
     pub files_to_open: Vec<String>,
 
     pub disowned: bool,
@@ -20,6 +21,7 @@ pub struct CmdLineSettings {
 impl Default for CmdLineSettings {
     fn default() -> Self {
         Self {
+            neovim_bin: None,
             verbosity: 0,
             log_to_file: false,
             neovim_args: vec![],
@@ -96,7 +98,14 @@ pub fn handle_command_line_arguments() {
 
     let matches = clapp.get_matches();
 
+    /*
+     * Integrate Environment Variables as Defaults to the command-line ones.
+     *
+     * NEOVIM_BIN
+     * NeovideMultiGrid || --multiGrid
+     */
     SETTINGS.set::<CmdLineSettings>(&CmdLineSettings {
+        neovim_bin: std::env::var("NEOVIM_BIN").ok(),
         neovim_args: matches
             .values_of("neovim_args")
             .map(|opt| opt.map(|v| v.to_owned()).collect())
@@ -108,7 +117,7 @@ pub fn handle_command_line_arguments() {
             .map(|opt| opt.map(|v| v.to_owned()).collect())
             .unwrap_or_default(),
         maximized: matches.is_present("maximized"),
-        multi_grid: matches.is_present("multi_grid"),
+        multi_grid: std::env::var("NeovideMultiGrid").is_ok() || matches.is_present("multi_grid"),
         remote_tcp: matches.value_of("remote_tcp").map(|i| i.to_owned()),
         disowned: matches.is_present("disowned"),
         wsl: matches.is_present("wsl"),

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -1,5 +1,7 @@
 use crate::settings::*;
 
+use clap::{App, Arg};
+
 #[derive(Clone)]
 pub struct CmdLineSettings {
     pub verbosity: u64,
@@ -33,22 +35,65 @@ impl Default for CmdLineSettings {
 }
 
 pub fn handle_command_line_arguments() {
-    let clapp = clap_app!(neovide =>
-    (author: crate_authors!())
-    (version: crate_version!())
-    (about: crate_description!())
-    (@arg verbosity: -v ... "Set the level of output information")
-    (@arg log_to_file: --log "Log to a file")
-    (@arg disowned: --disowned "Disown the process. (only on macos)")
-    (@arg maximized: --maximized "Maximize the window.")
-    (@arg multi_grid: --multi-grid "Enable Multigrid")
-    (@arg wsl: --wsl "Run in WSL")
-    (@arg remote_tcp: --remote-tcp +takes_value "Connect to Remote TCP")
-    (@arg geometry: --geometry +takes_value "Specify the Geometry of the window")
+    let clapp = App::new("Neovide")
+        .version(crate_version!())
+        .author(crate_authors!())
+        .about(crate_description!())
+        .arg(
+            Arg::with_name("verbosity")
+                .short("v")
+                .multiple(true)
+                .help("Set the level of verbosity"),
+        )
+        .arg(
+            Arg::with_name("log_to_file")
+                .long("log")
+                .help("Log to a file"),
+        )
+        .arg(
+            Arg::with_name("disowned")
+                .long("disowned")
+                .help("Disown the process. (only on macos)"),
+        )
+        .arg(
+            Arg::with_name("maximized")
+                .long("maximized")
+                .help("Maximize the window"),
+        )
+        .arg(
+            Arg::with_name("multi_grid")
+                //.long("multi-grid") TODO: multiGrid is the current way to call this, but I
+                //personally would prefer sticking to a unix-y way of naming things...
+                .long("multiGrid")
+                .help("Enable Multigrid"),
+        )
+        .arg(Arg::with_name("wsl").long("wsl").help("Run in WSL"))
+        .arg(
+            Arg::with_name("remote_tcp")
+                .long("remote-tcp")
+                .takes_value(true)
+                .help("Connect to Remote TCP"),
+        )
+        .arg(
+            Arg::with_name("geometry")
+                .long("geometry")
+                .takes_value(true)
+                .help("Specify the Geometry of the window"),
+        )
+        .arg(
+            Arg::with_name("files")
+                .multiple(true)
+                .takes_value(true)
+                .help("Specify the Geometry of the window"),
+        )
+        .arg(
+            Arg::with_name("neovim_args")
+                .multiple(true)
+                .takes_value(true)
+                .last(true)
+                .help("Specify Arguments to pass down to neovim"),
+        );
 
-    (@arg files: +takes_value +multiple "Open Files")
-    (@arg neovim_args: +takes_value +multiple +last "Args to pass to Neovim")
-                        );
     let matches = clapp.get_matches();
 
     SETTINGS.set::<CmdLineSettings>(&CmdLineSettings {

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -5,6 +5,7 @@ pub struct CmdLineSettings {
     pub verbosity: u64,
     pub log_to_file: bool,
     pub neovim_args: Vec<String>,
+    pub files_to_open: Vec<String>,
 }
 
 impl Default for CmdLineSettings {
@@ -13,6 +14,7 @@ impl Default for CmdLineSettings {
             verbosity: 0,
             log_to_file: false,
             neovim_args: vec![],
+            files_to_open: vec![],
         }
     }
 }
@@ -24,6 +26,7 @@ pub fn handle_command_line_arguments() {
     (about: crate_description!())
     (@arg verbosity: -v ... "Set the level of output information")
     (@arg log_to_file: --log "Log to a file")
+    (@arg files: +takes_value +multiple "Open Files")
     (@arg neovim_args: +takes_value +multiple +last "Args to pass to Neovim")
                         );
     let matches = clapp.get_matches();
@@ -35,5 +38,9 @@ pub fn handle_command_line_arguments() {
             .unwrap_or_default(),
         verbosity: matches.occurrences_of("verbosity"),
         log_to_file: matches.is_present("log_to_file"),
+        files_to_open: matches
+            .values_of("files")
+            .map(|opt| opt.map(|v| v.to_owned()).collect())
+            .unwrap_or_default(),
     });
 }

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -6,6 +6,13 @@ pub struct CmdLineSettings {
     pub log_to_file: bool,
     pub neovim_args: Vec<String>,
     pub files_to_open: Vec<String>,
+
+    pub disowned: bool,
+    pub geometry: Option<String>,
+    pub wsl: bool,
+    pub remote_tcp: Option<String>,
+    pub multi_grid: bool,
+    pub maximized: bool,
 }
 
 impl Default for CmdLineSettings {
@@ -15,6 +22,12 @@ impl Default for CmdLineSettings {
             log_to_file: false,
             neovim_args: vec![],
             files_to_open: vec![],
+            disowned: false,
+            geometry: None,
+            wsl: false,
+            remote_tcp: None,
+            multi_grid: false,
+            maximized: false,
         }
     }
 }
@@ -26,6 +39,13 @@ pub fn handle_command_line_arguments() {
     (about: crate_description!())
     (@arg verbosity: -v ... "Set the level of output information")
     (@arg log_to_file: --log "Log to a file")
+    (@arg disowned: --disowned "Disown the process. (only on macos)")
+    (@arg maximized: --maximized "Maximize the window.")
+    (@arg multi_grid: --multigrid "Enable Multigrid")
+    (@arg wsl: --wsl "Run in WSL")
+    (@arg remote_tcp: --remote +takes_value "Connect to Remote TCP")
+    (@arg geometry: --geometry +takes_value "Specify the Geometry of the window")
+
     (@arg files: +takes_value +multiple "Open Files")
     (@arg neovim_args: +takes_value +multiple +last "Args to pass to Neovim")
                         );
@@ -42,5 +62,11 @@ pub fn handle_command_line_arguments() {
             .values_of("files")
             .map(|opt| opt.map(|v| v.to_owned()).collect())
             .unwrap_or_default(),
+        maximized: matches.is_present("maximized"),
+        multi_grid: matches.is_present("multi_grid"),
+        remote_tcp: matches.value_of("remote_tcp").map(|i| i.to_owned()),
+        disowned: matches.is_present("disowned"),
+        wsl: matches.is_present("wsl"),
+        geometry: matches.value_of("geometry").map(|i| i.to_owned()),
     });
 }

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -117,7 +117,9 @@ pub fn handle_command_line_arguments() {
             .map(|opt| opt.map(|v| v.to_owned()).collect())
             .unwrap_or_default(),
         maximized: matches.is_present("maximized"),
-        multi_grid: std::env::var("NeovideMultiGrid").is_ok() || matches.is_present("multi_grid"),
+        multi_grid: std::env::var("NEOVIDE_MULTIGRID").is_ok()
+            || std::env::var("NeovideMultiGrid").is_ok()
+            || matches.is_present("multi_grid"),
         remote_tcp: matches.value_of("remote_tcp").map(|i| i.to_owned()),
         disowned: matches.is_present("disowned"),
         wsl: matches.is_present("wsl"),

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -1,0 +1,41 @@
+use crate::settings::*;
+
+#[derive(Clone)]
+pub struct CmdLineSettings {
+    pub verbosity: u64,
+    pub log_to_file: bool,
+    pub neovim_args: Vec<String>,
+}
+
+impl Default for CmdLineSettings {
+    fn default() -> Self {
+        Self {
+            verbosity: 0,
+            log_to_file: false,
+            neovim_args: vec![],
+        }
+    }
+}
+
+pub fn handle_command_line_arguments() {
+    let clapp = clap_app!(neovide =>
+    (author: crate_authors!())
+    (version: crate_version!())
+    (about: crate_description!())
+    (@arg verbosity: -v ... "Set the level of output information")
+    (@arg log_to_file: --log "Log to a file")
+    (@arg neovim_args: +takes_value +multiple +last "Args to pass to Neovim")
+                        );
+    let matches = clapp.get_matches();
+
+    println!("Occ: {}", matches.occurrences_of("verbosity"));
+
+    SETTINGS.set::<CmdLineSettings>(&CmdLineSettings {
+        neovim_args: matches
+            .values_of("neovim_args")
+            .map(|opt| opt.map(|v| v.to_owned()).collect())
+            .unwrap_or_default(),
+        verbosity: matches.occurrences_of("verbosity"),
+        log_to_file: matches.is_present("log_to_file"),
+    });
+}

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -28,8 +28,6 @@ pub fn handle_command_line_arguments() {
                         );
     let matches = clapp.get_matches();
 
-    println!("Occ: {}", matches.occurrences_of("verbosity"));
-
     SETTINGS.set::<CmdLineSettings>(&CmdLineSettings {
         neovim_args: matches
             .values_of("neovim_args")

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -41,9 +41,9 @@ pub fn handle_command_line_arguments() {
     (@arg log_to_file: --log "Log to a file")
     (@arg disowned: --disowned "Disown the process. (only on macos)")
     (@arg maximized: --maximized "Maximize the window.")
-    (@arg multi_grid: --multigrid "Enable Multigrid")
+    (@arg multi_grid: --multi-grid "Enable Multigrid")
     (@arg wsl: --wsl "Run in WSL")
-    (@arg remote_tcp: --remote +takes_value "Connect to Remote TCP")
+    (@arg remote_tcp: --remote-tcp +takes_value "Connect to Remote TCP")
     (@arg geometry: --geometry +takes_value "Specify the Geometry of the window")
 
     (@arg files: +takes_value +multiple "Open Files")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,16 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+#[cfg(not(test))]
+use flexi_logger::{Cleanup, Criterion, Duplicate, Logger, Naming};
+
 #[macro_use]
 extern crate neovide_derive;
 
+#[macro_use]
+extern crate clap;
+
 mod bridge;
+mod cmd_line;
 mod editor;
 mod error_handling;
 mod redraw_scheduler;
@@ -24,10 +31,13 @@ use std::sync::{atomic::AtomicBool, mpsc::channel, Arc};
 use crossfire::mpsc::unbounded_future;
 
 use bridge::start_bridge;
+#[cfg(not(test))]
+use cmd_line::CmdLineSettings;
 use editor::start_editor;
 use renderer::{cursor_renderer::CursorSettings, RendererSettings};
+#[cfg(not(test))]
+use settings::SETTINGS;
 use window::{create_window, window_geometry, KeyboardSettings, WindowSettings};
-use windows_utils::attach_parent_console;
 
 pub const INITIAL_DIMENSIONS: (u64, u64) = (100, 50);
 
@@ -101,22 +111,15 @@ fn main() {
     //   Multiple other parts of the app "queue_next_frame" function to ensure animations continue
     //   properly or updates to the graphics are pushed to the screen.
 
-    if std::env::args().any(|arg| arg == "--version" || arg == "-v") {
-        attach_parent_console();
-        println!("Neovide version: {}", env!("CARGO_PKG_VERSION"));
-        return;
-    }
-
-    if std::env::args().any(|arg| arg == "--help" || arg == "-h") {
-        attach_parent_console();
-        println!("Neovide: {}", env!("CARGO_PKG_DESCRIPTION"));
-        return;
-    }
+    cmd_line::handle_command_line_arguments(); //Will exit if -h or -v
 
     if let Err(err) = window_geometry() {
         eprintln!("{}", err);
         return;
     }
+
+    #[cfg(not(test))]
+    init_logger();
 
     #[cfg(target_os = "macos")]
     {
@@ -184,4 +187,32 @@ fn main() {
         ui_command_sender,
         running,
     );
+}
+
+#[cfg(not(test))]
+pub fn init_logger() {
+    let verbosity = match SETTINGS.get::<CmdLineSettings>().verbosity {
+        0 => "warn",
+        1 => "info",
+        2 => "debug",
+        _ => "trace",
+    };
+    let log_to_file = SETTINGS.get::<CmdLineSettings>().log_to_file;
+
+    if log_to_file {
+        Logger::with_env_or_str("neovide")
+            .duplicate_to_stderr(Duplicate::Error)
+            .log_to_file()
+            .rotate(
+                Criterion::Size(10_000_000),
+                Naming::Timestamps,
+                Cleanup::KeepLogFiles(1),
+            )
+            .start()
+            .expect("Could not start logger");
+    } else {
+        Logger::with_env_or_str(format!("neovide = {}", verbosity))
+            .start()
+            .expect("Could not start logger");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,9 +123,10 @@ fn main() {
 
     #[cfg(target_os = "macos")]
     {
+        let disowned_arg = SETTINGS.get::<CmdLineSettings>().disowned;
         // incase of app bundle, we can just pass --disowned option straight away to bypass this check
         #[cfg(not(debug_assertions))]
-        if !std::env::args().any(|f| f == "--disowned") {
+        if !SETTINGS.get::<CmdLineSettings>().disowned {
             if let Ok(curr_exe) = std::env::current_exe() {
                 assert!(std::process::Command::new(curr_exe)
                     .args(std::env::args().skip(1))

--- a/src/redraw_scheduler.rs
+++ b/src/redraw_scheduler.rs
@@ -4,8 +4,31 @@ use std::time::Instant;
 
 use log::trace;
 
+use crate::{cmd_line::CmdLineSettings, settings::*};
+
 lazy_static! {
     pub static ref REDRAW_SCHEDULER: RedrawScheduler = RedrawScheduler::new();
+}
+
+#[derive(Clone, SettingGroup)]
+pub struct RedrawSettings {
+    extra_buffer_frames: u64,
+}
+
+impl Default for RedrawSettings {
+    fn default() -> Self {
+        Self {
+            extra_buffer_frames: if SETTINGS
+                .get::<CmdLineSettings>()
+                .neovim_args
+                .contains(&"--extraBufferFrames".to_string())
+            {
+                60
+            } else {
+                1
+            },
+        }
+    }
 }
 
 pub struct RedrawScheduler {

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -316,7 +316,12 @@ impl CursorRenderer {
                     font_dimensions,
                     center_destination,
                     dt,
+<<<<<<< HEAD
                     immediate_movement,
+=======
+                    !settings.animate_in_insert_mode && in_insert_mode
+                        || !settings.animate_command_line && !changed_to_from_cmdline,
+>>>>>>> 6933a5f... implemented command line parsing with clap
                 );
 
                 animating |= corner_animating;

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -316,12 +316,7 @@ impl CursorRenderer {
                     font_dimensions,
                     center_destination,
                     dt,
-<<<<<<< HEAD
                     immediate_movement,
-=======
-                    !settings.animate_in_insert_mode && in_insert_mode
-                        || !settings.animate_command_line && !changed_to_from_cmdline,
->>>>>>> 6933a5f... implemented command line parsing with clap
                 );
 
                 animating |= corner_animating;

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -242,11 +242,9 @@ mod tests {
         let v4: String = format!("neovide_{}", v1);
         let v5: String = format!("neovide_{}", v2);
 
-        SETTINGS.set::<CmdLineSettings>(&CmdLineSettings {
-            verbosity: 0,
-            log_to_file: false,
-            neovim_args: vec![],
-        });
+        //create_nvim_command tries to read from CmdLineSettings.neovim_args
+        //TODO: this sets a static variable. Can this have side effects on other tests?
+        SETTINGS.set::<CmdLineSettings>(&CmdLineSettings::default());
 
         let (nvim, _) = create::new_child_cmd(&mut create_nvim_command(), NeovimHandler())
             .await

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -2,8 +2,6 @@ use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::convert::TryInto;
 
-#[cfg(not(test))]
-use flexi_logger::{Cleanup, Criterion, Duplicate, Logger, Naming};
 mod from_value;
 pub use from_value::FromValue;
 use log::warn;
@@ -34,7 +32,6 @@ type ReaderFunc = fn() -> Value;
 // struct except when prompted by an update event from nvim. Otherwise, the settings in Neovide and
 // nvim will get out of sync.
 pub struct Settings {
-    pub neovim_arguments: Vec<String>,
     settings: RwLock<HashMap<TypeId, Box<dyn Any + Send + Sync>>>,
     listeners: RwLock<HashMap<String, UpdateHandlerFunc>>,
     readers: RwLock<HashMap<String, ReaderFunc>>,
@@ -42,55 +39,10 @@ pub struct Settings {
 
 impl Settings {
     fn new() -> Self {
-        let mut log_to_file = false;
-        let neovim_arguments = std::env::args()
-            .filter(|arg| {
-                if arg == "--log" {
-                    log_to_file = true;
-                    false
-                } else {
-                    !(arg.starts_with("--geometry=")
-                        || arg.starts_with("--remote-tcp=")
-                        || arg == "--version"
-                        || arg == "-v"
-                        || arg == "--help"
-                        || arg == "-h"
-                        || arg == "--wsl"
-                        || arg == "--disowned"
-                        || arg == "--multiGrid"
-                        || arg == "--maximized")
-                }
-            })
-            .collect::<Vec<String>>();
-
-        #[cfg(not(test))]
-        Settings::init_logger(log_to_file);
-
         Self {
-            neovim_arguments,
             settings: RwLock::new(HashMap::new()),
             listeners: RwLock::new(HashMap::new()),
             readers: RwLock::new(HashMap::new()),
-        }
-    }
-
-    #[cfg(not(test))]
-    fn init_logger(log_to_file: bool) {
-        if log_to_file {
-            Logger::with_env_or_str("neovide")
-                .duplicate_to_stderr(Duplicate::Error)
-                .log_to_file()
-                .rotate(
-                    Criterion::Size(10_000_000),
-                    Naming::Timestamps,
-                    Cleanup::KeepLogFiles(1),
-                )
-                .start()
-                .expect("Could not start logger");
-        } else {
-            Logger::with_env_or_str("neovide = error")
-                .start()
-                .expect("Could not start logger");
         }
     }
 
@@ -122,7 +74,7 @@ impl Settings {
         let read_lock = self.settings.read();
         let boxed = &read_lock
             .get(&TypeId::of::<T>())
-            .expect("Trying to retrieve a settings object that doesn't exist");
+            .expect("Trying to retrieve a settings object that doesn't exist: {:?}");
         let value: &T = boxed
             .downcast_ref::<T>()
             .expect("Attempted to extract a settings object of the wrong type");
@@ -188,7 +140,10 @@ mod tests {
     use tokio;
 
     use super::*;
-    use crate::bridge::{create, create_nvim_command};
+    use crate::{
+        bridge::{create, create_nvim_command},
+        cmd_line::CmdLineSettings,
+    };
 
     #[derive(Clone)]
     pub struct NeovimHandler();
@@ -286,6 +241,12 @@ mod tests {
         let v3: String = "baz".to_string();
         let v4: String = format!("neovide_{}", v1);
         let v5: String = format!("neovide_{}", v2);
+
+        SETTINGS.set::<CmdLineSettings>(&CmdLineSettings {
+            verbosity: 0,
+            log_to_file: false,
+            neovim_args: vec![],
+        });
 
         let (nvim, _) = create::new_child_cmd(&mut create_nvim_command(), NeovimHandler())
             .await

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -4,8 +4,10 @@ mod window_wrapper;
 
 use crate::{
     bridge::UiCommand,
+    cmd_line::CmdLineSettings,
     editor::{DrawCommand, WindowCommand},
     renderer::Renderer,
+    settings::SETTINGS,
     INITIAL_DIMENSIONS,
 };
 use crossfire::mpsc::TxUnbounded;
@@ -16,12 +18,11 @@ pub use window_wrapper::start_loop;
 pub use settings::*;
 
 pub fn window_geometry() -> Result<(u64, u64), String> {
-    let prefix = "--geometry=";
-
-    std::env::args()
-        .find(|arg| arg.starts_with(prefix))
-        .map_or(Ok(INITIAL_DIMENSIONS), |arg| {
-            let input = &arg[prefix.len()..];
+    //TODO: Maybe move this parsing into cmd_line...
+    SETTINGS
+        .get::<CmdLineSettings>()
+        .geometry
+        .map_or(Ok(INITIAL_DIMENSIONS), |input| {
             let invalid_parse_err = format!(
                 "Invalid geometry: {}\nValid format: <width>x<height>",
                 input

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -1,4 +1,4 @@
-use crate::settings::*;
+use crate::{cmd_line::CmdLineSettings, settings::*};
 
 pub use super::keyboard::KeyboardSettings;
 
@@ -19,7 +19,8 @@ impl Default for WindowSettings {
             iso_layout: false,
             refresh_rate: 60,
             no_idle: SETTINGS
-                .neovim_arguments
+                .get::<CmdLineSettings>()
+                .neovim_args
                 .contains(&String::from("--noIdle")),
         }
     }

--- a/src/window/window_wrapper/mod.rs
+++ b/src/window/window_wrapper/mod.rs
@@ -4,8 +4,9 @@ mod renderer;
 
 use super::{handle_new_grid_size, keyboard::neovim_keybinding_string, settings::WindowSettings};
 use crate::{
-    bridge::UiCommand, editor::WindowCommand, error_handling::ResultPanicExplanation,
-    redraw_scheduler::REDRAW_SCHEDULER, renderer::Renderer, settings::SETTINGS,
+    bridge::UiCommand, cmd_line::CmdLineSettings, editor::WindowCommand,
+    error_handling::ResultPanicExplanation, redraw_scheduler::REDRAW_SCHEDULER, renderer::Renderer,
+    settings::SETTINGS,
 };
 use crossfire::mpsc::TxUnbounded;
 use glutin::{
@@ -428,7 +429,7 @@ pub fn start_loop(
         .with_title("Neovide")
         .with_inner_size(logical_size)
         .with_window_icon(Some(icon))
-        .with_maximized(std::env::args().any(|arg| arg == "--maximized"));
+        .with_maximized(SETTINGS.get::<CmdLineSettings>().maximized);
 
     let windowed_context = ContextBuilder::new()
         .with_depth_buffer(0)


### PR DESCRIPTION
This is a draft of integrating clap into neovide. I tried to stick to the existing architecture as much as possible, yet it could be that I overlooked or misunderstood something, so comments and criticism are greatly appreciated.

### Summary
* Created a file cmd_line.rs which has a `CmdLineSettings` struct. The function `handle_command_line_arguments` does the clap-thingy, builds a `CmdLineSettings` and sticks it into the `SETTINGS`.
* `SETTINGS.neovim_args` was removed and put into `CmdLineSettings` and the appropriate changes were made to the rest of the files.
* The `init_logger` function was moved to `main.rs` (It could probably be moved to a separate file completely...) and it reads `verbosity` and `log_to_file` from `CmdLineSettings` instead of taking them as a parameter.
* The primitive command-handling from `main.rs` was replaced with a call to `handle_command_line_arguments` mentioned above.
* `cargo fmt` made changes to `cursor_renderer/mod.rs` and `renderer/mod.rs`.
* Changed usages of `std::env::args()` to the new `CmdLineSettings` api.

### Currently implemented CLI arguments

```
Neovide 0.7.0
keith <keith@the-simmons.net>
A simple GUI for Neovim.

USAGE:
    neovide [FLAGS] [OPTIONS] [files]... [-- <neovim_args>...]

FLAGS:
        --disowned     Disown the process. (only on macos)
    -h, --help         Prints help information
        --log          Log to a file
        --maximized    Maximize the window
        --multiGrid    Enable Multigrid
    -V, --version      Prints version information
    -v                 Set the level of verbosity
        --wsl          Run in WSL

OPTIONS:
        --geometry <geometry>        Specify the Geometry of the window
        --remote-tcp <remote_tcp>    Connect to Remote TCP

ARGS:
    <files>...          Specify the Geometry of the window
    <neovim_args>...    Specify Arguments to pass down to neovim
```

I also would propose to change `--multiGrid` to `--multi-grid` or `--multigrid` to adhere to a unified unix-y style.