### PR TITLE
Fix sporadic cursor jumps (a bit hacky)

### DIFF
--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -383,6 +383,26 @@ impl Editor {
     }
 
     fn set_cursor_position(&mut self, grid: u64, grid_left: u64, grid_top: u64) {
+        // The gutter is window ID 3. Automatic command execution sometimes sends the
+        // cursor to the gutter unexpectedly, causing confusing trail effects.
+        let cursor_sent_to_gutter = self.cursor.parent_window_id != 3 && grid == 3;
+
+        // When the user presses ":" to type a command, the cursor is sent to the gutter
+        // in position 1 (right after the ":"). In that case, it's probably intentional
+        // and OK to show a trail.
+        let gutter_probably_intentional = grid_left == 1;
+
+        // Keep cursor unchanged if we suspect it was unintentionally sent to the gutter.
+        if cursor_sent_to_gutter && !gutter_probably_intentional {
+            trace!(
+                "Cursor unexpectedly sent to gutter ({} {} {})",
+                grid,
+                grid_left,
+                grid_top
+            );
+            return;
+        }
+
         self.cursor.parent_window_id = grid;
         self.cursor.grid_position = (grid_left, grid_top);
     }

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -43,9 +43,15 @@ pub enum WindowDrawCommand {
     },
 }
 
+pub enum WindowType {
+    Editor,
+    Message
+}
+
 pub struct Window {
     grid_id: u64,
     grid: CharacterGrid,
+    pub window_type: WindowType,
 
     pub anchor_info: Option<AnchorInfo>,
 
@@ -58,6 +64,7 @@ pub struct Window {
 impl Window {
     pub fn new(
         grid_id: u64,
+        window_type: WindowType,
         width: u64,
         height: u64,
         anchor_info: Option<AnchorInfo>,
@@ -68,6 +75,7 @@ impl Window {
         let window = Window {
             grid_id,
             grid: CharacterGrid::new((width, height)),
+            window_type,
             anchor_info,
             grid_left,
             grid_top,
@@ -370,7 +378,9 @@ mod tests {
     #[test]
     fn window_separator_modifies_grid_and_sends_draw_command() {
         let (batched_receiver, batched_sender) = build_test_channels();
-        let mut window = Window::new(1, 114, 64, None, 0.0, 0.0, batched_sender.clone());
+        let mut window = Window::new(
+            1, WindowType::Editor, 114, 64, None, 0.0, 0.0, batched_sender.clone()
+        );
         batched_sender
             .send_batch()
             .expect("Could not send batch of commands");


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #743
Fixes #341 (well, non-optionally)

Hello, me again :grin:. My cursor jumps to the bottom line quite often, especially with MultiGrid turned on. Sometimes just pressing "i" is enough to get a white streak across my screen.

This PR is a bit of a hack, but it completely resolves the problem for me.

## Did this PR introduce a breaking change?
This PR relies on the following assumptions:
- that the gutter window is always ID 3, and
- that intentionally moving the cursor to the gutter always lands you on column 1.

In my case, both of those assumptions hold, so I will leave this up for discussion!
