### PR TITLE
Add g:neovide_pixel_geometry setting

### DIFF
--- a/src/renderer/d3d.rs
+++ b/src/renderer/d3d.rs
@@ -7,7 +7,7 @@ use skia_safe::{
         BackendRenderTarget, DirectContext, FlushInfo, Protected, SurfaceOrigin, SyncCpu,
     },
     surface::BackendSurfaceAccess,
-    Canvas, ColorSpace, ColorType, PixelGeometry, Surface, SurfaceProps, SurfacePropsFlags,
+    Canvas, ColorSpace, ColorType, Surface, SurfaceProps, SurfacePropsFlags,
 };
 use windows::core::{Interface, Result, PCWSTR};
 use windows::Win32::Graphics::DirectComposition::{
@@ -369,7 +369,7 @@ impl D3DSkiaRenderer {
 
             let surface_props = SurfaceProps::new_with_text_properties(
                 SurfacePropsFlags::default(),
-                PixelGeometry::default(),
+                render_settings.pixel_geometry.into(),
                 render_settings.text_contrast,
                 render_settings.text_gamma,
             );

--- a/src/renderer/metal.rs
+++ b/src/renderer/metal.rs
@@ -15,7 +15,7 @@ use skia_safe::{
         surfaces::wrap_backend_render_target,
         DirectContext, SurfaceOrigin,
     },
-    Canvas, ColorSpace, ColorType, PixelGeometry, Surface, SurfaceProps, SurfacePropsFlags,
+    Canvas, ColorSpace, ColorType, Surface, SurfaceProps, SurfacePropsFlags,
 };
 use winit::{event_loop::EventLoopProxy, window::Window};
 
@@ -52,7 +52,7 @@ impl MetalDrawableSurface {
 
         let surface_props = SurfaceProps::new_with_text_properties(
             SurfacePropsFlags::default(),
-            PixelGeometry::default(),
+            render_settings.pixel_geometry.into(),
             render_settings.text_contrast,
             render_settings.text_gamma,
         );

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -37,7 +37,10 @@ use crate::{
     cmd_line::CmdLineSettings,
     editor::{Cursor, Style, WindowType},
     profiling::{tracy_create_gpu_context, tracy_named_frame, tracy_zone},
-    renderer::rendered_layer::{group_windows, FloatingLayer},
+    renderer::{
+        fonts::font_options::PixelGeometry,
+        rendered_layer::{group_windows, FloatingLayer},
+    },
     settings::*,
     units::{to_skia_rect, GridRect, GridSize, PixelPos},
     window::{ShouldRender, UserEvent},
@@ -104,6 +107,7 @@ pub struct RendererSettings {
     text_gamma: f32,
     text_contrast: f32,
     experimental_layer_grouping: bool,
+    pixel_geometry: PixelGeometry,
 }
 
 impl Default for RendererSettings {
@@ -126,6 +130,7 @@ impl Default for RendererSettings {
             text_gamma: 0.0,
             text_contrast: 0.5,
             experimental_layer_grouping: false,
+            pixel_geometry: PixelGeometry::default(),
         }
     }
 }

--- a/src/renderer/opengl.rs
+++ b/src/renderer/opengl.rs
@@ -24,7 +24,7 @@ use skia_safe::{
         backend_render_targets::make_gl, gl::FramebufferInfo, surfaces::wrap_backend_render_target,
         DirectContext, SurfaceOrigin,
     },
-    ColorSpace, ColorType, PixelGeometry, SurfaceProps, SurfacePropsFlags,
+    ColorSpace, ColorType, SurfaceProps, SurfacePropsFlags,
 };
 use winit::{
     dpi::PhysicalSize,
@@ -289,7 +289,7 @@ fn create_surface(
 
     let surface_props = SurfaceProps::new_with_text_properties(
         SurfacePropsFlags::default(),
-        PixelGeometry::default(),
+        render_settings.pixel_geometry.into(),
         render_settings.text_contrast,
         render_settings.text_gamma,
     );

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -359,7 +359,9 @@ impl WinitWindowWrapper {
 
     fn handle_render_settings_changed(&mut self, changed_setting: RendererSettingsChanged) {
         match changed_setting {
-            RendererSettingsChanged::TextGamma(..) | RendererSettingsChanged::TextContrast(..) => {
+            RendererSettingsChanged::TextGamma(..)
+            | RendererSettingsChanged::TextContrast(..)
+            | RendererSettingsChanged::PixelGeometry(..) => {
                 if let Some(skia_renderer) = &mut self.skia_renderer {
                     skia_renderer.resize();
                 }

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -167,6 +167,33 @@ a gamma of 0.8 and a contrast of 0.1.
 Note a gamma of 0.0, means standard sRGB gamma or 2.2. Also note that these settings don't
 necessarily apply immediately due to caching of the fonts.
 
+#### Pixel geometry
+
+VimScript:
+
+```vim
+let g:neovide_pixel_geometry = "RGBH"
+let g:neovide_pixel_geometry = "RGBH"
+```
+
+Lua:
+
+```lua
+vim.g.neovide_pixel_geometry = "RGBH"
+vim.g.neovide_pixel_geometry = "RGBH"
+```
+
+**Nightly.**
+
+Required for the guifont option `#e-subpixelantialias` to work. Defaults to "Unknown".
+
+Represents the physical location of the red, green, and blue light-emitting elements of your
+monitor. Possible options are "RGBH" (red on the left, green in the middle, and blue on the right,
+layed out horizontally), "BGRH" (horizontal, but flipped), "RGBV" (red on top, blue on bottom),
+"BGRV" (blue on top, red on bottom), and "Unknown" (effectively disables subpixel antialiasing).
+
+Most monitors are RGBH. If your monitor is rotated, it's probably something else.
+
 #### Padding
 
 VimScript:


### PR DESCRIPTION
Fixes https://github.com/neovide/neovide/issues/3136

In testing this PR, it appears that once you set `vim.g.neovide_pixel_geometry`, you need to resize the window (or trigger a redraw or something, I suppose) for the content to update to rerender with the new setting. Also, it appears that RGBV/BGRV do nothing on Windows at least (setting it to it makes text greyscale-aliased for me), but that's probably some Skia issue, and might be different on different platforms - the vertical setting is at least there for the future, in case Skia changes.

Not implemented in this PR is fetching the value from the OS. I know that Wayland exposes this value in its protocol, and surely Windows has some API to fetch the current cleartype pixel geometry setting, same for Mac, but I have no idea how that value might be plumbed through whatever graphics API that we can fetch it from. At least this PR allows the setting to be "hardcoded" by users - fetching it from the OS can be done in a later PR, IMO.

In my silly little opinion, this setting should default to Unknown, but in the issue, @fredizzimo said:

> I think we could set `RGBH` as the default, since the majority of the monitors have that layout.

which, valid, I suppose! :sparkles: