### PR TITLE
Refactor scaling code

### DIFF
--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -33,7 +33,7 @@ impl CachingShaper {
     pub fn new(scale_factor: f32) -> CachingShaper {
         CachingShaper {
             options: None,
-            font_loader: FontLoader::new(DEFAULT_FONT_SIZE),
+            font_loader: FontLoader::new(DEFAULT_FONT_SIZE * scale_factor),
             blob_cache: LruCache::new(10000),
             shape_context: ShapeContext::new(),
             scale_factor,

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -26,15 +26,17 @@ pub struct CachingShaper {
     font_loader: FontLoader,
     blob_cache: LruCache<ShapeKey, Vec<TextBlob>>,
     shape_context: ShapeContext,
+    scale_factor: f32,
 }
 
 impl CachingShaper {
-    pub fn new() -> CachingShaper {
+    pub fn new(scale_factor: f32) -> CachingShaper {
         CachingShaper {
             options: None,
             font_loader: FontLoader::new(DEFAULT_FONT_SIZE),
             blob_cache: LruCache::new(10000),
             shape_context: ShapeContext::new(),
+            scale_factor,
         }
     }
 
@@ -69,13 +71,15 @@ impl CachingShaper {
             .as_ref()
             .map(|options| options.size)
             .unwrap_or(DEFAULT_FONT_SIZE)
+            * self.scale_factor
     }
 
     pub fn update_font(&mut self, guifont_setting: &str) -> bool {
         let new_options = FontOptions::parse(guifont_setting, DEFAULT_FONT_SIZE);
 
         if new_options != self.options && new_options.is_some() {
-            self.font_loader = FontLoader::new(new_options.as_ref().unwrap().size);
+            self.font_loader =
+                FontLoader::new(new_options.as_ref().unwrap().size * self.scale_factor);
             self.blob_cache.clear();
             self.options = new_options;
 

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -47,10 +47,9 @@ fn build_window_surface_with_grid_size(
     renderer: &Renderer,
     grid_width: u64,
     grid_height: u64,
-    scaling: f32,
 ) -> Surface {
-    let pixel_width = ((grid_width * renderer.font_width) as f32 * scaling) as u64;
-    let pixel_height = ((grid_height * renderer.font_height) as f32 * scaling) as u64;
+    let pixel_width = ((grid_width * renderer.font_width) as f32) as u64;
+    let pixel_height = ((grid_height * renderer.font_height) as f32) as u64;
     let mut surface = build_window_surface(parent_canvas, pixel_width, pixel_height);
 
     let canvas = surface.canvas();
@@ -75,15 +74,9 @@ impl LocatedSurface {
         grid_width: u64,
         grid_height: u64,
         top_line: u64,
-        scaling: f32,
     ) -> LocatedSurface {
-        let surface = build_window_surface_with_grid_size(
-            parent_canvas,
-            renderer,
-            grid_width,
-            grid_height,
-            scaling,
-        );
+        let surface =
+            build_window_surface_with_grid_size(parent_canvas, renderer, grid_width, grid_height);
 
         LocatedSurface { surface, top_line }
     }
@@ -134,10 +127,9 @@ impl RenderedWindow {
         grid_position: Point,
         grid_width: u64,
         grid_height: u64,
-        scaling: f32,
     ) -> RenderedWindow {
         let current_surface =
-            LocatedSurface::new(parent_canvas, renderer, grid_width, grid_height, 0, scaling);
+            LocatedSurface::new(parent_canvas, renderer, grid_width, grid_height, 0);
 
         RenderedWindow {
             snapshots: VecDeque::new(),
@@ -302,7 +294,6 @@ impl RenderedWindow {
         mut self,
         renderer: &mut Renderer,
         draw_command: WindowDrawCommand,
-        scaling: f32,
     ) -> Self {
         match draw_command {
             WindowDrawCommand::Position {
@@ -334,7 +325,6 @@ impl RenderedWindow {
                         renderer,
                         grid_width,
                         grid_height,
-                        scaling,
                     );
                     old_surface.draw(
                         self.current_surface.surface.canvas(),
@@ -367,7 +357,6 @@ impl RenderedWindow {
 
                 let canvas = self.current_surface.surface.canvas();
                 canvas.save();
-                canvas.scale((scaling, scaling));
                 renderer.draw_background(canvas, grid_position, width, &style);
                 renderer.draw_foreground(canvas, &cells, grid_position, width, &style);
                 canvas.restore();
@@ -380,25 +369,24 @@ impl RenderedWindow {
                 rows,
                 cols,
             } => {
+                let font_width = renderer.font_width as f32;
+                let font_height = renderer.font_height as f32;
                 let scrolled_region = Rect::new(
-                    (left * renderer.font_width) as f32 * scaling,
-                    (top * renderer.font_height) as f32 * scaling,
-                    (right * renderer.font_width) as f32 * scaling,
-                    (bottom * renderer.font_height) as f32 * scaling,
+                    left as f32 * font_width,
+                    top as f32 * font_height,
+                    right as f32 * font_width,
+                    bottom as f32 * font_height,
                 );
 
                 let mut translated_region = scrolled_region;
-                translated_region.offset((
-                    (-cols * renderer.font_width as i64) as f32 * scaling,
-                    (-rows * renderer.font_height as i64) as f32 * scaling,
-                ));
+                translated_region.offset((-cols as f32 * font_width, -rows as f32 * font_height));
 
                 let snapshot = self.current_surface.surface.image_snapshot();
                 let canvas = self.current_surface.surface.canvas();
 
                 canvas.save();
-                canvas.clip_rect(scrolled_region, None, Some(false));
 
+                canvas.clip_rect(scrolled_region, None, Some(false));
                 canvas.draw_image_rect(
                     snapshot,
                     Some((&scrolled_region, SrcRectConstraint::Fast)),
@@ -414,7 +402,6 @@ impl RenderedWindow {
                     renderer,
                     self.grid_width,
                     self.grid_height,
-                    scaling,
                 );
 
                 self.snapshots.clear();

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     settings::SETTINGS,
     INITIAL_DIMENSIONS,
 };
-use glutin::dpi::LogicalSize;
+use glutin::dpi::PhysicalSize;
 use std::sync::{atomic::AtomicBool, mpsc::Receiver, Arc};
 
 pub use window_wrapper::start_loop;
@@ -68,7 +68,7 @@ fn windows_fix_dpi() {
 }
 
 fn handle_new_grid_size(
-    new_size: LogicalSize<u32>,
+    new_size: PhysicalSize<u32>,
     renderer: &Renderer,
     ui_command_sender: &LoggingTx<UiCommand>,
 ) {
@@ -88,22 +88,14 @@ pub fn create_window(
     ui_command_sender: LoggingTx<UiCommand>,
     running: Arc<AtomicBool>,
 ) {
-    let (width, height) = window_geometry_or_default();
-
-    let renderer = Renderer::new(batched_draw_command_receiver);
-    let logical_size = (
-        (width * renderer.font_width) as u64,
-        (height * renderer.font_height + 1) as u64,
-    );
-
     #[cfg(target_os = "windows")]
     windows_fix_dpi();
 
     start_loop(
+        batched_draw_command_receiver,
         window_command_receiver,
         ui_command_sender,
         running,
-        logical_size,
-        renderer,
+        window_geometry_or_default(),
     );
 }

--- a/src/window/window_wrapper/mod.rs
+++ b/src/window/window_wrapper/mod.rs
@@ -218,8 +218,6 @@ pub fn start_loop(
         .unwrap();
     let windowed_context = unsafe { windowed_context.make_current().unwrap() };
 
-    log::info!("window created");
-
     let skia_renderer = SkiaRenderer::new(&windowed_context);
     let scale_factor = windowed_context.window().scale_factor();
     let renderer = Renderer::new(batched_draw_command_receiver, scale_factor);
@@ -229,6 +227,13 @@ pub fn start_loop(
         get_initial_window_size(initial_size, (renderer.font_width, renderer.font_height));
 
     window.set_inner_size(initial_inner_size);
+
+    log::info!(
+        "window created (scale_factor: {}, font_size: {}x{})",
+        scale_factor,
+        renderer.font_width,
+        renderer.font_height,
+    );
 
     let saved_inner_size = window.inner_size();
 


### PR DESCRIPTION
Basic idea here is to remove scaling from as much app as possible.

Let's make only fonts aware of scaling, everything else is expected to just works.

What do you think? Is it good idea? Could this give us any problems in the future?

The basics are already working, it scales as i expect it to. No artifacts.

## What needs to be adressed before merge:

- [x] Fira Code font problem.
    It is not mac-specific, to reproduce you need to have `Fira Code` installed, and no `guifont` in vimrc. Then neovide tries to load Fira Code as default font, and with scaling greater than 1, bug happens.

-------------------

## What kind of change does this PR introduce?
- Fix
- Refactor

## Did this PR introduce a breaking change?
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
