### PR TITLE
feat: introduce macOS matching pair highlight with find indicator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2129,6 +2129,7 @@ dependencies = [
  "bitflags 2.10.0",
  "objc2 0.6.3",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation 0.3.2",
  "objc2-metal 0.3.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,9 @@ objc2-app-kit = { version = "0.3.1", default-features = false, features = [
 objc2-quartz-core = { version = "0.3.1", default-features = false, features = [
   "std",
   "objc2-core-foundation",
+  "objc2-core-graphics",
   "objc2-metal",
+  "CATransaction",
   "CALayer",
   "CAMetalLayer",
 ] }
@@ -169,6 +171,7 @@ objc2-core-video = { version = "0.3.1", default-features = false, features = [
   "CVDisplayLink",
 ] }
 objc2-core-graphics = { version = "0.3.1", default-features = false, features = [
+  "CGColor",
   "CGDirectDisplay",
 ] }
 objc2-metal = { version = "0.3.1", default-features = false, features = [

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -183,6 +183,8 @@ async fn launch(
     options.set_linegrid_external(true);
     options.set_multigrid_external(!cmdline_settings.no_multi_grid);
     options.set_rgb(true);
+    #[cfg(target_os = "macos")]
+    options.set_hlstate_external(true);
     // We can close the handle here, as Neovim already owns it
     #[cfg(not(target_os = "windows"))]
     if let Some(fd) = session.stdin_fd.take() {

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -11,13 +11,13 @@ use objc2::{
 };
 use objc2_app_kit::{
     NSApplication, NSAutoresizingMaskOptions, NSColor, NSEvent, NSEventModifierFlags, NSFont,
-    NSFontAttributeName, NSFontDescriptor, NSFontWeight, NSImage, NSMenu, NSMenuItem, NSView,
-    NSWindow, NSWindowStyleMask, NSWindowTabbingMode,
+    NSFontAttributeName, NSFontDescriptor, NSFontWeight, NSFontWeightLight, NSImage, NSMenu,
+    NSMenuItem, NSTextView, NSView, NSWindow, NSWindowStyleMask, NSWindowTabbingMode,
 };
 use objc2_core_foundation::CGFloat;
 use objc2_foundation::{
     ns_string, MainThreadMarker, NSArray, NSAttributedString, NSData, NSDictionary, NSInteger,
-    NSObject, NSPoint, NSProcessInfo, NSRect, NSSize, NSString, NSUserDefaults, NSURL,
+    NSObject, NSPoint, NSProcessInfo, NSRange, NSRect, NSSize, NSString, NSUserDefaults, NSURL,
 };
 
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
@@ -31,7 +31,7 @@ use crate::{
 };
 use crate::{cmd_line::CmdLineSettings, frame::Frame};
 
-use crate::units::Pixel;
+use crate::units::{Pixel, PixelRect};
 #[cfg(target_os = "macos")]
 use crate::window::ForceClickKind;
 use crate::window::{WindowSettings, WindowSettingsChanged};
@@ -85,6 +85,31 @@ define_class!(
 impl TitlebarClickHandler {
     fn new(mtm: MainThreadMarker) -> Retained<Self> {
         unsafe { msg_send![Self::alloc(mtm), init] }
+    }
+}
+
+define_class!(
+    #[derive(Debug)]
+    #[unsafe(super = NSTextView)]
+    #[thread_kind = MainThreadOnly]
+    struct MatchParenIndicatorView;
+
+    impl MatchParenIndicatorView {
+        #[unsafe(method(acceptsFirstResponder))]
+        fn accepts_first_responder(&self) -> bool {
+            false
+        }
+
+        #[unsafe(method(hitTest:))]
+        fn hit_test(&self, _point: NSPoint) -> *mut NSView {
+            std::ptr::null_mut()
+        }
+    }
+);
+
+impl MatchParenIndicatorView {
+    fn new(mtm: MainThreadMarker, frame: NSRect) -> Retained<Self> {
+        unsafe { msg_send![Self::alloc(mtm), initWithFrame: frame] }
     }
 }
 
@@ -194,6 +219,7 @@ pub struct MacosWindowFeature {
     menu: Option<Menu>,
     settings: Arc<Settings>,
     pub definition_is_active: bool,
+    match_paren_indicator_view: Option<Retained<MatchParenIndicatorView>>,
 }
 
 impl MacosWindowFeature {
@@ -254,6 +280,7 @@ impl MacosWindowFeature {
             menu: None,
             settings: settings.clone(),
             definition_is_active: false,
+            match_paren_indicator_view: None,
         };
 
         macos_window_feature.update_background();
@@ -434,6 +461,109 @@ impl MacosWindowFeature {
                 Some(attr_string.as_ref()),
                 translated_point,
             );
+        }
+    }
+
+    pub fn show_find_indicator_for_rect(&mut self, rect: PixelRect<f32>, text: Option<&str>) {
+        // just being defensive here in case of an invalid state.
+        let width = rect.max.x - rect.min.x;
+        let height = rect.max.y - rect.min.y;
+        if width <= 0.0 || height <= 0.0 {
+            return;
+        }
+
+        unsafe {
+            let ns_view = self.ns_window.contentView().unwrap();
+            let scale = self.ns_window.backingScaleFactor();
+            let size = NSSize::new(width as f64 / scale, height as f64 / scale);
+            let mut origin = NSPoint::new(rect.min.x as f64 / scale, rect.min.y as f64 / scale);
+
+            // future-proof for being defensive here.
+            //
+            // NSView flipped macOS standard value is false,
+            // https://developer.apple.com/documentation/appkit/nsview/isflipped
+            //
+            // but winit flips it since it uses the upper-left corner as the origin.
+            // https://docs.rs/crate/winit-appkit/0.31.0-beta.2/source/src/view.rs#149-153
+            if !ns_view.isFlipped() {
+                let view_height = ns_view.bounds().size.height;
+                origin.y = view_height - origin.y - size.height;
+            }
+
+            let ns_rect = NSRect::new(origin, size);
+            self.show_match_paren_indicator(ns_view.as_ref(), ns_rect, text)
+        }
+    }
+
+    unsafe fn show_match_paren_indicator(
+        &mut self,
+        ns_view: &NSView,
+        rect: NSRect,
+        text: Option<&str>,
+    ) {
+        let text = match text {
+            Some(text) if !text.is_empty() => text,
+            _ => return,
+        };
+
+        let indicator_view = self.ensure_match_paren_indicator_view(ns_view, rect);
+        indicator_view.setFrame(rect);
+
+        let ns_text = NSString::from_str(text);
+        indicator_view.setString(&ns_text);
+
+        let font_size = (rect.size.height * 0.85).max(1.0);
+        let font =
+            NSFont::monospacedSystemFontOfSize_weight(CGFloat::from(font_size), NSFontWeightLight);
+
+        indicator_view.setFont(Some(font.as_ref()));
+        indicator_view.setTextColor(Some(NSColor::textColor().as_ref()));
+
+        let show_range_selector = sel!(showFindIndicatorForRange:);
+        let can_show = msg_send![&*indicator_view, respondsToSelector: show_range_selector];
+        if can_show {
+            let length = text.encode_utf16().count();
+            indicator_view.showFindIndicatorForRange(NSRange::new(0, length));
+            let clear_color = NSColor::clearColor();
+            let _: () = msg_send![
+                &*indicator_view,
+                performSelector: sel!(setTextColor:),
+                withObject: clear_color.as_ref() as *const NSColor,
+                afterDelay: 0.35
+            ];
+        }
+    }
+
+    fn ensure_match_paren_indicator_view(
+        &mut self,
+        ns_view: &NSView,
+        rect: NSRect,
+    ) -> Retained<MatchParenIndicatorView> {
+        if let Some(view) = self.match_paren_indicator_view.as_ref() {
+            return view.clone();
+        }
+
+        let mtm = MainThreadMarker::new()
+            .expect("MatchParen indicator must be created on the main thread.");
+        let view = MatchParenIndicatorView::new(mtm, rect);
+        self.setup_match_paren_indicator_view(&view);
+
+        ns_view.addSubview(&view);
+        self.match_paren_indicator_view = Some(view.clone());
+
+        view
+    }
+
+    fn setup_match_paren_indicator_view(&self, view: &MatchParenIndicatorView) {
+        view.setEditable(false);
+        view.setSelectable(false);
+        view.setDrawsBackground(false);
+        view.setTextContainerInset(NSSize::new(0.0, 0.0));
+        view.setString(ns_string!(""));
+        view.setTextColor(Some(NSColor::clearColor().as_ref()));
+
+        if let Some(container) = unsafe { view.textContainer() } {
+            container.setLineFragmentPadding(CGFloat::from(0.0));
         }
     }
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -7,7 +7,7 @@ pub mod opengl;
 pub mod profiler;
 pub mod progress_bar;
 mod rendered_layer;
-mod rendered_window;
+pub mod rendered_window;
 mod vsync;
 
 #[cfg(target_os = "windows")]

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -13,6 +13,10 @@ use crate::{
     utils::RingBuffer,
 };
 
+#[cfg(target_os = "macos")]
+pub const BASE_GRID_ID: u64 = 1;
+pub const NO_MULTIGRID_GRID_ID: u64 = 0;
+
 #[derive(Debug)]
 pub struct ViewportMargins {
     pub top: u64,
@@ -98,7 +102,7 @@ pub struct WindowDrawDetails {
 impl WindowDrawDetails {
     pub fn event_grid_id(&self, settings: &Settings) -> u64 {
         if settings.get::<CmdLineSettings>().no_multi_grid {
-            0
+            NO_MULTIGRID_GRID_ID
         } else {
             self.id
         }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -116,6 +116,13 @@ pub enum WindowCommand {
         guifont: String,
         kind: ForceClickKind,
     },
+    #[cfg(target_os = "macos")]
+    HighlightMatchingPair {
+        grid: u64,
+        row: u64,
+        column: u64,
+        text: Option<String>,
+    },
     Minimize,
     ThemeChanged(Option<Theme>),
     #[cfg(windows)]

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -39,6 +39,8 @@ pub struct WindowSettings {
     pub input_macos_option_key_is_meta: OptionAsMeta,
     #[cfg(target_os = "macos")]
     pub macos_simple_fullscreen: bool,
+    #[cfg(target_os = "macos")]
+    pub highlight_matching_pair: bool,
     #[cfg(target_os = "windows")]
     pub title_background_color: String,
     #[cfg(target_os = "windows")]
@@ -85,6 +87,8 @@ impl Default for WindowSettings {
             input_macos_option_key_is_meta: OptionAsMeta::None,
             #[cfg(target_os = "macos")]
             macos_simple_fullscreen: false,
+            #[cfg(target_os = "macos")]
+            highlight_matching_pair: false,
             #[cfg(target_os = "windows")]
             title_background_color: "".to_string(),
             #[cfg(target_os = "windows")]

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -740,6 +740,25 @@ some cases the hack itself is buggy and prevents the cursor from moving to the c
 should. In that case you can try to disable it, especially if you are not using cursor animations
 and the flickering does not bother as much.
 
+#### Highlight Matching Pair (macOS only)
+
+VimScript:
+
+```vim
+let g:neovide_highlight_matching_pair = v:true
+```
+
+Lua:
+
+```lua
+vim.g.neovide_highlight_matching_pair = true
+```
+
+**Nightly.**
+
+When enabled, Neovide highlights the matching pair using the system find indicator. The
+default is `false`.
+
 ### Input Settings
 
 #### macOS Option Key is Meta


### PR DESCRIPTION
Introducing the native macOS find indicator effect for matching pairs.

Some time ago, I've seen this [request](https://github.com/neovide/neovide/issues/2918) made by @amwadud so I have been working on this since last week. Apple users are familiar with that yellow pop they see in apps like Xcode, so I think this will give a more native feeling/feedback for them.

It's a simple approach but took some time to refine. we basically hook into the highlight events to detect when the editor is pointing out a matching pair and if highlight matching is enabled we trigger the visual effect identifying the specific highlight id associated with matching parens. plus caching those grid coordinates to keep it smooth without scanning it every frame.

As I said this is opt-in by default just to keep things distraction free for users who prefer as it-is today. but for those who want that native visual feedback when navigating code, you have this option now.


https://github.com/user-attachments/assets/e7e7073a-0c8b-40e6-b9cb-1f8841235d0c

