### PR TITLE
fix: ensure the teardown safely on exit

### DIFF
--- a/src/window/update_loop.rs
+++ b/src/window/update_loop.rs
@@ -425,6 +425,7 @@ impl ApplicationHandler<UserEvent> for UpdateLoop {
 
     fn exiting(&mut self, event_loop: &ActiveEventLoop) {
         tracy_zone!("exiting");
+        self.teardown();
         self.window_wrapper.exit();
         self.schedule_next_event(event_loop);
     }


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->
For me, this resolves all issues that I had on exit using Neovide nightly in Linux Wayland. 
Basically, we drop the clipboard lifecycle using the teardown on exit. To avoid dropping it after the event loop.


## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
