### PR TITLE
chore: Change fontloader Arc to Rc

### DIFF
--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -1,4 +1,4 @@
-use std::{num::NonZeroUsize, sync::Arc};
+use std::{num::NonZeroUsize, rc::Rc};
 
 use itertools::Itertools;
 use log::{debug, error, info, trace};
@@ -56,7 +56,7 @@ impl CachingShaper {
         shaper
     }
 
-    fn current_font_pair(&mut self) -> Arc<FontPair> {
+    fn current_font_pair(&mut self) -> Rc<FontPair> {
         self.font_loader
             .get_or_load(&FontKey {
                 font_desc: self.options.primary_font(),
@@ -237,7 +237,7 @@ impl CachingShaper {
         &mut self,
         text: &str,
         style: CoarseStyle,
-    ) -> Vec<(Vec<CharCluster>, Arc<FontPair>)> {
+    ) -> Vec<(Vec<CharCluster>, Rc<FontPair>)> {
         let mut cluster = CharCluster::new();
 
         // Enumerate the characters storing the glyph index in the user data so that we can position

--- a/src/renderer/fonts/font_loader.rs
+++ b/src/renderer/fonts/font_loader.rs
@@ -1,7 +1,7 @@
 use std::{
     fmt::{Display, Formatter},
     num::NonZeroUsize,
-    sync::Arc,
+    rc::Rc,
 };
 
 use log::trace;
@@ -64,9 +64,9 @@ pub struct FontKey {
 
 pub struct FontLoader {
     font_mgr: FontMgr,
-    cache: LruCache<FontKey, Arc<FontPair>>,
+    cache: LruCache<FontKey, Rc<FontPair>>,
     font_size: f32,
-    last_resort: Option<Arc<FontPair>>,
+    last_resort: Option<Rc<FontPair>>,
 }
 
 impl Display for FontKey {
@@ -103,23 +103,23 @@ impl FontLoader {
         }
     }
 
-    pub fn get_or_load(&mut self, font_key: &FontKey) -> Option<Arc<FontPair>> {
+    pub fn get_or_load(&mut self, font_key: &FontKey) -> Option<Rc<FontPair>> {
         if let Some(cached) = self.cache.get(font_key) {
             return Some(cached.clone());
         }
 
         let loaded_font = self.load(font_key.clone())?;
-        let font_arc = Arc::new(loaded_font);
-        self.cache.put(font_key.clone(), font_arc.clone());
+        let font_rc = Rc::new(loaded_font);
+        self.cache.put(font_key.clone(), font_rc.clone());
 
-        Some(font_arc)
+        Some(font_rc)
     }
 
     pub fn load_font_for_character(
         &mut self,
         coarse_style: CoarseStyle,
         character: char,
-    ) -> Option<Arc<FontPair>> {
+    ) -> Option<Rc<FontPair>> {
         let font_style = coarse_style.into();
         let typeface =
             self.font_mgr
@@ -134,7 +134,7 @@ impl FontLoader {
             edging: FontEdging::default(),
         };
 
-        let font_pair = Arc::new(FontPair::new(
+        let font_pair = Rc::new(FontPair::new(
             font_key.clone(),
             Font::from_typeface(typeface, self.font_size),
         )?);
@@ -144,7 +144,7 @@ impl FontLoader {
         Some(font_pair)
     }
 
-    pub fn get_or_load_last_resort(&mut self) -> Option<Arc<FontPair>> {
+    pub fn get_or_load_last_resort(&mut self) -> Option<Rc<FontPair>> {
         if self.last_resort.is_some() {
             self.last_resort.clone()
         } else {
@@ -152,7 +152,7 @@ impl FontLoader {
             let data = Data::new_copy(LAST_RESORT_FONT);
 
             let typeface = self.font_mgr.new_from_data(&data, 0)?;
-            let font_pair = Arc::new(FontPair::new(
+            let font_pair = Rc::new(FontPair::new(
                 font_key,
                 Font::from_typeface(typeface, self.font_size),
             )?);
@@ -162,7 +162,7 @@ impl FontLoader {
         }
     }
 
-    pub fn loaded_fonts(&self) -> Vec<Arc<FontPair>> {
+    pub fn loaded_fonts(&self) -> Vec<Rc<FontPair>> {
         self.cache.iter().map(|(_, v)| v.clone()).collect()
     }
 

--- a/src/renderer/profiler.rs
+++ b/src/renderer/profiler.rs
@@ -1,5 +1,5 @@
 use std::collections::VecDeque;
-use std::sync::Arc;
+use std::{rc::Rc, sync::Arc};
 
 use crate::{
     profiling::tracy_zone,
@@ -11,7 +11,7 @@ use skia_safe::{Canvas, Color, Paint, Point, Rect, Size};
 const FRAMETIMES_COUNT: usize = 48;
 
 pub struct Profiler {
-    pub font: Arc<FontPair>,
+    pub font: Rc<FontPair>,
     pub position: Point,
     pub size: Size,
     pub frametimes: VecDeque<f32>,


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
The fontloader doesn't need to use `Arc`, `Rc` is enough.

## Did this PR introduce a breaking change? 
- No
