### PR TITLE
fix(keyboard): Fix shift+tab handling

### DIFF
--- a/src/window/window_wrapper/keyboard_manager.rs
+++ b/src/window/window_wrapper/keyboard_manager.rs
@@ -188,6 +188,7 @@ fn is_control_key(key: Key<'static>) -> Option<&str> {
         Key::End => Some("End"),
         Key::PageUp => Some("PageUp"),
         Key::PageDown => Some("PageDown"),
+        Key::Tab => Some("Tab"),
         _ => None,
     }
 }


### PR DESCRIPTION
This fixes Shift+Tab mappings (now it works).

This is simpler than variant from @smolck in https://github.com/Kethku/neovide/pull/782

And it works for me. @smolck please take a look, i think shift check in is_control_key isn't required.


Refs #445 

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change?
- No
