### PR TITLE
Remove duplicate `distance_length_adjust`  from  `src/renderer/cursor_renderer/mod.rs`

### DIFF
--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -48,7 +48,6 @@ impl Default for CursorSettings {
             animate_in_insert_mode: true,
             animate_command_line: true,
             trail_size: 0.7,
-            distance_length_adjust: false,
             vfx_mode: cursor_vfx::VfxMode::Disabled,
             vfx_opacity: 200.0,
             vfx_particle_lifetime: 1.2,


### PR DESCRIPTION
I just saw the newly pushed font fallback features in the opengl branch so I tried building it. Noticed that it didn't compile because `duplicate_length_adjust` was specified twice (probably by accident) in `src/renderer/cursor_renderer/mod.rs` ... so I deleted the extra line.
Not sure if it's worth a pull request, but here it is anyways.