### PR TITLE
ci: fix and limit mac deployment steps to main branch only

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -133,19 +133,19 @@ jobs:
           GENERATE_BUNDLE_APP=true GENERATE_DMG=false ./macos-builder/run x86_64-apple-darwin
 
       - name: Write Apple signing key to a file (macOS only)
-        if: matrix.os == 'macos-latest' && secrets.APPLE_SIGNING_KEY_P12 != ''
+        if: matrix.os == 'macos-latest' && github.ref == 'refs/heads/main'
         env:
           APPLE_SIGNING_KEY_P12: ${{ secrets.APPLE_SIGNING_KEY_P12 }}
         run: echo "$APPLE_SIGNING_KEY_P12" | base64 -d -o key.p12
 
       - name: Write App Store Connect API key to a file (macOS only)
-        if: matrix.os == 'macos-latest' && secrets.APP_STORE_CONNECT_API_KEY != ''
+        if: matrix.os == 'macos-latest' && github.ref == 'refs/heads/main'
         env:
           APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
         run: echo "$APP_STORE_CONNECT_API_KEY" > app_store_connect_api_key.json
 
       - name: Sign Mac App binary root (aarch64-apple-darwin)
-        if: matrix.os == 'macos-latest' && secrets.APPLE_SIGNING_KEY_P12 != ''
+        if: matrix.os == 'macos-latest' && github.ref == 'refs/heads/main'
         uses: indygreg/apple-code-sign-action@v1
         with:
           input_path: target/aarch64-apple-darwin/release/neovide
@@ -155,7 +155,7 @@ jobs:
           sign_args: "--code-signature-flags=runtime"
 
       - name: Sign Mac App binary (aarch64-apple-darwin)
-        if: matrix.os == 'macos-latest' && secrets.APPLE_SIGNING_KEY_P12 != ''
+        if: matrix.os == 'macos-latest' && github.ref == 'refs/heads/main'
         uses: indygreg/apple-code-sign-action@v1
         with:
           input_path: target/aarch64-apple-darwin/release/bundle/osx/Neovide.app/Contents/MacOS/neovide
@@ -165,7 +165,7 @@ jobs:
           sign_args: "--code-signature-flags=runtime"
 
       - name: Sign Mac App .app (aarch64-apple-darwin)
-        if: matrix.os == 'macos-latest' && secrets.APPLE_SIGNING_KEY_P12 != ''
+        if: matrix.os == 'macos-latest' && github.ref == 'refs/heads/main'
         uses: indygreg/apple-code-sign-action@v1
         with:
           input_path: target/aarch64-apple-darwin/release/bundle/osx/Neovide.app
@@ -175,7 +175,7 @@ jobs:
           sign_args: "--code-signature-flags=runtime"
 
       - name: Sign Mac App binary root (x86_64-apple-darwin)
-        if: matrix.os == 'macos-latest' && secrets.APPLE_SIGNING_KEY_P12 != ''
+        if: matrix.os == 'macos-latest' && github.ref == 'refs/heads/main'
         uses: indygreg/apple-code-sign-action@v1
         with:
           input_path: target/x86_64-apple-darwin/release/neovide
@@ -185,7 +185,7 @@ jobs:
           sign_args: "--code-signature-flags=runtime"
 
       - name: Sign Mac App binary (x86_64-apple-darwin)
-        if: matrix.os == 'macos-latest' && secrets.APPLE_SIGNING_KEY_P12 != ''
+        if: matrix.os == 'macos-latest' && github.ref == 'refs/heads/main'
         uses: indygreg/apple-code-sign-action@v1
         with:
           input_path: target/x86_64-apple-darwin/release/bundle/osx/Neovide.app/Contents/MacOS/neovide
@@ -195,7 +195,7 @@ jobs:
           sign_args: "--code-signature-flags=runtime"
 
       - name: Sign Mac App .app (x86_64-apple-darwin)
-        if: matrix.os == 'macos-latest' && secrets.APPLE_SIGNING_KEY_P12 != ''
+        if: matrix.os == 'macos-latest' && github.ref == 'refs/heads/main'
         uses: indygreg/apple-code-sign-action@v1
         with:
           input_path: target/x86_64-apple-darwin/release/bundle/osx/Neovide.app


### PR DESCRIPTION
restrict mac code signing and app store connect key steps to run only on the main branch.