### PR TITLE
Fix broken Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,9 +2276,9 @@ dependencies = [
 
 [[package]]
 name = "skia-bindings"
-version = "0.39.1"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751462e70a68391c38c76d5e14ea24ed4bedd7db4b9bcefffa179f63bddf5c86"
+checksum = "8e49c0905fe8fa4a4fe348f0ec33a3b3fc78e73f4602c7154d8fb70d4b0aaee2"
 dependencies = [
  "bindgen",
  "cc",
@@ -2294,9 +2294,9 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.39.1"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b06dfa844d8f75dd616b600c1dd018950ee5eff19bb36d97ec4a7232b3bdb60"
+checksum = "147b9ab328c7c40dbf590151313df9cd721be8c418cfefa2533c9a0c056ef21b"
 dependencies = [
  "bitflags",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "skia-bindings"
-version = "0.40.2"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "751462e70a68391c38c76d5e14ea24ed4bedd7db4b9bcefffa179f63bddf5c86"
 dependencies = [
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.40.2"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b06dfa844d8f75dd616b600c1dd018950ee5eff19bb36d97ec4a7232b3bdb60"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,11 +55,11 @@ winres = "0.1.11"
 
 [target.'cfg(linux)'.dependencies.skia-safe]
 features = ["gl", "egl"]
-version = "0.39.1"
+version = "0.40.2"
 
 [target.'cfg(not(linux))'.dependencies.skia-safe]
 features = ["gl"]
-version = "0.39.1"
+version = "0.40.2"
 
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,11 +55,11 @@ winres = "0.1.11"
 
 [target.'cfg(linux)'.dependencies.skia-safe]
 features = ["gl", "egl"]
-version = "0.40.2"
+version = "0.39.1"
 
 [target.'cfg(not(linux))'.dependencies.skia-safe]
 features = ["gl"]
-version = "0.40.2"
+version = "0.39.1"
 
 [profile.release]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,11 +55,11 @@ winres = "0.1.11"
 
 [target.'cfg(linux)'.dependencies.skia-safe]
 features = ["gl", "egl"]
-version = "0.40.2"
+version = "^0.40.2"
 
 [target.'cfg(not(linux))'.dependencies.skia-safe]
 features = ["gl"]
-version = "0.40.2"
+version = "^0.40.2"
 
 [profile.release]
 debug = true


### PR DESCRIPTION
@shaunsingh first time you updated only versions in lockfile, second time you updated only versions in Cargo.toml, i reverted both commits, and updated versions and checksums in one commit with.

```
# 1. Update version in Cargo.toml
# 2. Update lockfile
cargo update -p skia-safe
```

## What kind of change does this PR introduce?
- [x] Fix
- [ ] Feature
- [ ] Codestyle
- [ ] Refactor
- [ ] Other

## Did this PR introduce a breaking change?
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- [ ] Yes, please list breaking changes
- [x] No
