### PR TITLE
feat: add animated progress bar with nvim_echo event support

### DIFF
--- a/lua/init.lua
+++ b/lua/init.lua
@@ -166,4 +166,25 @@ vim.api.nvim_create_user_command("NeovideConfig", function()
     end
 end, {})
 
+local function progress_bar(data)
+    -- Wrap inside pcall to avoid errors if Neovide disconnects.
+    pcall(rpcnotify, "neovide.progress_bar", data)
+end
+
+pcall(vim.api.nvim_create_autocmd, 'Progress', {
+    group = vim.api.nvim_create_augroup('NeovideProgressBar', { clear = true }),
+    desc = 'Forward progress events to Neovide',
+    callback = function(ev)
+        if ev.data and ev.data.status == 'running' then
+            progress_bar({
+                percent = ev.data.percent or 0,
+                title = ev.data.title or "",
+                message = ev.data.message or "",
+            })
+        else
+            progress_bar({ percent = 100 })
+        end
+    end,
+})
+
 _G["neovide"] = M

--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -9,7 +9,10 @@ use rmpv::Value;
 use skia_safe::Color4f;
 use strum::AsRefStr;
 
-use crate::editor::{Colors, CursorMode, CursorShape, Style, UnderlineStyle};
+use crate::{
+    editor::{Colors, CursorMode, CursorShape, Style, UnderlineStyle},
+    window::UserEvent,
+};
 
 #[derive(Clone, Debug)]
 pub enum ParseError {
@@ -1062,4 +1065,15 @@ pub fn parse_redraw_event(event_value: Value) -> Result<Vec<RedrawEvent>> {
     }
 
     Ok(parsed_events)
+}
+
+pub fn parse_progress_bar_event(value: Option<&Value>) -> Option<UserEvent> {
+    let map = value.filter(|v| matches!(v, Value::Map(_)))?.as_map()?;
+    let percent = map
+        .iter()
+        .find(|(key, _)| key.as_str() == Some("percent"))
+        .and_then(|(_, value)| value.as_f64())
+        .unwrap_or(0.0) as f32;
+
+    Some(UserEvent::ShowProgressBar { percent })
 }

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -11,7 +11,7 @@ use crate::{
     bridge::{
         clipboard::{get_clipboard_contents, set_clipboard_contents},
         events::parse_redraw_event,
-        send_ui, NeovimWriter, ParallelCommand, RedrawEvent,
+        parse_progress_bar_event, send_ui, NeovimWriter, ParallelCommand, RedrawEvent,
     },
     error_handling::ResultPanicExplanation,
     running_tracker::RunningTracker,
@@ -133,6 +133,18 @@ impl Handler for NeovimHandler {
                     let value = value.as_bool().unwrap_or(true);
                     let _ = self.sender.send(RedrawEvent::NeovideSetRedraw(value));
                 }
+            }
+            "neovide.progress_bar" => {
+                parse_progress_bar_event(arguments.first())
+                    .map(|event| {
+                        let _ = self.proxy.lock().unwrap().send_event(event);
+                    })
+                    .unwrap_or_else(|| {
+                        log::info!(
+                            "Failed to parse neovide.progress_bar event data: {:?}",
+                            arguments
+                        );
+                    });
             }
             _ => {}
         }

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -225,7 +225,6 @@ impl ParallelCommand {
             ParallelCommand::DisplayAvailableFonts(fonts) => display_available_fonts(nvim, fonts)
                 .await
                 .context("DisplayAvailableFonts failed"),
-
             ParallelCommand::ShowError { lines } => {
                 // nvim.err_write(&message).await.ok();
                 // NOTE: https://github.com/neovim/neovim/issues/5067

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,9 @@ use backtrace::Backtrace;
 use bridge::NeovimRuntime;
 use cmd_line::CmdLineSettings;
 use error_handling::handle_startup_errors;
-use renderer::{cursor_renderer::CursorSettings, RendererSettings};
+use renderer::{
+    cursor_renderer::CursorSettings, progress_bar::ProgressBarSettings, RendererSettings,
+};
 use running_tracker::RunningTracker;
 use window::{
     create_event_loop, determine_window_size, UpdateLoop, UserEvent, WindowSettings, WindowSize,
@@ -215,6 +217,7 @@ fn setup(
     settings.register::<WindowSettings>();
     settings.register::<RendererSettings>();
     settings.register::<CursorSettings>();
+    settings.register::<ProgressBarSettings>();
 
     let config = Config::init();
     Config::watch_config_file(config.clone(), proxy.clone());

--- a/src/renderer/progress_bar.rs
+++ b/src/renderer/progress_bar.rs
@@ -1,0 +1,114 @@
+use std::time::Instant;
+
+use crate::{renderer::GridRenderer, settings::ParseFromValue};
+use neovide_derive::SettingGroup;
+use skia_safe::{Canvas, Color4f, Paint, Rect};
+
+#[derive(Clone, SettingGroup)]
+#[setting_prefix = "progress_bar"]
+pub struct ProgressBarSettings {
+    pub enabled: bool,
+    pub height: f32,
+    pub animation_speed: f32,
+    pub hide_delay: f32,
+}
+
+impl Default for ProgressBarSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            height: 3.0,
+            animation_speed: 100.0,
+            hide_delay: 0.5,
+        }
+    }
+}
+
+enum ProgressBarState {
+    Idle,
+    Animating,
+    Completing { completion_time: Instant },
+}
+
+pub struct ProgressBar {
+    current_percent: f32,
+    target_percent: f32,
+    state: ProgressBarState,
+}
+
+impl ProgressBar {
+    pub fn new() -> Self {
+        Self {
+            current_percent: 0.0,
+            target_percent: 0.0,
+            state: ProgressBarState::Idle,
+        }
+    }
+
+    pub fn is_animating(&self) -> bool {
+        !matches!(self.state, ProgressBarState::Idle)
+    }
+
+    pub fn start(&mut self, percent: f32) {
+        self.target_percent = percent.clamp(0.0, 100.0);
+        if self.target_percent < self.current_percent {
+            self.current_percent = self.target_percent;
+        }
+        self.state = ProgressBarState::Animating;
+    }
+
+    pub fn animate(&mut self, settings: &ProgressBarSettings, dt: f32) {
+        match &self.state {
+            ProgressBarState::Idle => {}
+            ProgressBarState::Animating => {
+                if self.current_percent < self.target_percent {
+                    self.current_percent += settings.animation_speed * dt;
+                    // here we clamp to the target to prevent overshooting.
+                    self.current_percent = self.current_percent.min(self.target_percent);
+                }
+                if self.current_percent >= 100.0 {
+                    self.state = ProgressBarState::Completing {
+                        completion_time: Instant::now(),
+                    };
+                }
+            }
+            ProgressBarState::Completing { completion_time } => {
+                if completion_time.elapsed().as_secs_f32() > settings.hide_delay {
+                    self.state = ProgressBarState::Idle;
+                    // Reset percents for next time
+                    self.current_percent = 0.0;
+                    self.target_percent = 0.0;
+                }
+            }
+        }
+    }
+
+    pub fn draw(
+        &self,
+        settings: &ProgressBarSettings,
+        canvas: &Canvas,
+        grid_renderer: &GridRenderer,
+        grid_size: crate::units::GridSize<u32>,
+    ) {
+        if !self.is_animating() || !settings.enabled {
+            return;
+        }
+
+        let width = grid_size.width as f32 * grid_renderer.grid_scale.width();
+        let height = settings.height;
+        let x = 0.0;
+        let y = 0.0;
+        let foreground_color = grid_renderer
+            .default_style
+            .colors
+            .foreground
+            .unwrap()
+            .to_color();
+
+        let mut paint = Paint::new(Color4f::from(foreground_color), None);
+        paint.set_anti_alias(true);
+
+        let rect = Rect::from_xywh(x, y, width * (self.current_percent / 100.0), height);
+        canvas.draw_rect(rect, &paint);
+    }
+}

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -189,6 +189,7 @@ pub enum SettingsChanged {
     Window(crate::window::WindowSettingsChanged),
     Cursor(crate::renderer::cursor_renderer::CursorSettingsChanged),
     Renderer(crate::renderer::RendererSettingsChanged),
+    ProgressBar(crate::renderer::progress_bar::ProgressBarSettingsChanged),
     #[cfg(test)]
     Test(tests::TestSettingsChanged),
 }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -96,6 +96,9 @@ pub enum UserEvent {
     #[allow(dead_code)]
     RedrawRequested,
     NeovimExited,
+    ShowProgressBar {
+        percent: f32,
+    },
 }
 
 impl From<Vec<DrawCommand>> for UserEvent {

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -432,6 +432,9 @@ impl WinitWindowWrapper {
             UserEvent::ConfigsChanged(config) => {
                 self.handle_config_changed(*config);
             }
+            UserEvent::ShowProgressBar { percent, .. } => {
+                self.renderer.progress_bar.start(percent);
+            }
             _ => {}
         }
     }

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -447,6 +447,34 @@ When scrolling more than one screen at a time, only this many lines at the end o
 will be animated. Set it to 0 to snap to the final position without any animation, or to something
 big like 9999 to always scroll the whole screen, much like Neovide <= 0.10.4 did.
 
+#### Progress Bar
+
+VimScript:
+
+```vim
+let g:neovide_progress_bar_enabled = v:true
+let g:neovide_progress_bar_height = 5.0
+let g:neovide_progress_bar_animation_speed = 200.0
+let g:neovide_progress_bar_hide_delay = 0.2
+```
+
+Lua:
+
+```lua
+vim.g.neovide_progress_bar_enabled = true
+vim.g.neovide_progress_bar_height = 5.0
+vim.g.neovide_progress_bar_animation_speed = 200.0
+vim.g.neovide_progress_bar_hide_delay = 0.2
+```
+
+**Unreleased yet.**
+
+- `g:neovide_progress_bar_enabled` sets whether the progress bar is enabled.
+- `g:neovide_progress_bar_height` sets the height of the progress bar in pixels.
+- `g:neovide_progress_bar_animation_speed` sets the speed of the progress bar animation.
+- `g:neovide_progress_bar_hide_delay` sets the delay in seconds before the progress bar is
+  hidden after reaching 100%.
+
 #### Hiding the mouse when typing
 
 VimScript:


### PR DESCRIPTION
introduces an animated progress bar to provide visual feedback for long-running background tasks by hooking into the native vim.api.nvim_echo fn for progress events, this feature works out-of-the-box.

inspired from https://github.com/neovim/neovim/pull/34846 https://github.com/neovim/neovim/pull/35973

https://github.com/user-attachments/assets/2ae0b06d-71d5-4141-8aaa-ea2fb75d042b


real use-case show-off.

https://github.com/user-attachments/assets/bf3099fa-31bb-498a-9ec4-58a8dadef772


the following new settings can customize the appearance and behavior of the progress bar. 
```
vim.g.neovide_progress_bar_enabled = true
vim.g.neovide_progress_bar_height = 5.0
vim.g.neovide_progress_bar_animation_speed = 150.0
vim.g.neovide_progress_bar_hide_delay = 1.0

``` 


