### PR TITLE
fix(renderer): prevent font cache thrashing on high-DPI displays

### DIFF
--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -365,6 +365,11 @@ impl CachingShaper {
     }
 
     pub fn cleanup_font_cache(&self) {
+        // Only purge if we are truly about to exhaust the cache.
+        // See: https://github.com/neovide/neovide/issues/3299
+        // On high-DPI displays the old unconditional purge invalidated
+        // glyphs every frame, which forced the GPU to keep
+        // re-uploading textures and tanked performance.
         let limit = font_cache_limit();
         let used = font_cache_used();
 

--- a/src/window/update_loop.rs
+++ b/src/window/update_loop.rs
@@ -303,6 +303,9 @@ impl UpdateLoop {
             self.animate();
             self.schedule_render(skipped_frame);
         } else {
+            // Cache purging should only happen once we become idle; doing it while throttling for
+            // vsync caused Skia to evict glyphs mid-animation and re-upload them every frame.
+            // See https://github.com/neovide/neovide/pull/3324
             if self.num_consecutive_rendered > 0 {
                 self.window_wrapper
                     .renderer


### PR DESCRIPTION
The previous implementation triggered `cleanup_font_cache` aggressively whenever the render loop was waiting for VSync or idle. On high-resolution displays (like 4K), this caused excessive cache thrashing, forcing the GPU to re-upload font textures every frame and significantly increasing GPU usage.

Closes: #3299

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No
