### PR TITLE
fix: neovim passthrough & command builder cleanup 

### DIFF
--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -1,40 +1,124 @@
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+use std::process::Command as StdCommand;
 use tokio::process::Command as TokioCommand;
 
 use crate::{cmd_line::CmdLineSettings, settings::*};
 
+#[derive(Clone)]
+struct CommandSpec {
+    program: String,
+    args: Vec<String>,
+    #[cfg(target_os = "windows")]
+    creation_flags: Option<u32>,
+}
+
+impl CommandSpec {
+    fn new(program: impl Into<String>, args: Vec<String>) -> Self {
+        Self {
+            program: program.into(),
+            args,
+            #[cfg(target_os = "windows")]
+            creation_flags: None,
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    fn with_creation_flags(mut self, flags: u32) -> Self {
+        self.creation_flags = Some(flags);
+        self
+    }
+}
+
 pub fn create_nvim_command(settings: &Settings) -> TokioCommand {
-    let bin = settings
-        .get::<CmdLineSettings>()
-        .neovim_bin
-        .unwrap_or("nvim".to_owned());
-    let mut args = Vec::new();
-    args.push("--embed".to_string());
-    args.extend(settings.get::<CmdLineSettings>().neovim_args);
-    let mut cmd = create_platform_command(&bin, &args, settings);
-    if let Some(dir) = settings.get::<CmdLineSettings>().chdir {
+    let cmdline_settings = settings.get::<CmdLineSettings>();
+    create_tokio_nvim_command(&cmdline_settings, true)
+}
+
+pub fn create_blocking_nvim_command(cmdline_settings: &CmdLineSettings, embed: bool) -> StdCommand {
+    let (bin, args) = build_nvim_command_parts(cmdline_settings, embed);
+    let spec = create_command_spec(&bin, &args, cmdline_settings);
+    let mut cmd = std_command_from_spec(spec);
+    if let Some(dir) = &cmdline_settings.chdir {
         cmd.current_dir(dir);
     }
     cmd
 }
 
-// Creates a shell command if needed on this platform
+fn create_tokio_nvim_command(cmdline_settings: &CmdLineSettings, embed: bool) -> TokioCommand {
+    let (bin, args) = build_nvim_command_parts(cmdline_settings, embed);
+    let spec = create_command_spec(&bin, &args, cmdline_settings);
+    let mut cmd = tokio_command_from_spec(spec);
+    if let Some(dir) = &cmdline_settings.chdir {
+        cmd.current_dir(dir);
+    }
+    cmd
+}
+
+fn build_nvim_command_parts(
+    cmdline_settings: &CmdLineSettings,
+    embed: bool,
+) -> (String, Vec<String>) {
+    let bin = cmdline_settings
+        .neovim_bin
+        .clone()
+        .unwrap_or_else(|| "nvim".to_owned());
+    let mut args = Vec::new();
+    if embed {
+        args.push("--embed".to_string());
+    }
+    args.extend(cmdline_settings.neovim_args.clone());
+    (bin, args)
+}
+
+fn tokio_command_from_spec(spec: CommandSpec) -> TokioCommand {
+    let CommandSpec {
+        program,
+        args,
+        #[cfg(target_os = "windows")]
+        creation_flags,
+    } = spec;
+    let mut result = TokioCommand::new(program);
+    result.args(&args);
+    #[cfg(target_os = "windows")]
+    if let Some(flags) = creation_flags {
+        result.creation_flags(flags);
+    }
+    result
+}
+
+fn std_command_from_spec(spec: CommandSpec) -> StdCommand {
+    let CommandSpec {
+        program,
+        args,
+        #[cfg(target_os = "windows")]
+        creation_flags,
+    } = spec;
+    let mut result = StdCommand::new(program);
+    result.args(&args);
+    #[cfg(target_os = "windows")]
+    if let Some(flags) = creation_flags {
+        result.creation_flags(flags);
+    }
+    result
+}
+
+// Creates a shell command if needed on this platform.
 #[cfg(target_os = "macos")]
-fn create_platform_command(
+fn create_command_spec(
     command: &str,
-    args: &Vec<String>,
-    _settings: &Settings,
-) -> TokioCommand {
+    args: &[String],
+    _cmdline_settings: &CmdLineSettings,
+) -> CommandSpec {
     use std::env;
     use uzers::os::unix::UserExt;
     if env::var_os("TERM").is_some() {
         // If $TERM is set, we assume user is running from a terminal, and we shouldn't
-        // re-initialize the environment.
-        // See https://github.com/neovide/neovide/issues/2584
-        let mut result = TokioCommand::new(command);
-        result.args(args);
-        result
+        // re-initialize the environment. See https://github.com/neovide/neovide/issues/2584
+        CommandSpec::new(command, args.to_vec())
     } else {
-        // Otherwise run inside a login shell
+        // Otherwise run inside a login shell to ensure the environment matches a
+        // normal GUI launch. See https://github.com/neovide/neovide/issues/2584
         let user = uzers::get_user_by_uid(uzers::get_current_uid()).unwrap();
         let shell = user.shell();
         // -f: Bypasses authentication for the already-logged-in user.
@@ -44,48 +128,52 @@ fn create_platform_command(
         // Convert to a single string and add quotes
         let args =
             shlex::try_join(args.iter().map(|s| s.as_ref())).expect("Failed to join arguments");
-        let mut result = TokioCommand::new("/usr/bin/login");
-        result.args([
-            "-fpq",
-            user.name().to_str().unwrap(),
-            shell.to_str().unwrap(),
-            "-c",
-        ]);
-        result.arg(format!("{command} {args}"));
-        result
+        CommandSpec::new(
+            "/usr/bin/login",
+            vec![
+                "-fpq".to_string(),
+                user.name().to_str().unwrap().to_string(),
+                shell.to_str().unwrap().to_string(),
+                "-c".to_string(),
+                format!("{command} {args}"),
+            ],
+        )
     }
 }
 
-// Creates a shell command if needed on this platform
+// Creates a shell command if needed on this platform.
 #[cfg(target_os = "windows")]
-fn create_platform_command(command: &str, args: &Vec<String>, settings: &Settings) -> TokioCommand {
-    let mut result = if cfg!(target_os = "windows") && settings.get::<CmdLineSettings>().wsl {
-        let mut result = TokioCommand::new("wsl");
-        result.args(["$SHELL", "-l", "-c"]);
+fn create_command_spec(
+    command: &str,
+    args: &[String],
+    cmdline_settings: &CmdLineSettings,
+) -> CommandSpec {
+    let spec = if cfg!(target_os = "windows") && cmdline_settings.wsl {
         let args =
             shlex::try_join(args.iter().map(|s| s.as_ref())).expect("Failed to join arguments");
-        result.arg(format!("{command} {args}"));
-        result
+        CommandSpec::new(
+            "wsl",
+            vec![
+                "$SHELL".to_string(),
+                "-l".to_string(),
+                "-c".to_string(),
+                format!("{command} {args}"),
+            ],
+        )
     } else {
         // There's no need to go through the shell on Windows when not using WSL
-        let mut result = TokioCommand::new(command);
-        result.args(args);
-        result
+        CommandSpec::new(command, args.to_vec())
     };
-
-    result.creation_flags(windows::Win32::System::Threading::CREATE_NO_WINDOW.0);
-    result
+    spec.with_creation_flags(windows::Win32::System::Threading::CREATE_NO_WINDOW.0)
 }
 
-// Creates a shell command if needed on this platform
+// Creates a shell command if needed on this platform.
+// On Linux we can just launch directly
 #[cfg(target_os = "linux")]
-fn create_platform_command(
+fn create_command_spec(
     command: &str,
-    args: &Vec<String>,
-    _settings: &Settings,
-) -> TokioCommand {
-    // On Linux we can just launch directly
-    let mut result = TokioCommand::new(command);
-    result.args(args);
-    result
+    args: &[String],
+    _cmdline_settings: &CmdLineSettings,
+) -> CommandSpec {
+    CommandSpec::new(command, args.to_vec())
 }

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -33,7 +33,7 @@ pub use handler::NeovimHandler;
 use session::{NeovimInstance, NeovimSession};
 use setup::{get_api_information, setup_neovide_specific_state};
 
-pub use command::create_nvim_command;
+pub use command::{create_blocking_nvim_command, create_nvim_command};
 pub use events::*;
 pub use session::NeovimWriter;
 pub use ui_commands::{send_ui, start_ui_command_handler, ParallelCommand, SerialCommand};

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,6 +236,12 @@ fn setup(
 
     //Will exit if -h or -v
     cmd_line::handle_command_line_arguments(args().collect(), settings.as_ref())?;
+    {
+        let cmdline_settings = settings.get::<CmdLineSettings>();
+        if let Some(status) = cmd_line::maybe_passthrough_to_neovim(&cmdline_settings)? {
+            std::process::exit(cmd_line::exit_status_code(status));
+        }
+    }
     #[cfg(not(target_os = "windows"))]
     maybe_disown(&settings);
 


### PR DESCRIPTION
closes https://github.com/neovide/neovide/issues/2446

the cli argument processing now detects help/version/api-info/ etc combinations and launches nvim without --embed.

*Note: **macos login-shell usage, windows wsl wrapping and linux direct launches behave exactly as before. we are just moving things around.***


## outputs comparison


### old behavior

neovide attempted to embed neovim, rejected the extra output during the handshake and crashed.

```bash
neovide -- -h
ERROR [neovide::error_handling] Neovide just crashed :(
This is the error that caused the crash. In case you don't know what to do with this, please feel free to report this on https://github.com/neovide/neovide/issues!

Could not locate or start neovim process

Caused by:
    0: stderr output:
       
    1: Error receiving handshake response, unexpected output:
       Usage:
         nvim [options] [file ...]
       
       Options:
         --cmd <cmd>           Execute <cmd> before any config
         +<cmd>, -c <cmd>      Execute <cmd> after config and first file
         -l <script> [args...] Execute Lua <script> (with optional args)
         -S <session>          Source <session> after loading the first file
         -s <scriptin>         Read Normal mode commands from <scriptin>
         -u <config>           Use this config file
       
         -d                    Diff mode
         -es, -Es              Silent (batch) mode
         -h, --help            Print this help message
         -i <shada>            Use this shada file
         -n                    No swap file, use memory only
         -o[N]                 Open N windows (default: one per file)
         -O[N]                 Open N vertical windows (default: one per file)
         -p[N]                 Open N tab pages (default: one per file)
         -R                    Read-only (view) mode
         -v, --version         Print version information
         -V[N][file]           Verbose [level][file]
       
         --                    Only file names after this
         --api-info            Write msgpack-encoded API metadata to stdout
         --clean               "Factory defaults" (skip user config and plugins, shada)
         --embed               Use stdin/stdout as a msgpack-rpc channel
         --headless            Don't start a user interface
         --listen <address>    Serve RPC API from this address
         --remote[-subcommand] Execute commands remotely on a server
         --server <address>    Connect to this Nvim server
         --startuptime <file>  Write startup timing messages to <file>
       
       See ":help startup-options" for all options.
```

### new behavior

neovim is invoked without --embed, printing its canonical help text and exiting with status 0, exactly matching nvim -h.


```bash
neovide -- -h
Usage:
  nvim [options] [file ...]

Options:
  --cmd <cmd>           Execute <cmd> before any config
  +<cmd>, -c <cmd>      Execute <cmd> after config and first file
  -l <script> [args...] Execute Lua <script> (with optional args)
  -S <session>          Source <session> after loading the first file
  -s <scriptin>         Read Normal mode commands from <scriptin>
  -u <config>           Use this config file

  -d                    Diff mode
  -es, -Es              Silent (batch) mode
  -h, --help            Print this help message
  -i <shada>            Use this shada file
  -n                    No swap file, use memory only
  -o[N]                 Open N windows (default: one per file)
  -O[N]                 Open N vertical windows (default: one per file)
  -p[N]                 Open N tab pages (default: one per file)
  -R                    Read-only (view) mode
  -v, --version         Print version information
  -V[N][file]           Verbose [level][file]

  --                    Only file names after this
  --api-info            Write msgpack-encoded API metadata to stdout
  --clean               "Factory defaults" (skip user config and plugins, shada)
  --embed               Use stdin/stdout as a msgpack-rpc channel
  --headless            Don't start a user interface
  --listen <address>    Serve RPC API from this address
  --remote[-subcommand] Execute commands remotely on a server
  --server <address>    Connect to this Nvim server
  --startuptime <file>  Write startup timing messages to <file>

See ":help startup-options" for all options.
```
more examples of the new hooking behavior

```bash
neovide -- -v
NVIM v0.12.0-dev-1596+g653871da1b
Build type: RelWithDebInfo
LuaJIT 2.1.1762617240
Run "nvim -V1 -v" for more info
```


