### PR TITLE
refactor(startup): Use SETTINGS to store window geometry

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -18,7 +18,6 @@ use tokio::runtime::Runtime;
 
 use crate::channel_utils::*;
 use crate::settings::*;
-use crate::window::window_geometry_or_default;
 use crate::{cmd_line::CmdLineSettings, error_handling::ResultPanicExplanation};
 pub use events::*;
 use handler::NeovimHandler;
@@ -162,7 +161,6 @@ async fn start_neovim_runtime(
     redraw_event_sender: LoggingTx<RedrawEvent>,
     running: Arc<AtomicBool>,
 ) {
-    let (width, height) = window_geometry_or_default();
     let handler = NeovimHandler::new(ui_command_sender.clone(), redraw_event_sender.clone());
     let (mut nvim, io_handler) = match connection_mode() {
         ConnectionMode::Child => create::new_child_cmd(&mut create_nvim_command(), handler).await,
@@ -276,6 +274,7 @@ async fn start_neovim_runtime(
         .await
         .ok();
 
+    let WindowGeometry { width, height } = SETTINGS.get::<CmdLineSettings>().geometry;
     let mut options = UiAttachOptions::new();
     options.set_linegrid_external(true);
 

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -11,7 +11,7 @@ pub struct CmdLineSettings {
     pub files_to_open: Vec<String>,
 
     pub disowned: bool,
-    pub geometry: Option<String>,
+    pub geometry: WindowGeometry,
     pub wsl: bool,
     pub remote_tcp: Option<String>,
     pub multi_grid: bool,
@@ -28,7 +28,7 @@ impl Default for CmdLineSettings {
             neovim_args: vec![],
             files_to_open: vec![],
             disowned: false,
-            geometry: None,
+            geometry: DEFAULT_WINDOW_GEOMETRY,
             wsl: false,
             remote_tcp: None,
             multi_grid: false,
@@ -38,7 +38,7 @@ impl Default for CmdLineSettings {
     }
 }
 
-pub fn handle_command_line_arguments() {
+pub fn handle_command_line_arguments() -> Result<(), String> {
     let clapp = App::new("Neovide")
         .version(crate_version!())
         .author(crate_authors!())
@@ -130,7 +130,8 @@ pub fn handle_command_line_arguments() {
         remote_tcp: matches.value_of("remote_tcp").map(|i| i.to_owned()),
         disowned: matches.is_present("disowned"),
         wsl: matches.is_present("wsl"),
-        geometry: matches.value_of("geometry").map(|i| i.to_owned()),
         frameless: matches.is_present("frameless") || std::env::var("NEOVIDE_FRAMELESS").is_ok(),
+        geometry: parse_window_geometry(matches.value_of("geometry").map(|i| i.to_owned()))?,
     });
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,10 +41,9 @@ use editor::start_editor;
 use renderer::{cursor_renderer::CursorSettings, RendererSettings};
 #[cfg(not(test))]
 use settings::SETTINGS;
-use window::{create_window, window_geometry, WindowSettings};
+use window::{create_window, WindowSettings};
 
 pub use channel_utils::*;
-pub const INITIAL_DIMENSIONS: (u64, u64) = (100, 50);
 
 fn main() {
     //  -----------
@@ -116,9 +115,8 @@ fn main() {
     //   Multiple other parts of the app "queue_next_frame" function to ensure animations continue
     //   properly or updates to the graphics are pushed to the screen.
 
-    cmd_line::handle_command_line_arguments(); //Will exit if -h or -v
-
-    if let Err(err) = window_geometry() {
+    //Will exit if -h or -v
+    if let Err(err) = cmd_line::handle_command_line_arguments() {
         eprintln!("{}", err);
         return;
     }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -3,11 +3,13 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 
 mod from_value;
+mod window_geometry;
 pub use from_value::FromValue;
 use log::trace;
 use nvim_rs::Neovim;
 use parking_lot::RwLock;
 pub use rmpv::Value;
+pub use window_geometry::{parse_window_geometry, WindowGeometry, DEFAULT_WINDOW_GEOMETRY};
 
 use crate::bridge::TxWrapper;
 use crate::error_handling::ResultPanicExplanation;

--- a/src/settings/window_geometry.rs
+++ b/src/settings/window_geometry.rs
@@ -1,0 +1,43 @@
+#[derive(Debug, Clone)]
+pub struct WindowGeometry {
+    pub width: u64,
+    pub height: u64,
+}
+
+pub const DEFAULT_WINDOW_GEOMETRY: WindowGeometry = WindowGeometry {
+    width: 100,
+    height: 50,
+};
+
+pub fn parse_window_geometry(geometry: Option<String>) -> Result<WindowGeometry, String> {
+    geometry.map_or(Ok(DEFAULT_WINDOW_GEOMETRY), |input| {
+        let invalid_parse_err = format!(
+            "Invalid geometry: {}\nValid format: <width>x<height>",
+            input
+        );
+
+        input
+            .split('x')
+            .map(|dimension| {
+                dimension
+                    .parse::<u64>()
+                    .map_err(|_| invalid_parse_err.as_str())
+                    .and_then(|dimension| {
+                        if dimension > 0 {
+                            Ok(dimension)
+                        } else {
+                            Err("Invalid geometry: Window dimensions should be greater than 0.")
+                        }
+                    })
+            })
+            .collect::<Result<Vec<_>, &str>>()
+            .and_then(|dimensions| {
+                if let [width, height] = dimensions[..] {
+                    Ok(WindowGeometry { width, height })
+                } else {
+                    Err(invalid_parse_err.as_str())
+                }
+            })
+            .map_err(|msg| msg.to_owned())
+    })
+}

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -4,11 +4,8 @@ mod window_wrapper;
 use crate::{
     bridge::UiCommand,
     channel_utils::*,
-    cmd_line::CmdLineSettings,
     editor::{DrawCommand, WindowCommand},
     renderer::Renderer,
-    settings::SETTINGS,
-    INITIAL_DIMENSIONS,
 };
 use glutin::dpi::PhysicalSize;
 use std::sync::{atomic::AtomicBool, mpsc::Receiver, Arc};
@@ -16,47 +13,6 @@ use std::sync::{atomic::AtomicBool, mpsc::Receiver, Arc};
 pub use window_wrapper::start_loop;
 
 pub use settings::*;
-
-pub fn window_geometry() -> Result<(u64, u64), String> {
-    //TODO: Maybe move this parsing into cmd_line...
-    SETTINGS
-        .get::<CmdLineSettings>()
-        .geometry
-        .map_or(Ok(INITIAL_DIMENSIONS), |input| {
-            let invalid_parse_err = format!(
-                "Invalid geometry: {}\nValid format: <width>x<height>",
-                input
-            );
-
-            input
-                .split('x')
-                .map(|dimension| {
-                    dimension
-                        .parse::<u64>()
-                        .map_err(|_| invalid_parse_err.as_str())
-                        .and_then(|dimension| {
-                            if dimension > 0 {
-                                Ok(dimension)
-                            } else {
-                                Err("Invalid geometry: Window dimensions should be greater than 0.")
-                            }
-                        })
-                })
-                .collect::<Result<Vec<_>, &str>>()
-                .and_then(|dimensions| {
-                    if let [width, height] = dimensions[..] {
-                        Ok((width, height))
-                    } else {
-                        Err(invalid_parse_err.as_str())
-                    }
-                })
-                .map_err(|msg| msg.to_owned())
-        })
-}
-
-pub fn window_geometry_or_default() -> (u64, u64) {
-    window_geometry().unwrap_or(INITIAL_DIMENSIONS)
-}
 
 #[cfg(target_os = "windows")]
 fn windows_fix_dpi() {
@@ -96,6 +52,5 @@ pub fn create_window(
         window_command_receiver,
         ui_command_sender,
         running,
-        window_geometry_or_default(),
     );
 }


### PR DESCRIPTION
While i was researching neovim startup sequence, i refactored it a little.

- Removed multiple calls to functions getting window size
- Now there is only one call, when parsing command line arguments
- After this value is used from SETTINGS

I think this way it is better. @Kethku what do you think?

---------------------

## What kind of change does this PR introduce?
- Refactor

## Did this PR introduce a breaking change?
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No

Btw, i suppose no one objects i'm using just lists instead of checkboxes in this template? Github is treating checkboxes as "tasks", and i don't like having "2 of 7 tasks" on my PRs :)