### PR TITLE
ci: automate nightly cross-platform nightly-release builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,6 +9,8 @@ jobs:
   create_release:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:


### PR DESCRIPTION
- add a github actions workflow to build and publish nightly pre-release builds for windows, macos, and linux
- automate cross-platform builds, packaging, and upload of release assets for each os
- ensure nightly releases are overwritten, and published as drafts before final release
- include steps for installing build toolchains and platform-specific dependencies
- support workflow scheduling via cron and manual dispatch<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->
