### PR TITLE
fix: cargo-nextest build without --locked causes impl conflicts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
         uses: cargo-bins/cargo-binstall@main
 
       - name: Install cargo-nextest
-        run: cargo binstall -y cargo-nextest
+        run: cargo binstall -y --locked cargo-nextest
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
reference https://github.com/nextest-rs/nextest/pull/2991

error https://github.com/neovide/neovide/actions/runs/21332352621/job/61399677346