### PR TITLE
Put Windows artefact in zip archive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         cargo build --release
         
-    - name: Zip Windows artifact
+    - name: Archive Windows artifact
       run: |
         powershell Compress-Archive ./target/release/neovide.exe ./target/release/neovide.zip 
 
@@ -167,11 +167,15 @@ jobs:
     - name: Build Release
       run: |
         cargo build --release
+        
+    - name: Archive Linux artifact
+      run: |
+        tar czvf ./target/release/neovide.tar.gz ./target/release/neovide
 
     - uses: actions/upload-artifact@v1
       with:
-        name: neovide-linux
-        path: ./target/release/neovide
+        name: neovide-linux.tar.gz
+        path: ./target/release/neovide.tar.gz
 
   build-m1:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,11 +48,15 @@ jobs:
     - name: Build Release
       run: |
         cargo build --release
+        
+    - name: Zip Windows artifact
+      run: |
+        powershell Compress-Archive ./target/release/neovide.exe neovide.zip 
 
     - uses: actions/upload-artifact@v1
       with:
-        name: neovide-windows.exe
-        path: ./target/release/neovide.exe
+        name: neovide-windows.zip
+        path: ./target/release/neovide.zip
 
   build-mac:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         
     - name: Zip Windows artifact
       run: |
-        powershell Compress-Archive ./target/release/neovide.exe neovide.zip 
+        powershell Compress-Archive ./target/release/neovide.exe ./target/release/neovide.zip 
 
     - uses: actions/upload-artifact@v1
       with:


### PR DESCRIPTION
This PR adds an extra step to the Windows pipeline to put the Windows artefact in a `.zip` archive. 

A lot of places (specially companies) has proxies that outright blocks everything ending in `.exe` and this is a neat way to make it a bit easier to distribute from Github to those places.

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- [ ] Fix
- [ ] Feature
- [ ] Codestyle
- [ ] Refactor
- [x] Other

## Did this PR introduce a breaking change?
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- [x] Yes, please list breaking changes
- [ ] No

This change is potentially breaking if there exist update processes that links directly to the artefact, alternatively this could be an addition :)