### PR TITLE
feat: handling a custom icon path if provided

### DIFF
--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -141,6 +141,10 @@ pub struct CmdLineSettings {
     )]
     pub x11_wm_class_instance: String,
 
+    /// The custom icon to use for the app.
+    #[arg(long)]
+    pub icon: Option<String>,
+
     #[command(flatten)]
     pub geometry: GeometryArgs,
 

--- a/src/window/error_window.rs
+++ b/src/window/error_window.rs
@@ -22,7 +22,7 @@ use winit::{
 
 use crate::{
     clipboard,
-    cmd_line::SRGB_DEFAULT,
+    cmd_line::{CmdLineSettings, SRGB_DEFAULT},
     renderer::{build_window_config, create_skia_renderer, SkiaRenderer, WindowConfig},
     settings::Settings,
     window::{load_icon, UserEvent},
@@ -490,7 +490,8 @@ fn create_paragraphs(
 }
 
 fn create_window(event_loop: &ActiveEventLoop, settings: &Settings) -> WindowConfig {
-    let icon = load_icon();
+    let cmd_line_settings = settings.get::<CmdLineSettings>();
+    let icon = load_icon(cmd_line_settings.icon.as_ref());
 
     let window_attributes = Window::default_attributes()
         .with_title("Neovide")

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -38,6 +38,8 @@ use winit::platform::macos::EventLoopBuilderExtMacOS;
 use image::{load_from_memory, GenericImageView, Pixel};
 use keyboard_manager::KeyboardManager;
 use mouse_manager::MouseManager;
+use std::fs::File;
+use std::io::Read;
 
 use crate::{
     cmd_line::{CmdLineSettings, GeometryArgs},
@@ -55,7 +57,7 @@ pub use update_loop::ShouldRender;
 pub use update_loop::UpdateLoop;
 pub use window_wrapper::WinitWindowWrapper;
 
-static ICON: &[u8] = include_bytes!("../../assets/neovide.ico");
+static DEFAULT_ICON: &[u8] = include_bytes!("../../assets/neovide.ico");
 
 const DEFAULT_WINDOW_SIZE: PhysicalSize<u32> = PhysicalSize {
     width: 500,
@@ -137,9 +139,8 @@ pub fn create_window(
     title: &str,
     settings: &Settings,
 ) -> WindowConfig {
-    let icon = load_icon();
-
     let cmd_line_settings = settings.get::<CmdLineSettings>();
+    let icon = load_icon(cmd_line_settings.icon.as_ref());
 
     let window_settings = load_last_window_settings().ok();
 
@@ -289,8 +290,21 @@ pub fn determine_window_size(
     }
 }
 
-pub fn load_icon() -> Icon {
-    let icon = load_from_memory(ICON).expect("Failed to parse icon data");
+pub fn load_icon(path: Option<&String>) -> Icon {
+    let icon_result = path
+        .and_then(|path| {
+            let mut file = File::open(path).ok()?;
+            let mut data = Vec::new();
+            file.read_to_end(&mut data).ok()?;
+            Some(data)
+        })
+        .map(|data| load_from_memory(&data));
+
+    let icon = match icon_result {
+        Some(Ok(icon)) => icon,
+        _ => load_from_memory(DEFAULT_ICON).expect("Failed to parse icon data"),
+    };
+
     let (width, height) = icon.dimensions();
     let mut rgba = Vec::with_capacity((width * height) as usize * 4);
     for (_, _, pixel) in icon.pixels() {

--- a/website/docs/command-line-reference.md
+++ b/website/docs/command-line-reference.md
@@ -160,6 +160,16 @@ to its generalistic purpose.
 
 This sets the window title to be hidden on macOS.
 
+### Application Icon
+
+```sh
+--icon <path>
+```
+
+**Unreleased yet.**
+
+This sets a custom application icon.
+
 ### sRGB
 
 ```sh


### PR DESCRIPTION
This should address some user [complaints](https://github.com/neovide/neovide/issues/2929) about previous support of custom icons when we tried to fix the console default process icon in general.

It's better to free users to customize it using their favorite neovide custom icon if they wish providing an option.