### PR TITLE
fix(mouse): Cursor is invisible on unfocused window

### DIFF
--- a/src/window/mouse_manager.rs
+++ b/src/window/mouse_manager.rs
@@ -464,6 +464,13 @@ impl MouseManager {
                     }
                 }
             }
+            WindowEvent::Focused(false) => {
+                let window_settings = self.settings.get::<WindowSettings>();
+                if window_settings.hide_mouse_when_typing && self.mouse_hidden {
+                    window.set_cursor_visible(true);
+                    self.mouse_hidden = false;
+                }
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
If the cursor is hidden and we Atl-Tab, it will stay invisible. On focus loss, this PR restore visibility (https://github.com/neovide/neovide/issues/2414#issuecomment-3538787842 )

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
