### PR TITLE
refactor: remove background color legacy setting

### DIFF
--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -8,7 +8,6 @@ pub use crate::platform::macos::settings::*;
 
 #[derive(Clone, SettingGroup, PartialEq)]
 pub struct WindowSettings {
-    pub background_color: String,
     pub confirm_quit: bool,
     pub cursor_hack: bool,
     pub fullscreen: bool,
@@ -56,7 +55,6 @@ pub struct WindowSettings {
 impl Default for WindowSettings {
     fn default() -> Self {
         Self {
-            background_color: "".to_string(),
             confirm_quit: true,
             cursor_hack: true,
             fullscreen: false,

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -192,46 +192,14 @@ vim.g.neovide_padding_left = 0
 Controls the space between the window border and the actual Neovim, which is filled with the
 background color instead.
 
-#### Background Color (**Deprecated**, Currently macOS only)
+#### Background Color (Removed at Nightly, Previously macOS only)
 
-This configuration is deprecated now and might be removed in the future. In
-[#2168](https://github.com/neovide/neovide/issues/2168), we have made Neovide control the title bar
-color itself. The color of title bar now honors [`neovide_opacity`](#transparency). If you want
-a transparent title bar, setting `neovide_opacity` is sufficient.
+This legacy configuration has now been fully removed. Neovide controls the title bar color
+automatically, and setting `g:neovide_background_color` no longer has any effect.
 
-VimScript:
-
-```vim
-" g:neovide_opacity should be 0 if you want to unify transparency of content and title bar.
-let g:neovide_opacity = 0.0
-let g:transparency = 0.8
-let g:neovide_background_color = '#0f1117'.printf('%x', float2nr(255 * g:transparency))
-```
-
-Lua:
-
-```lua
--- Helper function for transparency formatting
-local alpha = function()
-  return string.format("%x", math.floor(255 * vim.g.transparency or 0.8))
-end
--- g:neovide_opacity should be 0 if you want to unify transparency of content and title bar.
-vim.g.neovide_opacity = 0.0
-vim.g.transparency = 0.8
-vim.g.neovide_background_color = "#0f1117" .. alpha()
-```
-
-**Available since 0.10.**
-**Deprecated in 0.12.2.**
-
-![BackgroundColor](assets/BackgroundColor.png)
-
-Setting `g:neovide_background_color` to a value that can be parsed by
-[csscolorparser-rs](https://github.com/mazznoer/csscolorparser-rs) will set the color of the whole
-window to that value.
-
-Note that `g:neovide_opacity` should be 0 if you want to unify transparency of content and
-title bar.
+If you want a transparent title bar, simply configure [`g:neovide_opacity`](#transparency)
+(or its alias `g:neovide_transparency`) and, if needed, `g:neovide_normal_opacity` to tune how
+opaque the buffer content should remain.
 
 #### Title Bar Color (Currently Windows only)
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -72,45 +72,45 @@ Credits to [BHatGuy here](https://github.com/neovide/neovide/pull/1589).
 
 ## How can I Dynamically Change The Transparency At Runtime? (macOS)
 
+from Nightly release `g:neovide_background_color` has been removed. To adjust the window
+transparency at runtime on macOS you only need to update `g:neovide_opacity` (and optionally
+`g:neovide_normal_opacity` for the editor background). Here is a simple example that binds the
+Command-`]`/Command-`[` keys to tweak the opacity:
+
 VimScript:
 
 ```vim
-" Set transparency and background color (title bar color)
-let g:neovide_opacity=0.0
-let g:neovide_opacity_point=0.8
-let g:neovide_background_color = '#0f1117'.printf('%x', float2nr(255 * g:neovide_opacity_point))
+let g:neovide_opacity = 0.8
 
-" Add keybinds to change transparency
 function! ChangeTransparency(delta)
-  let g:neovide_opacity_point = g:neovide_opacity_point + a:delta
-  let g:neovide_background_color = '#0f1117'.printf('%x', float2nr(255 * g:neovide_opacity_point))
+  let g:neovide_opacity = g:neovide_opacity + a:delta
+  if g:neovide_opacity > 1
+    let g:neovide_opacity = 1
+  elseif g:neovide_opacity < 0
+    let g:neovide_opacity = 0
+  endif
 endfunction
-noremap <expr><D-]> ChangeTransparency(0.01)
-noremap <expr><D-[> ChangeTransparency(-0.01)
+
+nnoremap <silent> <D-]> :call ChangeTransparency(0.01)<CR>
+nnoremap <silent> <D-[> :call ChangeTransparency(-0.01)<CR>
 ```
 
 Lua:
 
 ```lua
--- Helper function for transparency formatting
-local alpha = function()
-  return string.format("%x", math.floor(255 * vim.g.neovide_opacity_point or 0.8))
-end
--- Set transparency and background color (title bar color)
-vim.g.neovide_opacity = 0.0
-vim.g.neovide_opacity_point = 0.8
-vim.g.neovide_background_color = "#0f1117" .. alpha()
--- Add keybinds to change transparency
+vim.g.neovide_opacity = 0.8
+
 local change_transparency = function(delta)
-  vim.g.neovide_opacity_point = vim.g.neovide_opacity_point + delta
-  vim.g.neovide_background_color = "#0f1117" .. alpha()
+  local next_value = (vim.g.neovide_opacity or 1) + delta
+  vim.g.neovide_opacity = math.min(1, math.max(0, next_value))
 end
+
 vim.keymap.set({ "n", "v", "o" }, "<D-]>", function()
   change_transparency(0.01)
-end)
+end, { desc = "Increase Neovide opacity" })
 vim.keymap.set({ "n", "v", "o" }, "<D-[>", function()
   change_transparency(-0.01)
-end)
+end, { desc = "Decrease Neovide opacity" })
 ```
 
 ## Neovide Is Not Picking Up Some Shell-configured Information


### PR DESCRIPTION
Neovide no longer listens for `g:neovide_background_color` completing the removal of the old macOS-only hack.