### PR TITLE
docs: refer to nightly builds for better visibility

### DIFF
--- a/website/docs/command-line-reference.md
+++ b/website/docs/command-line-reference.md
@@ -166,7 +166,7 @@ This sets the window title to be hidden on macOS.
 --icon <path>
 ```
 
-**Unreleased yet.**
+**Nightly.**
 
 This sets a custom application icon. A default icon is bundled with Neovide.
 
@@ -276,7 +276,7 @@ Wayland, depending on what you are running on.
 --chdir <path> or $NEOVIDE_CHDIR
 ```
 
-**Unreleased yet.**
+**Nightly.**
 
 Start neovim in the specified working directory. This will impact neovim
 arguments that use relative path names (e.g. file names), and the initial

--- a/website/docs/commands.md
+++ b/website/docs/commands.md
@@ -19,7 +19,7 @@ is useful for tools like neovim_remote which can manipulate
 neovim remotely or if long running tasks would like to
 activate the Neovide window after finishing.
 
-## Force Click (macOS) (Unreleased yet)
+## Force Click (macOS) (Nightly)
 
 On macOS, `:NeovideForceClick` triggers native force-click behaviours for whatever is under the
 cursor. Plain text falls back to the usual "Look Up" popover; file paths and URLs both open in the
@@ -46,7 +46,7 @@ nnoremap <silent> <X1Mouse> :NeovideForceClick<CR>
 nnoremap <silent> <leader>k :NeovideForceClick<CR>
 ```
 
-## Open Config File (Unreleased yet)
+## Open Config File (Nightly)
 
 Running the `NeovideConfig` command will open your Neovide
 configuration file for editing. This provides a simple and

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -467,7 +467,7 @@ vim.g.neovide_progress_bar_animation_speed = 200.0
 vim.g.neovide_progress_bar_hide_delay = 0.2
 ```
 
-**Unreleased yet.**
+**Nightly.**
 
 - `g:neovide_progress_bar_enabled` sets whether the progress bar is enabled.
 - `g:neovide_progress_bar_height` sets the height of the progress bar in pixels.
@@ -536,7 +536,7 @@ Set the [`background`](https://neovim.io/doc/user/options.html#'background') opt
 starts. Possible values: _light_, _dark_, _auto_. On systems that support it, _auto_ will mirror the
 system theme, and will update `background` when the system theme changes.
 
-**Unreleased yet.**
+**Nightly.**
 
 **NOTE:** The meaning of the setting has changed in 0.16.0. The default value of the Neovim
 [`background`](https://neovim.io/doc/user/options.html#'background') option is now always
@@ -1308,7 +1308,7 @@ Lua:
 vim.g.neovide_has_mouse_grid_detection = true
 ```
 
-**Unreleased yet.**
+**Nightly.**
 
 **Requires Neovim 0.12.0.**
 

--- a/website/docs/maintainer-cookbook.md
+++ b/website/docs/maintainer-cookbook.md
@@ -99,7 +99,7 @@ Now here's where the order becomes important:
     - `Cargo.toml` (do note it contains the version _twice_, one time in the
         top, one time at the bottom in the bundling section)
     - `extra/osx/Neovide.app/Contents/Resources/Info.plist`
-    - `website/docs/*.md` and update `Unreleased yet` to `Available since $tag`
+    - `website/docs/*.md` and update `Nightly` to `Available since $tag`
       (where `$tag` is the tag name)
 
 5. Run `cargo build` and make sure it succeeds, **remember to `git add


### PR DESCRIPTION
reference nightly instead of "unreleased yet" so the users are aware the feature can be used easily.