### PR TITLE
Remove <S- when holding shift

### DIFF
--- a/src/window/window_wrapper/keyboard_manager.rs
+++ b/src/window/window_wrapper/keyboard_manager.rs
@@ -86,16 +86,15 @@ impl KeyboardManager {
     }
 
     fn format_keybinding_string(&self, special: bool, text: &str) -> String {
-        let special = special || self.shift || self.ctrl || self.alt || self.logo;
+        let special = special || self.ctrl || self.alt || self.logo;
 
         let open = or_empty(special, "<");
-        let shift = or_empty(self.shift, "S-");
         let ctrl = or_empty(self.ctrl, "C-");
         let alt = or_empty(self.alt, "M-");
         let logo = or_empty(use_logo(self.logo), "D-");
         let close = or_empty(special, ">");
 
-        format!("{}{}{}{}{}{}{}", open, shift, ctrl, alt, logo, text, close)
+        format!("{}{}{}{}{}{}", open, ctrl, alt, logo, text, close)
     }
 
     pub fn handle_event(&mut self, event: &Event<()>) {


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fixes #750 

This PR makes the window wrapper no longer send `<S-{key}>` when the shift key is held.

See the linked issue for details. I don't know much about how nvim handles raw terminal input, but Neovide seems to behave perfectly fine sending `A` instead of `<S-A>`.

## Did this PR introduce a breaking change?

Maybe! This change is pretty closely related to windowing and input, and I only have an Arch Linux device to test on right now. Would be awesome if somebody could hop on Windows/macOS and try holding the shift button.