### PR TITLE
feat: support  `title-hidden` option in full frame for macOS

### DIFF
--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -234,7 +234,7 @@ pub fn create_window(
 
     #[cfg(target_os = "macos")]
     let mut window_attributes = match frame_decoration {
-        Frame::Full => window_attributes,
+        Frame::Full => window_attributes.with_title_hidden(title_hidden),
         Frame::None => window_attributes.with_decorations(false),
         Frame::Buttonless => window_attributes
             .with_title_hidden(title_hidden)


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

Clarified `--title-hidden` option's behavior, according to the following code snippet:

https://github.com/neovide/neovide/blob/7a3f56830caf671ad884caff4990741336282a1e/src/window/mod.rs#L235-L248

## What kind of change does this PR introduce?

- Documentation

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
