### PR TITLE
fix(macos): Fix scaling on mac-os

### DIFF
--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -326,6 +326,10 @@ fn points_to_pixels(value: f32) -> f32 {
     // from points to pixels, so this is standard constant values.
     let pixels_per_inch = 96.0;
     let points_per_inch = 72.0;
+    // On macos points == pixels
+    #[cfg(target_os = "macos")]
+    let points_per_inch = 96.0;
+
     let pixels_per_point = pixels_per_inch / points_per_inch;
 
     value * pixels_per_point


### PR DESCRIPTION
On MacOS points and pixels are the same.

@clason please check this

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change?
- No
