### PR TITLE
fix: detect real stdin descriptors to stabilize embedded neovim ingestion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,7 @@ csscolorparser = "0.7.0"
 shlex = "1.3.0"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-rustix = "1.0.8"
+rustix = { version = "1.0.8", features = ["fs"] }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winres = "0.1.12"


### PR DESCRIPTION
embedded launch path now forwards `stdin` only when the descriptor truly represents redirected input.

Instead of using `stdin.is_terminal()` we now uses the `rustix::fs::fstat` to classify stdin by file type and hands it to neovim only for regular files, FIFOs or sockets.

Finder/Dock launches therefore retain their character-device stdin and no longer hang, while `ls | neovide -` correctly propagates the pipe, since macOS bundled apps have stdin connected to a char e.g `/dev/null` so the check misidentified them as pipes previously.

closes https://github.com/neovide/neovide/issues/3289

it fix the bug introduced from https://github.com/neovide/neovide/pull/3206 at nightly builds
