### PR TITLE
chore: bump Neovide to 0.15.2, Neovide-derive to 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "neovide"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "approx",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "neovide-derive"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "convert_case",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neovide"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2021"
 build = "build.rs"
 resolver = "2"
@@ -63,7 +63,7 @@ image = { version = "0.25.5", default-features = false, features = ["ico"] }
 itertools = "0.14.0"
 log = "0.4.22"
 lru = "0.16.0"
-neovide-derive = { path = "neovide-derive", version = "0.1.3" }
+neovide-derive = { path = "neovide-derive", version = "0.1.4" }
 notify-debouncer-full = "0.6.0"
 num = "0.4.3"
 nvim-rs = { version = "0.9.2", features = ["use_tokio"] }
@@ -194,7 +194,7 @@ debug = true
 name = "Neovide"
 identifier = "com.neovide.neovide"
 icon = ["assets/neovide.ico"]
-version = "0.15.1"
+version = "0.15.2"
 resources = []
 copyright = "Copyright (c) Neovide Contributors 2025. All rights reserved."
 category = "Productivity"

--- a/extra/osx/Neovide.app/Contents/Info.plist
+++ b/extra/osx/Neovide.app/Contents/Info.plist
@@ -21,7 +21,7 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.15.1</string>
+  <string>0.15.2</string>
   <key>CFBundleVersion</key>
   <string>20230908.235224</string>
   <key>LSMinimumSystemVersion</key>

--- a/neovide-derive/Cargo.toml
+++ b/neovide-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neovide-derive"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT"
 description = "Derive macros for the Neovide gui"


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
Prepare for the 0.15.2 release by bumping Neovide to 0.15.2 and Neovide-derive to 0.1.4

## Did this PR introduce a breaking change? 
- No
