### PR TITLE
feat: add :NeovideConfig command to open the config file

### DIFF
--- a/lua/init.lua
+++ b/lua/init.lua
@@ -1,8 +1,10 @@
 ---@class Args
 ---@field neovide_channel_id integer
 ---@field neovide_version string
+---@field config_path string
 ---@field register_clipboard boolean
 ---@field register_right_click boolean
+---@field remote boolean
 ---@field enable_focus_command boolean
 ---@field global_variable_settings string[]
 ---@field option_settings string[]
@@ -146,5 +148,22 @@ M.enable_redraw = function()
     -- Wrap inside pcall to avoid errors if Neovide disconnects
     pcall(rpcnotify, "neovide.set_redraw", true)
 end
+
+vim.api.nvim_create_user_command("NeovideConfig", function()
+    if args.remote then
+        if vim.fn.filereadable(args.config_path) ~= 0 then
+            vim.notify(
+                "Neovide is running as a remote server. So the config file may not be on this machine.\n"
+                .. "Open it manually if you intend to edit the file anyway.\n"
+                .. "Config file location: "
+                .. args.config_path,
+                vim.log.levels.WARN,
+                { title = "Neovide" }
+            )
+        end
+    else
+        vim.cmd('edit ' .. vim.fn.fnameescape(args.config_path))
+    end
+end, {})
 
 _G["neovide"] = M

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -113,7 +113,6 @@ async fn launch(
     settings: Arc<Settings>,
 ) -> Result<NeovimSession> {
     let neovim_instance = neovim_instance(settings.as_ref()).await?;
-
     #[allow(unused_mut)]
     let mut session = NeovimSession::new(neovim_instance, handler)
         .await
@@ -136,16 +135,10 @@ async fn launch(
 
     let cmdline_settings = settings.get::<CmdLineSettings>();
 
-    let should_handle_clipboard = cmdline_settings.wsl || cmdline_settings.server.is_some();
+    let remote = cmdline_settings.wsl || cmdline_settings.server.is_some();
     // This is too verbose to keep enabled all the time
     // log::info!("Api information {:#?}", api_information);
-    setup_neovide_specific_state(
-        &session.neovim,
-        should_handle_clipboard,
-        &api_information,
-        &settings,
-    )
-    .await?;
+    setup_neovide_specific_state(&session.neovim, remote, &api_information, &settings).await?;
     if api_information.version.has_version(0, 12, 0, Some(1264)) {
         let mut window_settings = settings.get::<WindowSettings>();
         window_settings.has_mouse_grid_detection = true;

--- a/src/bridge/setup.rs
+++ b/src/bridge/setup.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::{
     bridge::NeovimWriter,
-    settings::{SettingLocation, Settings},
+    settings::{config::config_path, SettingLocation, Settings},
 };
 
 const INIT_LUA: &str = include_str!("../../lua/init.lua");
@@ -28,7 +28,7 @@ pub async fn get_api_information(nvim: &Neovim<NeovimWriter>) -> Result<ApiInfor
 
 pub async fn setup_neovide_specific_state(
     nvim: &Neovim<NeovimWriter>,
-    should_handle_clipboard: bool,
+    remote: bool,
     api_information: &ApiInformation,
     settings: &Settings,
 ) -> Result<()> {
@@ -56,7 +56,7 @@ pub async fn setup_neovide_specific_state(
     .await
     .context("Error setting client info")?;
 
-    let register_clipboard = should_handle_clipboard;
+    let register_clipboard = remote;
     let register_right_click = cfg!(target_os = "windows");
 
     let setting_locations = settings.setting_locations();
@@ -80,8 +80,10 @@ pub async fn setup_neovide_specific_state(
         call_args![nvim_dict! {
             "neovide_channel_id" => api_information.channel,
             "neovide_version" => crate_version!(),
+            "config_path" => config_path().to_string_lossy().into_owned(),
             "register_clipboard" => register_clipboard,
             "register_right_click" => register_right_click,
+            "remote" => remote,
             "global_variable_settings" => global_variable_settings,
             "option_settings" => option_settings,
         }],

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -22,7 +22,7 @@ pub use window_size::{
     PersistentWindowSettings, DEFAULT_GRID_SIZE, MIN_GRID_SIZE,
 };
 
-mod config;
+pub mod config;
 pub use config::{Config, HotReloadConfigs};
 
 pub trait SettingGroup {

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -18,3 +18,10 @@ window containing Neovide to the front and activate it. This
 is useful for tools like neovim_remote which can manipulate
 neovim remotely or if long running tasks would like to
 activate the Neovide window after finishing.
+
+## Open Config File (Unreleased yet)
+
+Running the `NeovideConfig` command will open your Neovide
+configuration file for editing. This provides a simple and
+discoverable way to access your settings without needing to
+know the platform-specific path to the file.


### PR DESCRIPTION
Currently, editing the configuration file requires users to know and **find** or **create** the specific file path for their operating system

- $XDG_CONFIG_HOME/neovide/config.toml
- ~/Library/Application Support/neovide/config.toml
- etc. 

This can be inconvenient and requires looking up documentation, especially for new users.

Just for practical and convenience reasons adding `:NeovideConfig` command, that directly opens the `config.toml` file for editing within the running Neovide instance would be really cool to have.


https://github.com/neoclide/coc.nvim has inspired this feature.