### PR TITLE
feat: include a new icon field in the configuration file

### DIFF
--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -142,7 +142,7 @@ pub struct CmdLineSettings {
     pub x11_wm_class_instance: String,
 
     /// The custom icon to use for the app.
-    #[arg(long)]
+    #[arg(long, env = "NEOVIDE_ICON")]
     pub icon: Option<String>,
 
     #[command(flatten)]

--- a/src/settings/config.rs
+++ b/src/settings/config.rs
@@ -59,6 +59,7 @@ pub struct Config {
     pub vsync: Option<bool>,
     pub wsl: Option<bool>,
     pub backtraces_path: Option<PathBuf>,
+    pub icon: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -120,6 +121,9 @@ impl Config {
         }
         if let Some(tabs) = &self.tabs {
             env::set_var("NEOVIDE_TABS", tabs.to_string());
+        }
+        if let Some(icon) = &self.icon {
+            env::set_var("NEOVIDE_ICON", icon);
         }
     }
 

--- a/website/docs/command-line-reference.md
+++ b/website/docs/command-line-reference.md
@@ -168,7 +168,7 @@ This sets the window title to be hidden on macOS.
 
 **Unreleased yet.**
 
-This sets a custom application icon.
+This sets a custom application icon. A default icon is bundled with Neovide.
 
 ### sRGB
 

--- a/website/docs/config-file.md
+++ b/website/docs/config-file.md
@@ -33,6 +33,7 @@ backtraces_path = "/path/to/neovide_backtraces.log" # see below for the default 
 fork = false
 frame = "full"
 idle = true
+icon = "/full/path/to/neovide.ico" # Example path. Default icon is bundled. Use .icns on macOS.
 maximized = false
 mouse-cursor-icon = "arrow"
 neovim-bin = "/usr/bin/nvim" # in reality found dynamically on $PATH if unset


### PR DESCRIPTION
Upon discussion at https://github.com/neovide/neovide/pull/3272 some ideas has been made like creating and prioritizing within neovim itself an option in lua, so let's bring the config option first and discuss here to support or not other ways to load icons if needed.