### PR TITLE
feat: inject and manage sponsor banner in neovim intro message

### DIFF
--- a/lua/init.lua
+++ b/lua/init.lua
@@ -171,6 +171,93 @@ local function progress_bar(data)
     pcall(rpcnotify, "neovide.progress_bar", data)
 end
 
+local function buffer_is_empty(bufnr)
+    if vim.api.nvim_buf_line_count(bufnr) ~= 1 then
+        return false
+    end
+    local first_line = vim.api.nvim_buf_get_lines(bufnr, 0, 1, true)[1]
+    return first_line == nil or first_line == ""
+end
+
+local function current_window_is_only_normal()
+    local current = vim.api.nvim_get_current_win()
+    local found
+    for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+        local config = vim.api.nvim_win_get_config(win)
+        if config.relative == "" then
+            if found ~= nil then
+                return false
+            end
+            found = win
+        end
+    end
+    return found ~= nil and found == current
+end
+
+local function shortmess_allows_intro()
+    return not string.find(vim.o.shortmess or "", "I", 1, true)
+end
+
+local function should_show_intro_banner()
+    local current_buffer = vim.api.nvim_get_current_buf()
+    local buffer_name = vim.api.nvim_buf_get_name(current_buffer)
+    local current_window = vim.api.nvim_get_current_win()
+
+    return buffer_is_empty(current_buffer)
+        and buffer_name == ""
+        and current_buffer == 1
+        and current_window == 1000
+        and current_window_is_only_normal()
+        and shortmess_allows_intro()
+end
+
+local intro_banner_state
+
+local function notify_intro_state()
+    local allowed = false
+    local ok, result = pcall(should_show_intro_banner)
+    if ok then
+        allowed = result
+    end
+
+    if intro_banner_state ~= allowed then
+        intro_banner_state = allowed
+        pcall(rpcnotify, "neovide.intro_banner_allowed", allowed)
+    end
+end
+
+local function schedule_intro_state_check()
+    vim.schedule(notify_intro_state)
+end
+
+local intro_group = vim.api.nvim_create_augroup("NeovideIntroBanner", { clear = true })
+
+vim.api.nvim_create_autocmd({
+    "VimEnter",
+    "BufEnter",
+    "BufFilePost",
+    "BufNewFile",
+    "BufReadPost",
+    "TextChanged",
+    "TextChangedI",
+    "WinEnter",
+    "WinNew",
+    "WinClosed",
+    "TabEnter",
+    "TabClosed",
+}, {
+    group = intro_group,
+    callback = schedule_intro_state_check,
+})
+
+vim.api.nvim_create_autocmd("OptionSet", {
+    group = intro_group,
+    pattern = "shortmess",
+    callback = schedule_intro_state_check,
+})
+
+notify_intro_state()
+
 pcall(vim.api.nvim_create_autocmd, 'Progress', {
     group = vim.api.nvim_create_augroup('NeovideProgressBar', { clear = true }),
     desc = 'Forward progress events to Neovide',

--- a/src/bridge/events.rs
+++ b/src/bridge/events.rs
@@ -419,6 +419,7 @@ pub enum RedrawEvent {
     },
     Suspend,
     NeovideSetRedraw(bool),
+    NeovideIntroBannerAllowed(bool),
 }
 
 fn unpack_color(packed_color: u64) -> Color4f {

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -134,6 +134,15 @@ impl Handler for NeovimHandler {
                     let _ = self.sender.send(RedrawEvent::NeovideSetRedraw(value));
                 }
             }
+            "neovide.intro_banner_allowed" => {
+                if let Some(value) = arguments.first() {
+                    if let Some(allowed) = value.as_bool() {
+                        let _ = self
+                            .sender
+                            .send(RedrawEvent::NeovideIntroBannerAllowed(allowed));
+                    }
+                }
+            }
             "neovide.progress_bar" => {
                 parse_progress_bar_event(arguments.first())
                     .map(|event| {

--- a/src/editor/intro.rs
+++ b/src/editor/intro.rs
@@ -1,0 +1,215 @@
+use std::collections::HashMap;
+
+use crate::bridge::GridLineCell;
+
+use super::{window::Window, DrawCommandBatcher};
+
+const INTRO_HEADER_PREFIX: &str = "NVIM ";
+const INTRO_FINAL_LINE: &str = "type  :help Kuwasha<Enter>    for information";
+const SPONSOR_MESSAGE_LINES: &[&str] =
+    &["", "Sponsor Neovide: https://github.com/sponsors/neovide"];
+
+#[derive(Default)]
+pub(crate) struct IntroMessageExtender {
+    per_grid: HashMap<u64, IntroState>,
+    sponsor_allowed: bool,
+}
+
+#[derive(Default)]
+struct IntroState {
+    saw_intro_header: bool,
+    banner_start_row: Option<u64>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum IntroProcessing {
+    Skip,
+    Process,
+    ClearBanner,
+}
+
+#[derive(Clone, Copy)]
+enum IntroLineKind {
+    Blank,
+    Filler,
+    HeaderCandidate,
+    Other,
+}
+
+impl IntroState {
+    fn mark_intro_possible(&mut self) {
+        self.saw_intro_header = true;
+    }
+
+    fn remember_injection(&mut self, row: u64) {
+        self.saw_intro_header = false;
+        self.banner_start_row = Some(row);
+    }
+
+    fn has_visible_banner(&self) -> bool {
+        self.banner_start_row.is_some()
+    }
+
+    fn take_banner_start_row(&mut self) -> Option<u64> {
+        self.banner_start_row.take()
+    }
+}
+
+impl IntroMessageExtender {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn reset(&mut self, grid: u64) {
+        self.per_grid.remove(&grid);
+    }
+
+    pub(crate) fn preprocess_line(&mut self, grid: u64, cells: &[GridLineCell]) -> IntroProcessing {
+        let state = self.per_grid.entry(grid).or_default();
+
+        if state.saw_intro_header {
+            return IntroProcessing::Process;
+        }
+
+        if state.has_visible_banner() {
+            return IntroProcessing::ClearBanner;
+        }
+
+        match classify_intro_line_start(cells) {
+            IntroLineKind::Blank | IntroLineKind::Filler => IntroProcessing::Skip,
+            IntroLineKind::HeaderCandidate => IntroProcessing::Process,
+            IntroLineKind::Other => IntroProcessing::Skip,
+        }
+    }
+
+    pub(crate) fn banner_injection_row(
+        &mut self,
+        grid: u64,
+        row: u64,
+        line_text: &str,
+    ) -> Option<u64> {
+        if !self.sponsor_allowed {
+            return None;
+        }
+
+        let state = self.per_grid.entry(grid).or_default();
+
+        if !state.saw_intro_header && !is_intro_header(line_text) {
+            return None;
+        } else if !state.saw_intro_header {
+            state.mark_intro_possible();
+        }
+
+        if !is_neovim_intro_final_line_text(line_text) {
+            return None;
+        }
+
+        if state.has_visible_banner() {
+            return None;
+        }
+
+        let sponsor_start_row = row + 1;
+        Some(sponsor_start_row)
+    }
+
+    pub(crate) fn inject_banner(
+        &mut self,
+        grid: u64,
+        window: &mut Window,
+        sponsor_start_row: u64,
+        batcher: &mut DrawCommandBatcher,
+    ) {
+        for (offset, line) in SPONSOR_MESSAGE_LINES.iter().enumerate() {
+            let target_row = sponsor_start_row + offset as u64;
+            if target_row >= window.get_height() {
+                break;
+            }
+
+            window.draw_centered_text_line(batcher, target_row as usize, line);
+        }
+
+        if let Some(state) = self.per_grid.get_mut(&grid) {
+            state.remember_injection(sponsor_start_row);
+        }
+    }
+
+    pub(crate) fn maybe_hide_banner(
+        &mut self,
+        grid: u64,
+        windows: &mut HashMap<u64, Window>,
+        batcher: &mut DrawCommandBatcher,
+    ) {
+        if let Some(state) = self.per_grid.get_mut(&grid) {
+            if let Some(start_row) = state.take_banner_start_row() {
+                if let Some(window) = windows.get_mut(&grid) {
+                    clear_banner_rows(window, start_row, batcher);
+                }
+            }
+        }
+    }
+
+    pub(crate) fn set_sponsor_allowed(
+        &mut self,
+        allowed: bool,
+        windows: &mut HashMap<u64, Window>,
+        batcher: &mut DrawCommandBatcher,
+    ) {
+        if self.sponsor_allowed == allowed {
+            return;
+        }
+
+        self.sponsor_allowed = allowed;
+        if !allowed {
+            let grids: Vec<u64> = self.per_grid.keys().copied().collect();
+            for grid in grids {
+                self.maybe_hide_banner(grid, windows, batcher);
+            }
+        }
+    }
+
+    pub(crate) fn sponsor_allowed(&self) -> bool {
+        self.sponsor_allowed
+    }
+}
+
+fn is_intro_header(text: &str) -> bool {
+    text.trim_start().starts_with(INTRO_HEADER_PREFIX)
+}
+
+fn is_neovim_intro_final_line_text(text: &str) -> bool {
+    text.trim() == INTRO_FINAL_LINE
+}
+
+fn classify_intro_line_start(cells: &[GridLineCell]) -> IntroLineKind {
+    match first_non_whitespace_char(cells) {
+        None => IntroLineKind::Blank,
+        Some('~') => IntroLineKind::Filler,
+        Some('N') => IntroLineKind::HeaderCandidate,
+        _ => IntroLineKind::Other,
+    }
+}
+
+fn first_non_whitespace_char(cells: &[GridLineCell]) -> Option<char> {
+    for cell in cells {
+        let repeat = cell.repeat.unwrap_or(1);
+        for _ in 0..repeat {
+            for ch in cell.text.chars() {
+                if ch.is_whitespace() {
+                    continue;
+                }
+                return Some(ch);
+            }
+        }
+    }
+    None
+}
+
+fn clear_banner_rows(window: &mut Window, start_row: u64, batcher: &mut DrawCommandBatcher) {
+    for offset in 0..SPONSOR_MESSAGE_LINES.len() {
+        let row = start_row + offset as u64;
+        if row >= window.get_height() {
+            break;
+        }
+        window.draw_centered_text_line(batcher, row as usize, "");
+    }
+}

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -385,6 +385,48 @@ impl Window {
         }
     }
 
+    pub fn draw_centered_text_line(
+        &mut self,
+        batcher: &mut DrawCommandBatcher,
+        row: usize,
+        text: &str,
+    ) {
+        if row >= self.grid.height {
+            return;
+        }
+
+        for column in 0..self.grid.width {
+            if let Some(cell) = self.grid.get_cell_mut(column, row) {
+                *cell = (" ".to_string(), None);
+            }
+        }
+
+        if text.is_empty() {
+            self.redraw_line(batcher, row);
+            return;
+        }
+
+        let text_width = text.chars().count();
+        let start_column = if text_width >= self.grid.width {
+            0
+        } else {
+            (self.grid.width - text_width) / 2
+        };
+
+        for (offset, ch) in text.chars().enumerate() {
+            let column = start_column + offset;
+            if column >= self.grid.width {
+                break;
+            }
+
+            if let Some(cell) = self.grid.get_cell_mut(column, row) {
+                *cell = (ch.to_string(), None);
+            }
+        }
+
+        self.redraw_line(batcher, row);
+    }
+
     pub fn scroll_region(
         &mut self,
         batcher: &mut DrawCommandBatcher,


### PR DESCRIPTION
Introduces a sponsor banner with neovim's own intro rules so we only react when the built-in intro actually renders fully respecting the neovim [may_show_intro](https://github.com/neovim/neovim/blob/2822c38f2e737e9b249d2dc7b09eedd03dcc077c/src/nvim/version.c#L2727) rules.

Instead of disabling detection as soon as any non-blank text hits the default grid, a scenario that frequently happens when users have autocmds or plugins that prints or customize it during startup, we now keep listening until Neovim paints its real [intro](https://github.com/neovim/neovim/blob/master/src/nvim/version.c#L2742-L2852) header and final line `type  :help Kuwasha<Enter>` ensuring the sponsor banner appears exactly whenever the intro would be visible, even for configs that run early commands.

Note that If we want a better, future-proof solution, it would have to come from neovim itself by [emitting a dedicated msg_show of kind intro or tagging the intro draw with metadata. Until Neovim doesn't exposes and forward :intro message properly to external UI:s](https://github.com/neovim/neovim/pull/24764) such a signal, string-matching that line, per grid and **once** is *probably* the best option for Neovide to hook and extend it *without modifying or hacking too much*.

<img width="2160" height="1562" alt="CleanShot 2025-11-11 at 02 36 38@2x" src="https://github.com/user-attachments/assets/921ef90f-da54-45b3-89ee-d9cec7774153" />

