### PR TITLE
fix: link the quartz macos framework via ffi

### DIFF
--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -37,6 +37,9 @@ use crate::units::Pixel;
 use crate::window::ForceClickKind;
 use crate::window::{WindowSettings, WindowSettingsChanged};
 
+#[link(name = "Quartz", kind = "framework")]
+extern "C" {}
+
 static DEFAULT_NEOVIDE_ICON_BYTES: &[u8] =
     include_bytes!("../../../extra/osx/Neovide.app/Contents/Resources/Neovide.icns");
 


### PR DESCRIPTION
when we removed the quartz link during our [review](https://github.com/neovide/neovide/pull/2762#discussion_r2564973930) we mistakenly though it wouldn't be necessary. 

```rust
#[link(name = "Quartz", kind = "framework")]
extern "C" {}
```

the actual error

```
Neovide panicked with the message 'class QLPreviewPanel could not be found'. (File: src/platform/macos/mod.rs; Line: 366, Column: 47)
```

Shortly we could take the [Oil](https://github.com/stevearc/oil.nvim) plugin as an example. The link actually fixes this because Oil forces the "preview file" path when triggered, which must load the Quick Look framework. Regular force-clicks on plain text didn’t hit that code path, so they kept working even without the linkage.

the patch is needed because this is what pulls in the Quartz framework and loads the Obj‑C runtime registers for the [QLPreviewPane](https://developer.apple.com/documentation/quicklookui/qlpreviewpanel) which must be putted back.
