### PR TITLE
fix: ensure clean up during teardown and on drop

### DIFF
--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -1,7 +1,7 @@
 use std::{
     io::{stdout, IsTerminal},
     process::ExitCode,
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 use anyhow::{Error, Result};
@@ -15,7 +15,7 @@ use crate::windows_attach_to_console;
 
 use crate::{
     bridge::{send_ui, ParallelCommand},
-    clipboard::ClipboardHandle,
+    clipboard::{Clipboard, ClipboardHandle},
     settings::Settings,
     window::{show_error_window, UserEvent},
 };
@@ -71,8 +71,10 @@ pub fn handle_startup_errors(
     err: Error,
     event_loop: EventLoop<UserEvent>,
     settings: Arc<Settings>,
-    clipboard: ClipboardHandle,
+    clipboard: Arc<Mutex<Clipboard>>,
 ) -> ExitCode {
+    let clipboard_handle = ClipboardHandle::new(&clipboard);
+
     // Command line output is always printed to the stdout/stderr
     if let Some(clap_error) = err.downcast_ref::<ClapError>() {
         #[cfg(target_os = "windows")]
@@ -88,7 +90,7 @@ pub fn handle_startup_errors(
             &format_and_log_error_message(err),
             event_loop,
             settings,
-            clipboard,
+            clipboard_handle,
         );
         ExitCode::from(1)
     }


### PR DESCRIPTION
An easier and consistent fix for the Wayland edge case issue for the clipboard crash.

After https://github.com/neovide/neovide/pull/3312 the issue persisted on some edge cases and the clipboard worker kept outliving the event loop, which kept libwayland aborting because we dropped the connection before the worker stopped.

the ownership in the UpdateLoop now holds both the runtime and the clipboard Arc. It has a fn teardown() helper for the Drop impl that first drains the clipboard ensuring the clear up while the event loop is still alive. That ordering seems to be important to prevent the Wayland crash.

As a side note: I finally could reproduce this in another laptop using wayland but mainly, thanks @ewhac for reporting and [testing](https://github.com/neovide/neovide/issues/3311#issuecomment-3597758854) it constantly without hesitate for even a second. that was tricky but very appreciated, sir. lovely.
