### PR TITLE
build-dmg: improve build script reliability

### DIFF
--- a/macos-builder/run
+++ b/macos-builder/run
@@ -6,11 +6,23 @@ if [ -n "$1" ]; then
   TARGET_ARCHITECTURE=$1
 fi
 
+TARGET="neovide"
+
+if [ "$CLEAN_BUILD" == "true" ]; then
+  echo "Cleaning build artifacts..."
+  if [ -n "$TARGET_ARCHITECTURE" ]; then
+    cargo clean --target "${TARGET_ARCHITECTURE}"
+  else
+    cargo clean
+  fi
+fi
+
 RELEASE_DIR=${TARGET_ARCHITECTURE:+target/${TARGET_ARCHITECTURE}/release}
 RELEASE_DIR=${RELEASE_DIR:-target/release}
+RELEASE_BINARY="${RELEASE_DIR}/${TARGET}"
 
-if [ ! -d "${RELEASE_DIR}" ]; then
-  echo "Release directory '${RELEASE_DIR}' does not exist."
+if [ ! -f "${RELEASE_BINARY}" ]; then
+  echo "Release binary '${RELEASE_BINARY}' does not exist."
   echo "Running 'cargo build --release${TARGET_ARCHITECTURE:+ --target ${TARGET_ARCHITECTURE}}' ..."
   cargo build --release ${TARGET_ARCHITECTURE:+--target "${TARGET_ARCHITECTURE}"}
 fi
@@ -20,7 +32,6 @@ if [ -n "$2" ]; then
 fi
 
 DEVELOPER_ID=${DEVELOPER_ID:-""}
-TARGET="neovide"
 EXTRAS_DIR="extra"
 ASSETS_DIR="assets"
 BUNDLE_DIR="${RELEASE_DIR}/bundle"
@@ -65,6 +76,11 @@ if [ "$GENERATE_BUNDLE_APP" == "true" ]; then
 fi
 
 if [ "$GENERATE_DMG" == "true" ]; then
+  if [ -f "${APP_DIR}/${DMG_NAME}" ]; then
+    echo "Removing existing DMG '${APP_DIR}/${DMG_NAME}'"
+    rm -f "${APP_DIR}/${DMG_NAME}"
+  fi
+
   # Make Neovide.dmg
   create-dmg \
     --filesystem "${DMG_FILESYSTEM}" \


### PR DESCRIPTION
treating an edge-case when the dmg script fails when the output file already exists.

(mostly useful locally)