### PR TITLE
Update rust-skia to support aarch64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "skia-bindings"
-version = "0.39.1"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "751462e70a68391c38c76d5e14ea24ed4bedd7db4b9bcefffa179f63bddf5c86"
 dependencies = [
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.39.1"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b06dfa844d8f75dd616b600c1dd018950ee5eff19bb36d97ec4a7232b3bdb60"
 dependencies = [


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- [x] Fix
- [ ] Feature
- [ ] Codestyle
- [ ] Refactor
- [ ] Other

## Did this PR introduce a breaking change?
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- [ ] Yes, please list breaking changes
- [x] No

Tested locally on a chromebook machine, seems to work fine. Fixes https://github.com/Kethku/neovide/issues/766. I would just double check with @Shatur before merging 

Side note: I think quite a few of the dependencies are out of date now. Is it possible to add dependabots for rust? if not, I might have to manually take a look at them one day