### PR TITLE
feat: set window borders enabled by default

### DIFF
--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -75,7 +75,7 @@ impl Default for WindowSettings {
             remember_window_position: true,
             remember_window_size: true,
             scale_factor: 1.0,
-            show_border: false,
+            show_border: true,
             theme: ThemeSettings::Auto,
             touch_deadzone: 6.0,
             touch_drag_timeout: 0.17,

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -390,7 +390,7 @@ vim.g.neovide_show_border = true
 
 Draw a grey border around opaque windows only.
 
-Default: `false`
+Default: `true`
 
 #### Position Animation Length
 


### PR DESCRIPTION
the window border setting is now true by default.

just cherry picking a missing change to be done from https://github.com/neovide/neovide/pull/3253