### PR TITLE
refactor: rename updateloop to application

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ use renderer::{
 };
 use running_tracker::RunningTracker;
 use window::{
-    create_event_loop, determine_window_size, UpdateLoop, UserEvent, WindowSettings, WindowSize,
+    create_event_loop, determine_window_size, Application, UserEvent, WindowSettings, WindowSize,
 };
 
 pub use channel_utils::*;
@@ -122,7 +122,7 @@ fn main() -> ExitCode {
     ) {
         Err(err) => handle_startup_errors(err, event_loop, settings.clone(), clipboard),
         Ok((window_size, initial_config, runtime)) => {
-            let mut update_loop = UpdateLoop::new(
+            let mut application = Application::new(
                 window_size,
                 initial_config,
                 event_loop.create_proxy(),
@@ -131,7 +131,7 @@ fn main() -> ExitCode {
                 clipboard,
             );
 
-            let result = event_loop.run_app(&mut update_loop);
+            let result = event_loop.run_app(&mut application);
 
             match result {
                 Ok(_) => running_tracker.exit_code(),
@@ -286,6 +286,7 @@ fn setup(
         settings,
         colorscheme_stream,
     )?;
+
     Ok((window_size, config, runtime))
 }
 

--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -212,8 +212,8 @@ impl CachingShaper {
 
     pub fn underline_offset(&mut self) -> f32 {
         let metrics = self.metrics();
-        if self.options.underline_offset.is_some() {
-            -self.options.underline_offset.unwrap()
+        if let Some(underline_offset) = self.options.underline_offset {
+            -underline_offset
         } else if metrics.underline_offset != 0. {
             metrics.underline_offset
         } else {

--- a/src/window/application.rs
+++ b/src/window/application.rs
@@ -84,7 +84,7 @@ struct RestartRequest {
     grid_size: GridSize<u32>,
 }
 
-pub struct UpdateLoop {
+pub struct Application {
     idle: bool,
     previous_frame_start: Instant,
     last_dt: f32,
@@ -106,7 +106,7 @@ pub struct UpdateLoop {
     pending_restart: Option<RestartRequest>,
 }
 
-impl UpdateLoop {
+impl Application {
     pub fn new(
         initial_window_size: WindowSize,
         initial_config: Config,
@@ -405,13 +405,13 @@ impl UpdateLoop {
     }
 }
 
-impl Drop for UpdateLoop {
+impl Drop for Application {
     fn drop(&mut self) {
         self.teardown();
     }
 }
 
-impl ApplicationHandler<UserEvent> for UpdateLoop {
+impl ApplicationHandler<UserEvent> for Application {
     fn window_event(
         &mut self,
         event_loop: &ActiveEventLoop,

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -1,8 +1,8 @@
+mod application;
 mod error_window;
 mod keyboard_manager;
 mod mouse_manager;
 mod settings;
-mod update_loop;
 mod window_wrapper;
 
 #[cfg(target_os = "macos")]
@@ -54,10 +54,10 @@ use crate::{
     units::GridSize,
     utils::expand_tilde,
 };
+pub use application::Application;
+pub use application::ShouldRender;
 pub use error_window::show_error_window;
 pub use settings::{ThemeSettings, WindowSettings, WindowSettingsChanged};
-pub use update_loop::ShouldRender;
-pub use update_loop::UpdateLoop;
 pub use window_wrapper::WinitWindowWrapper;
 
 static DEFAULT_ICON: &[u8] = include_bytes!("../../assets/neovide.ico");


### PR DESCRIPTION
just renaming `UpdateLoop` to `Application` to improve conceptual clarity which aligns better with  the ApplicationHandler trait it implements. for example:

```rust
impl ApplicationHandler<UserEvent> for Application { ... }
```

also just cherry picking this minimal change from the multi-window [feature](https://github.com/neovide/neovide/pull/2872) to avoid frequent conflicts at every commit made on main since I am keeping things sorted out there. 