### PR TITLE
support some font weights by ':set guifont=...'

### DIFF
--- a/src/renderer/fonts/font_options.rs
+++ b/src/renderer/fonts/font_options.rs
@@ -187,6 +187,53 @@ impl FontOptions {
         for font in font_options.normal.iter_mut() {
             font.style = style.clone();
         }
+        for font in font_options.normal.iter_mut() {
+            match font.family.split_whitespace().last() {
+                Some("Thin") => {
+                    font.family = font.family[..font.family.len() - 5].to_string();
+                    font.style = Some("Thin".to_string());
+                }
+                Some("ExtraLight") => {
+                    font.family = font.family[..font.family.len() - 11].to_string();
+                    font.style = Some("ExtraLight".to_string());
+                }
+                Some("Light") => {
+                    font.family = font.family[..font.family.len() - 6].to_string();
+                    font.style = Some("Light".to_string());
+                }
+                Some("Normal") => {
+                    font.family = font.family[..font.family.len() - 7].to_string();
+                    font.style = Some("Normal".to_string());
+                }
+                Some("Medium") => {
+                    font.family = font.family[..font.family.len() - 7].to_string();
+                    font.style = Some("Medium".to_string());
+                }
+                Some("SemiBold") => {
+                    font.family = font.family[..font.family.len() - 9].to_string();
+                    font.style = Some("SemiBold".to_string());
+                }
+                Some("Bold") => {
+                    font.family = font.family[..font.family.len() - 5].to_string();
+                    font.style = Some("Bold".to_string());
+                }
+                Some("ExtraBold") => {
+                    font.family = font.family[..font.family.len() - 10].to_string();
+                    font.style = Some("ExtraBold".to_string());
+                }
+                Some("Black") => {
+                    font.family = font.family[..font.family.len() - 6].to_string();
+                    font.style = Some("Black".to_string());
+                }
+                Some("ExtraBlack") => {
+                    font.family = font.family[..font.family.len() - 11].to_string();
+                    font.style = Some("ExtraBlack".to_string());
+                }
+                _ => {
+                    warn!("last word of font family name {:?} does not equal to one of these weights (case sensitive) : Thin, ExtraLight, Light, Normal, Medium, SemiBold, Bold, ExtraBold, Black, ExtraBlack", font.family);
+                }
+            }
+        }
 
         Ok(font_options)
     }

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -35,13 +35,14 @@ end
 VimScript:
 
 ```vim
-set guifont=Source\ Code\ Pro:h14
+set guifont=Cascadia\ Code\ PL\ Light:h14
+set guifont=Cascadia_Code_PL_Light:h14
 ```
 
 Lua:
 
 ```lua
-vim.o.guifont = "Source Code Pro:h14" -- text below applies for VimScript
+vim.o.guifont = "Cascadia Code PL Light:h14" -- text below applies for VimScript
 ```
 
 Controls the font used by Neovide. Also check [the config file](./config-file.md) to see how to
@@ -54,6 +55,9 @@ as such it's also documented in `:h guifont`. But to sum it up and also add Neov
 - Fonts
   - are separated with `,` (commas).
   - can contain spaces by either escaping them or using `_` (underscores).
+  - the last word of a font name can contain below weight
+    - `Thin`, `ExtraLight`, `Light`, `Normal`, `Medium`, `SemiBold`, `Bold`,
+      `ExtraBold`, `Black`, `ExtraBlack`
 - Options
   - apply to all fonts at once.
   - are separated from the fonts and themselves through `:` (colons).


### PR DESCRIPTION
https://rust-skia.github.io/doc/skia_safe/type.FontMgr.html#method.family_names

FontMgr::family_names() get font names between Windows and Ubuntu differently

For Cascadia Code fonts,
on Windows will get 'Cascadia Code PL' ..., which does not contain font weight 
on Ubuntu   will get 'Cascadia Code PL Light' ..., which contains font weight 'Light'

This commit is a workaround to use `:set guifont=Cascadia_Code_PL_Light:h10`

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No
