### PR TITLE
fix: update colorscheme stream management at NeovimRuntime

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -107,8 +107,6 @@ fn main() -> ExitCode {
 
     let event_loop = create_event_loop();
     let clipboard = clipboard::Clipboard::new(&event_loop);
-    let colorscheme_stream = mundy::Preferences::stream(mundy::Interest::ColorScheme);
-
     let running_tracker = RunningTracker::new();
     let settings = Arc::new(Settings::new());
     let clipboard_handle = clipboard::ClipboardHandle::new(&clipboard);
@@ -118,7 +116,6 @@ fn main() -> ExitCode {
         running_tracker.clone(),
         settings.clone(),
         clipboard_handle.clone(),
-        colorscheme_stream,
     ) {
         Err(err) => handle_startup_errors(err, event_loop, settings.clone(), clipboard),
         Ok((window_size, initial_config, runtime)) => {
@@ -147,7 +144,6 @@ fn setup(
     running_tracker: RunningTracker,
     settings: Arc<Settings>,
     clipboard: clipboard::ClipboardHandle,
-    colorscheme_stream: mundy::PreferencesStream,
 ) -> Result<(WindowSize, Config, NeovimRuntime)> {
     //  --------------
     // | Architecture |
@@ -279,13 +275,7 @@ fn setup(
     };
 
     let mut runtime = NeovimRuntime::new(clipboard)?;
-    runtime.launch(
-        proxy,
-        grid_size,
-        running_tracker,
-        settings,
-        colorscheme_stream,
-    )?;
+    runtime.launch(proxy, grid_size, running_tracker, settings)?;
 
     Ok((window_size, config, runtime))
 }

--- a/src/window/application.rs
+++ b/src/window/application.rs
@@ -394,13 +394,13 @@ impl Application {
         // safely. see https://github.com/neovide/neovide/issues/3311
         self.clipboard.take();
 
-        if let Some(runtime) = self.runtime.take() {
+        if let Some(mut runtime) = self.runtime.take() {
             // Wait a little bit more and force Neovim to exit after that.
             // This should not be required, but Neovim through libuv spawns child processes that inherit all the handles.
             // This means that the stdio and stderr handles are not properly closed, so the nvim-rs
             // read will hang forever, waiting for more data to read.
             // See https://github.com/neovide/neovide/issues/2182 (which includes links to libuv issues)
-            runtime.runtime.shutdown_timeout(Duration::from_millis(500));
+            runtime.shutdown_timeout(Duration::from_millis(500));
         }
     }
 }


### PR DESCRIPTION
closes #3356

now we only instantiate the mundy stream after the Tokio runtime existence and settted as the current one, for then avoid the zbus lifecycle problem which spawn tasks without an active reactor.

we also make cleanup safer by dropping the stream under runtime context on launch failure and relying on runtime shutdown.

plus Drop as defensive fallback cleanup.

