### PR TITLE
feat: support :restart with some state preservation

### DIFF
--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -112,7 +112,18 @@ impl Handler for NeovimHandler {
                         .unwrap_or_explained_panic("Could not parse event from neovim");
 
                     for parsed_event in parsed_events {
-                        let _ = self.sender.send(parsed_event);
+                        match parsed_event {
+                            RedrawEvent::Restart { details } => {
+                                let _ = self
+                                    .proxy
+                                    .lock()
+                                    .unwrap()
+                                    .send_event(UserEvent::NeovimRestart(details));
+                            }
+                            _ => {
+                                let _ = self.sender.send(parsed_event);
+                            }
+                        }
                     }
                 }
             }

--- a/src/bridge/restart.rs
+++ b/src/bridge/restart.rs
@@ -1,0 +1,25 @@
+use rmpv::Value;
+
+#[derive(Clone, Debug)]
+pub struct RestartDetails {
+    pub progpath: String,
+    pub argv: Vec<String>,
+}
+
+impl RestartDetails {
+    pub fn from_values(arguments: &[Value]) -> Option<Self> {
+        if arguments.len() < 2 {
+            return None;
+        }
+
+        let progpath = arguments[0].as_str()?.to_string();
+        let argv = arguments
+            .get(1)?
+            .as_array()?
+            .iter()
+            .filter_map(|value| value.as_str().map(|s| s.to_string()))
+            .collect::<Vec<_>>();
+
+        Some(Self { progpath, argv })
+    }
+}

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -499,6 +499,14 @@ impl Renderer {
             .for_each(|(_, w)| w.flush(renderer_settings));
     }
 
+    pub fn clear(&mut self) {
+        self.rendered_windows.clear();
+        self.window_regions.clear();
+        self.cursor_renderer = CursorRenderer::new(self.settings.clone());
+        self.progress_bar = ProgressBar::new();
+        self.current_mode = EditorMode::Unknown(String::new());
+    }
+
     pub fn get_cursor_destination(&self) -> PixelPos<f32> {
         self.cursor_renderer.get_destination()
     }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -43,6 +43,7 @@ use std::fs::File;
 use std::io::Read;
 
 use crate::{
+    bridge::RestartDetails,
     cmd_line::{CmdLineSettings, GeometryArgs},
     frame::Frame,
     renderer::{build_window_config, DrawCommand, WindowConfig},
@@ -132,6 +133,7 @@ pub enum UserEvent {
     #[allow(dead_code)]
     RedrawRequested,
     NeovimExited,
+    NeovimRestart(RestartDetails),
     ShowProgressBar {
         percent: f32,
     },

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -484,6 +484,10 @@ impl WinitWindowWrapper {
         }
     }
 
+    pub fn clear_renderer(&mut self) {
+        self.renderer.clear();
+    }
+
     pub fn draw_frame(&mut self, dt: f32) {
         tracy_zone!("draw_frame");
         if self.skia_renderer.is_none() {


### PR DESCRIPTION
A straight approach has been taken.

The runtime keeps a single Neovim handler alive across restarts, spins up new embedded processes with the exact progpath/argv from Neovim and reattaches the existing UI seamlessly.

The `UpdateLoop` tracks pending restart requests, clears renderer state and attempts a new spawn. if anything fails we fallback and take a defensive approach to exiting cleanly instead of anything unexpected.

For that last, after restart event the Renderer must be cleaned up and fully reset floating windows and cursor state. then queued draw commands that may be left behing.

For :restart, the UI and server must live on the same machine.