### PR TITLE
Don't drop entire blob when shaping control characters

### DIFF
--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -235,7 +235,7 @@ impl CachingShaper {
             });
 
             if glyph_data.is_empty() {
-                return Vec::new();
+                continue;
             }
 
             let mut blob_builder = TextBlobBuilder::new();


### PR DESCRIPTION
Fixes the issue where a control character in a text run would cause the entire blob to be dropped. Now it will just skip the control characters.

This issue can appear at the end of a line when there is e.g. virtual text after the newline character

@PyGamer0 @last-partizan @tpict Please try out this branch and see if it fixes your issues!

Ref #723