### PR TITLE
Fix incorrect initial scaling

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -255,7 +255,7 @@ impl Renderer {
 
     #[allow(clippy::needless_collect)]
     pub fn draw_frame(&mut self, root_canvas: &mut Canvas, dt: f32, scaling: f32) -> bool {
-        trace!("Drawing Frame");
+        trace!("Drawing Frame at {} scale", scaling);
         let mut font_changed = false;
 
         let draw_commands: Vec<_> = self
@@ -277,7 +277,7 @@ impl Renderer {
         root_canvas.save();
 
         root_canvas.reset_matrix();
-        root_canvas.scale((1.0 / scaling, 1.0 / scaling));
+        root_canvas.scale((scaling, scaling));
 
         if let Some(root_window) = self.rendered_windows.get(&1) {
             let clip_rect = root_window.pixel_region(self.font_width, self.font_height);

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -49,8 +49,8 @@ fn build_window_surface_with_grid_size(
     grid_height: u64,
     scaling: f32,
 ) -> Surface {
-    let pixel_width = ((grid_width * renderer.font_width) as f32 / scaling) as u64;
-    let pixel_height = ((grid_height * renderer.font_height) as f32 / scaling) as u64;
+    let pixel_width = ((grid_width * renderer.font_width) as f32 * scaling) as u64;
+    let pixel_height = ((grid_height * renderer.font_height) as f32 * scaling) as u64;
     let mut surface = build_window_surface(parent_canvas, pixel_width, pixel_height);
 
     let canvas = surface.canvas();
@@ -367,7 +367,7 @@ impl RenderedWindow {
 
                 let canvas = self.current_surface.surface.canvas();
                 canvas.save();
-                canvas.scale((1.0 / scaling, 1.0 / scaling));
+                canvas.scale((scaling, scaling));
                 renderer.draw_background(canvas, grid_position, width, &style);
                 renderer.draw_foreground(canvas, &cells, grid_position, width, &style);
                 canvas.restore();
@@ -381,16 +381,16 @@ impl RenderedWindow {
                 cols,
             } => {
                 let scrolled_region = Rect::new(
-                    (left * renderer.font_width) as f32 / scaling,
-                    (top * renderer.font_height) as f32 / scaling,
-                    (right * renderer.font_width) as f32 / scaling,
-                    (bot * renderer.font_height) as f32 / scaling,
+                    (left * renderer.font_width) as f32 * scaling,
+                    (top * renderer.font_height) as f32 * scaling,
+                    (right * renderer.font_width) as f32 * scaling,
+                    (bot * renderer.font_height) as f32 * scaling,
                 );
 
                 let mut translated_region = scrolled_region;
                 translated_region.offset((
-                    (-cols * renderer.font_width as i64) as f32 / scaling,
-                    (-rows * renderer.font_height as i64) as f32 / scaling,
+                    (-cols * renderer.font_width as i64) as f32 * scaling,
+                    (-rows * renderer.font_height as i64) as f32 * scaling,
                 ));
 
                 let snapshot = self.current_surface.surface.image_snapshot();

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -10,6 +10,7 @@ use crate::{
     settings::SETTINGS,
     INITIAL_DIMENSIONS,
 };
+use glutin::dpi::LogicalSize;
 use std::sync::{atomic::AtomicBool, mpsc::Receiver, Arc};
 
 pub use window_wrapper::start_loop;
@@ -67,20 +68,16 @@ fn windows_fix_dpi() {
 }
 
 fn handle_new_grid_size(
-    new_size: (u64, u64),
+    new_size: LogicalSize<u32>,
     renderer: &Renderer,
     ui_command_sender: &LoggingTx<UiCommand>,
 ) {
-    let (new_width, new_height) = new_size;
-    if new_width > 0 && new_height > 0 {
+    if new_size.width > 0 && new_size.height > 0 {
         // Add 1 here to make sure resizing doesn't change the grid size on startup
-        let new_width = ((new_width + 1) / renderer.font_width) as u32;
-        let new_height = ((new_height + 1) / renderer.font_height) as u32;
+        let width = ((new_size.width + 1) / renderer.font_width as u32) as u32;
+        let height = ((new_size.height + 1) / renderer.font_height as u32) as u32;
         ui_command_sender
-            .send(UiCommand::Resize {
-                width: new_width,
-                height: new_height,
-            })
+            .send(UiCommand::Resize { width, height })
             .ok();
     }
 }

--- a/src/window/window_wrapper/mod.rs
+++ b/src/window/window_wrapper/mod.rs
@@ -166,12 +166,13 @@ impl GlutinWindowWrapper {
 
     pub fn draw_frame(&mut self, dt: f32) {
         let window = self.windowed_context.window();
+        let scaling = window.scale_factor();
         let new_size = window.inner_size();
+
         if self.previous_size != new_size {
             self.previous_size = new_size;
-            let new_size: LogicalSize<u32> = new_size.to_logical(window.scale_factor());
             handle_new_grid_size(
-                (new_size.width as u64, new_size.height as u64),
+                new_size.to_logical(scaling),
                 &self.renderer,
                 &self.ui_command_sender,
             );
@@ -182,9 +183,8 @@ impl GlutinWindowWrapper {
         let ui_command_sender = self.ui_command_sender.clone();
 
         if REDRAW_SCHEDULER.should_draw() || SETTINGS.get::<WindowSettings>().no_idle {
-            log::debug!("Render Triggered");
+            log::debug!("Render triggered using scale factor: {}", scaling);
 
-            let scaling = 1.0 / self.windowed_context.window().scale_factor();
             let renderer = &mut self.renderer;
 
             {
@@ -192,7 +192,7 @@ impl GlutinWindowWrapper {
 
                 if renderer.draw_frame(canvas, dt, scaling as f32) {
                     handle_new_grid_size(
-                        (current_size.width as u64, current_size.height as u64),
+                        current_size.to_logical(scaling),
                         renderer,
                         &ui_command_sender,
                     );


### PR DESCRIPTION
Also, I replaced inverse scaling (like 1 / scaling) with natural scaling (like 1 ... 2, what returned by window.scale_factor())
I think easier to work with natural scaling factor and multiplication, instead of inverse scaling factor and division.

It looks fine, and works as expected, but please, review carefully parts where i changed scaling.

Also, instead of passing pair of width/height to handle_new_grid_size i pass LogicalSize. So it's impossible to pass incorrect value.

(Probably, this could be splitted into "just fix" and "refactoring", but i hope it's small enough and can be merged as is)

## What kind of change does this PR introduce?
- [x] Fix
- [ ] Feature
- [ ] Codestyle
- [x] Refactor
- [ ] Other

## Did this PR introduce a breaking change?
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- [ ] Yes, please list breaking changes
- [x] No

Refs #771