### PR TITLE
docs: add sponsor docs page and refresh readme support info

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,35 @@ much more, head on over to [neovide.dev](https://neovide.dev).
     <em>Screenshot of Neovide running on Windows</em>
 </div>
 
-## Author Notes
+## Installation
 
-I've been using this as my daily driver since November 2019. It should be relatively stable, but I'm
-still working out some kinks and ironing out some cross platform issues. In general it should be
-usable at this point, and if it isn't I consider that a bug and appreciate a report in the issues!
-Any help and ideas are also greatly appreciated.
+Pre-built releases for macOS, Windows and Linux are published on the
+[GitHub Releases page](https://github.com/neovide/neovide/releases) and each release includes signed
+installers or AppImage builds. For detailed package-manager commands, verification steps and build
+from source instructions, see the [installation guide on neovide.dev](https://neovide.dev/installation.html)
 
-I'm also very interested in suggestions code quality/style wise when it comes to Rust. I'm pretty
-new to the language and appreciate any critiques that you might have to offer. I won't take all of
-them, but I promise to consider anything you might have to offer.
+## Getting help
+
+Neovide is maintained in spare time, so please be patient when asking for support. Depending on your
+question:
+
+- Use the [issue tracker](https://github.com/neovide/neovide/issues) for reproducible bugs or crash reports.
+- Open a thread in [GitHub Discussions](https://github.com/neovide/neovide/discussions) for general
+  questions, tips, or feature ideas.
+- Chat in real time on [Discord](https://discord.gg/SjFpZdQys6) or on
+  [Matrix](https://matrix.to/#/#neovide:matrix.org) if you want help from other community members.
+
+Discussions and chat are better suited to questions or workflow brainstorming, while the issue
+tracker works best for actionable bugs.
+
+## Supporting the Project
+
+If you use and like Neovide, please consider
+[sponsoring the project on GitHub](https://github.com/sponsors/neovide). Funding helps pay for
+code-signing certificates, cross-platform hardware and the time maintainers spend supporting users.
+There are tiers for individuals and teams, and one-time contributions are welcome too.
+
+[Read more about sponsoring Neovide](https://neovide.dev/sponsor.html).
 
 ## License
 

--- a/website/docs/SUMMARY.md
+++ b/website/docs/SUMMARY.md
@@ -15,3 +15,4 @@
 - [Troubleshooting](troubleshooting.md)
 - [FAQ](faq.md)
 - [Maintainer Cookbook](maintainer-cookbook.md)
+- [Sponsor](sponsor.md)

--- a/website/docs/sponsor.md
+++ b/website/docs/sponsor.md
@@ -1,0 +1,30 @@
+# Sponsoring
+
+Neovide is driven by volunteers who design, code, test and support releases in their spare time.
+Financial sponsorship gives maintainers predictable time and resources to keep improving the project,
+triage bug reports faster and invest in long-term architectural improvements.
+
+Sponsorship also helps cover recurring costs such as code-signing certificates and the hardware
+needed to verify Neovide works well across macOS, Windows and Linux.
+
+## GitHub Sponsors
+
+You can sponsor the project directly through [GitHub Sponsors](https://github.com/sponsors/neovide)
+which exposes multiple tiers so individuals and companies can choose a monthly contribution that
+matches their budget. One-time contributions are also supported if you just want to say thanks for a
+recent bug fix or release.
+
+Every contribution signals that Neovide is valuable to you. That feedback helps us prioritize
+features, fix pain points and justify the time we spend supporting the community.
+
+## Other ways to support
+
+Not everyone can contribute money and that's fine! You can still help by:
+
+- Improving documentation;
+- Sharing reproducible bug reports and feature requests;
+- Joining the commnity and help other users in [Discord](https://discord.gg/SjFpZdQys6) or on [Matrix](https://matrix.to/#/#neovide:matrix.org);
+- Sharing blog posts about your workflow using Neovide;
+
+These contributions keep the project healthy and often unlock new releases faster than funding
+alone. Whatever form your support takes, thank you for helping Neovide thrive.


### PR DESCRIPTION
a dedicated sponsor page to the docs and refresh the README a bit to have a more direct info for installation docs, official support channels and a simple sponsor information being mentioned.

the new sponsor page.

<img width="1900" height="1810" alt="sponsor" src="https://github.com/user-attachments/assets/60863dd1-c088-4ecc-8c22-c84fd28fa2b4" />
