### PR TITLE
fix(fonts): Fix font scaling (points to pixels conversion)

### DIFF
--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -316,7 +316,7 @@ impl CachingShaper {
 fn points_to_pixels(value: f32) -> f32 {
     // Fonts in neovim are using points, not pixels.
     //
-    // Skia docs is incorrectly statint it uses points, but uses pixels:
+    // Skia docs is incorrectly stating it uses points, but uses pixels:
     // https://api.skia.org/classSkFont.html#a7e28a156a517d01bc608c14c761346bf
     // https://github.com/mono/SkiaSharp/issues/1147#issuecomment-587421201
     //

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -30,7 +30,8 @@ pub struct CachingShaper {
 }
 
 impl CachingShaper {
-    pub fn new(scale_factor: f32) -> CachingShaper {
+    pub fn new(device_scale_factor: f32) -> CachingShaper {
+        let scale_factor = points_to_pixels(device_scale_factor);
         CachingShaper {
             options: None,
             font_loader: FontLoader::new(DEFAULT_FONT_SIZE * scale_factor),
@@ -310,4 +311,19 @@ impl CachingShaper {
 
         self.blob_cache.get(&key).unwrap()
     }
+}
+
+fn points_to_pixels(value: f32) -> f32 {
+    // Fonts in neovim are using points, not pixels.
+    //
+    // Skia docs is incorrectly statint it uses points, but uses pixels:
+    // https://api.skia.org/classSkFont.html#a7e28a156a517d01bc608c14c761346bf
+    // https://github.com/mono/SkiaSharp/issues/1147#issuecomment-587421201
+    //
+    // So, we need to convert points to pixels.
+    let pixels_per_inch = 96.0;
+    let points_per_inch = 72.0;
+    let pixels_per_point = pixels_per_inch / points_per_inch;
+
+    value * pixels_per_point
 }

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -321,6 +321,9 @@ fn points_to_pixels(value: f32) -> f32 {
     // https://github.com/mono/SkiaSharp/issues/1147#issuecomment-587421201
     //
     // So, we need to convert points to pixels.
+    //
+    // In reality, this depends on DPI/PPI of monitor, but here we only care about converting
+    // from points to pixels, so this is standard constant values.
     let pixels_per_inch = 96.0;
     let points_per_inch = 72.0;
     let pixels_per_point = pixels_per_inch / points_per_inch;


### PR DESCRIPTION
Fixes font scaling from #387

Fonts are actually in points, not pixels. So we need to convert them.

![image](https://user-images.githubusercontent.com/301015/125103708-4e41cd80-e0e5-11eb-9e36-c67e4f155aa8.png)


## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change?
- No
