### PR TITLE
fix: ensure teardown via context to avoid clipboard outliving event loop

### DIFF
--- a/src/bridge/clipboard.rs
+++ b/src/bridge/clipboard.rs
@@ -2,11 +2,14 @@ use std::error::Error;
 
 use rmpv::Value;
 
-use crate::clipboard;
+use crate::clipboard::Clipboard;
 
-pub fn get_clipboard_contents(register: &Value) -> Result<Value, Box<dyn Error + Send + Sync>> {
+pub fn get_clipboard_contents(
+    clipboard: &mut Clipboard,
+    register: &Value,
+) -> Result<Value, Box<dyn Error + Send + Sync>> {
     let register = register.as_str().unwrap_or("+");
-    let clipboard_raw = clipboard::get_contents(register)?.replace('\r', "");
+    let clipboard_raw = clipboard.get_contents(register)?.replace('\r', "");
     let is_line_paste = clipboard_raw.ends_with('\n');
 
     let lines = clipboard_raw
@@ -25,6 +28,7 @@ pub fn get_clipboard_contents(register: &Value) -> Result<Value, Box<dyn Error +
 }
 
 pub fn set_clipboard_contents(
+    clipboard: &mut Clipboard,
     value: &Value,
     register: &Value,
 ) -> Result<Value, Box<dyn Error + Send + Sync>> {
@@ -45,7 +49,7 @@ pub fn set_clipboard_contents(
         })
         .ok_or("can't build string from provided text")?;
 
-    clipboard::set_contents(lines, register)?;
+    clipboard.set_contents(lines, register)?;
 
     Ok(Value::Nil)
 }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -15,6 +15,7 @@ use winit::window::Theme;
 
 use crate::{
     bridge::{GridLineCell, GuiOption, NeovimHandler, RedrawEvent, WindowAnchor},
+    clipboard::ClipboardHandle,
     profiling::{tracy_named_frame, tracy_zone},
     renderer::{DrawCommand, WindowDrawCommand},
     running_tracker::RunningTracker,
@@ -755,6 +756,7 @@ pub fn start_editor(
     event_loop_proxy: EventLoopProxy<UserEvent>,
     running_tracker: RunningTracker,
     settings: Arc<Settings>,
+    clipboard: ClipboardHandle,
 ) -> NeovimHandler {
     let (sender, mut receiver) = unbounded_channel();
     let handler = NeovimHandler::new(
@@ -762,6 +764,7 @@ pub fn start_editor(
         event_loop_proxy.clone(),
         running_tracker,
         settings.clone(),
+        clipboard,
     );
     thread::spawn(move || {
         let mut editor = Editor::new(event_loop_proxy, settings.clone());

--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -15,6 +15,7 @@ use crate::windows_attach_to_console;
 
 use crate::{
     bridge::{send_ui, ParallelCommand},
+    clipboard::ClipboardHandle,
     settings::Settings,
     window::{show_error_window, UserEvent},
 };
@@ -70,6 +71,7 @@ pub fn handle_startup_errors(
     err: Error,
     event_loop: EventLoop<UserEvent>,
     settings: Arc<Settings>,
+    clipboard: ClipboardHandle,
 ) -> ExitCode {
     // Command line output is always printed to the stdout/stderr
     if let Some(clap_error) = err.downcast_ref::<ClapError>() {
@@ -82,7 +84,12 @@ pub fn handle_startup_errors(
         log::error!("{}", &format_and_log_error_message(err));
         ExitCode::from(1)
     } else {
-        show_error_window(&format_and_log_error_message(err), event_loop, settings);
+        show_error_window(
+            &format_and_log_error_message(err),
+            event_loop,
+            settings,
+            clipboard,
+        );
         ExitCode::from(1)
     }
 }


### PR DESCRIPTION
just cherry-picking only the isolated clipboard lifetime fix from https://github.com/neovide/neovide/pull/3252

Instead of a whole refactor, the clipboard is now owned centrally by the app: we build a single `Arc<Mutex<Clipboard>>` from the event loop, forward a weak handle through the runtime, error handling, RPC layers, etc and each consumer locks that shared handle when it needs clipboard access.

This removes the old global OnceLock and ensures the clipboard drops before the event loop shuts down, fixing the crash we hit when winit begins to tears things down.

fixes https://github.com/neovide/neovide/issues/2868
fixes https://github.com/neovide/neovide/issues/3311
