### PR TITLE
fix: window error now takes ownership of the real clipboard

### DIFF
--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -15,7 +15,7 @@ use crate::windows_attach_to_console;
 
 use crate::{
     bridge::{send_ui, ParallelCommand},
-    clipboard::{Clipboard, ClipboardHandle},
+    clipboard::Clipboard,
     settings::Settings,
     window::{show_error_window, UserEvent},
 };
@@ -73,8 +73,6 @@ pub fn handle_startup_errors(
     settings: Arc<Settings>,
     clipboard: Arc<Mutex<Clipboard>>,
 ) -> ExitCode {
-    let clipboard_handle = ClipboardHandle::new(&clipboard);
-
     // Command line output is always printed to the stdout/stderr
     if let Some(clap_error) = err.downcast_ref::<ClapError>() {
         #[cfg(target_os = "windows")]
@@ -90,7 +88,7 @@ pub fn handle_startup_errors(
             &format_and_log_error_message(err),
             event_loop,
             settings,
-            clipboard_handle,
+            clipboard,
         );
         ExitCode::from(1)
     }


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->
I have tried to replicate every reported situation in #3318, and here is the feedback using Wayland on my machine. 

It doesn't occur any error running the following commands and monitoring the logs on exit.
```
neovide -- --clean
neovide --version
neovide --help
neovide --fork --neovim-bin non/existing/neovim/path
``` 
This PR attempts to fix edge cases reported in #3318. Even if I couldn't reproduce some of them which might be a very specific case.

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
