### PR TITLE
Rename "bot" to "bottom" in WindowDrawCommand::Scroll

### DIFF
--- a/src/editor/grid.rs
+++ b/src/editor/grid.rs
@@ -243,7 +243,7 @@ mod tests {
         character_grid.characters = vec![grid_cell.clone(); context.area];
 
         // RUN FUNCTION
-        character_grid.resize(width, height);
+        character_grid.resize((width, height));
 
         assert_eq!(character_grid.width, width);
         assert_eq!(character_grid.height, height);

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -25,7 +25,7 @@ pub enum WindowDrawCommand {
     },
     Scroll {
         top: u64,
-        bot: u64,
+        bottom: u64,
         left: u64,
         right: u64,
         rows: i64,
@@ -256,21 +256,21 @@ impl Window {
     pub fn scroll_region(
         &mut self,
         top: u64,
-        bot: u64,
+        bottom: u64,
         left: u64,
         right: u64,
         rows: i64,
         cols: i64,
     ) {
         let y_iter: Box<dyn Iterator<Item = i64>> = if rows > 0 {
-            Box::new((top as i64 + rows)..bot as i64)
+            Box::new((top as i64 + rows)..bottom as i64)
         } else {
-            Box::new((top as i64..(bot as i64 + rows)).rev())
+            Box::new((top as i64..(bottom as i64 + rows)).rev())
         };
 
         self.send_command(WindowDrawCommand::Scroll {
             top,
-            bot,
+            bottom,
             left,
             right,
             rows,

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -374,7 +374,7 @@ impl RenderedWindow {
             }
             WindowDrawCommand::Scroll {
                 top,
-                bot,
+                bottom,
                 left,
                 right,
                 rows,
@@ -384,7 +384,7 @@ impl RenderedWindow {
                     (left * renderer.font_width) as f32 * scaling,
                     (top * renderer.font_height) as f32 * scaling,
                     (right * renderer.font_width) as f32 * scaling,
-                    (bot * renderer.font_height) as f32 * scaling,
+                    (bottom * renderer.font_height) as f32 * scaling,
                 );
 
                 let mut translated_region = scrolled_region;


### PR DESCRIPTION
This is just renaming `bot` to `bottom` in WindowDrawCommand::Scroll

Small increase in character count, big increase in readability :)

## What kind of change does this PR introduce?
- [ ] Fix
- [ ] Feature
- [x] Codestyle
- [ ] Refactor
- [ ] Other

## Did this PR introduce a breaking change?
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- [ ] Yes, please list breaking changes
- [x] No
