### PR TITLE
fix: properly detach from the terminal when forking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,6 +911,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
+name = "fork"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30268f1eefccc9d72f43692e8b89e659aeb52e84016c3b32b6e7e9f1c8f38f94"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,6 +1599,7 @@ dependencies = [
  "derive-new",
  "dirs",
  "flexi_logger",
+ "fork",
  "futures 0.3.31",
  "gl",
  "glamour",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,6 +188,7 @@ shlex = "1.3.0"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 rustix = { version = "1.0.8", features = ["fs"] }
+fork = "0.4.0"
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winres = "0.1.12"

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,18 +322,25 @@ fn maybe_disown(settings: &Settings) {
         return;
     }
 
-    if let Ok(current_exe) = env::current_exe() {
-        assert!(process::Command::new(current_exe)
-            .stdin(process::Stdio::null())
-            .stdout(process::Stdio::null())
-            .stderr(process::Stdio::null())
-            .args(env::args().skip(1))
-            .spawn()
-            .is_ok());
-        process::exit(0);
-    } else {
-        eprintln!("error in disowning process, cannot obtain the path for the current executable, continuing without disowning...");
-    }
+    match fork::daemon(true, false) {
+        Ok(fork::Fork::Parent(_)) => process::exit(0),
+        Ok(fork::Fork::Child) => {
+            if let Ok(current_exe) = env::current_exe() {
+                assert!(process::Command::new(current_exe)
+                    .stdin(process::Stdio::null())
+                    .stdout(process::Stdio::null())
+                    .stderr(process::Stdio::null())
+                    .args(env::args().skip(1))
+                    .spawn()
+                    .is_ok());
+                process::exit(0);
+            } else {
+                eprintln!("error in disowning process, cannot obtain the path for the current executable, exiting...");
+                process::exit(1);
+            }
+        }
+        Err(_) => eprintln!("error in disowning process, continuing without disowning..."),
+    };
 }
 
 fn generate_stderr_log_message(panic_info: &PanicHookInfo, backtrace: &Backtrace) -> String {


### PR DESCRIPTION
If Neovide is run in forking mode with a terminal and the shell from which it is invoked exits, Neovide is killed.  This can be easily seen with `env -u TMUX tmux new 'neovide --fork; sleep 3'`.

To avoid that, we must detach from the terminal using the double-fork technique, which calls `setsid` and closes the file descriptors after the first fork so that we detach from the terminal.  Then, when the caller exits, we will not receive a SIGHUP and will continue running.

This is implemented in the `fork` crate, which contains an analogue of the `daemon` function found on Linux and the BSDs, so use that here to detach properly.

Fixes #3362

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- No
