### PR TITLE
classic division by zero panic.

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -23,7 +23,6 @@ use std::{
 };
 
 use itertools::Itertools;
-use log::error;
 use progress_bar::{ProgressBar, ProgressBarSettings};
 use skia_safe::Canvas;
 
@@ -461,10 +460,10 @@ impl Renderer {
                         }
                         _ => {
                             let settings = self.settings.get::<CmdLineSettings>();
-                            // Ignore the errors when not using multigrid, since Neovim wrongly sends some of these
+                            // Neovim can emit draw commands before a window is positioned when using multigrid.
                             if !settings.no_multi_grid {
-                                error!(
-                                    "WindowDrawCommand: {command:?} sent for uninitialized grid {grid_id}"
+                                log::warn!(
+                                    "Ignoring {command:?} sent for uninitialized grid {grid_id}"
                                 );
                             }
                         }

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -395,6 +395,15 @@ impl RenderedWindow {
             WindowDrawCommand::DrawLine { row, line } => {
                 tracy_zone!("draw_line_cmd", 0);
 
+                if self.actual_lines.is_empty() || !self.valid {
+                    log::warn!(
+                        "Ignoring DrawLine for grid {} row {} because the window is not ready yet",
+                        self.id,
+                        row
+                    );
+                    return;
+                }
+
                 let line = RenderedLine {
                     line,
                     background_picture: None,


### PR DESCRIPTION
```
Neovide panicked with the message 'attempt to calculate the remainder with a divisor of zero'. (File: src/utils/ring_buffer.rs; Line: 89, Column: 38)
```

During the :restart impl we just found this bug at the draw line whenever the window hasn’t received a position update yet or its backing buffers are empty. 

This prevents stale batches that arrive after the renderer reset from indexing a zero-length ring buffer, stopping the [rem_euclid(0)](https://doc.rust-lang.org/stable/std/primitive.i32.html#method.rem_euclid) panic while we blank the UI for :restart.

In short: just ignore invalid draw operations briefly so we trade a harmless no-op for stability.
