### PR TITLE
fix: copy command output by drag selection

### DIFF
--- a/src/renderer/rendered_layer.rs
+++ b/src/renderer/rendered_layer.rs
@@ -96,6 +96,7 @@ impl FloatingLayer<'_> {
                 id: window.id,
                 region: regions[i],
                 grid_size: window.grid_size,
+                window_type: window.window_type,
             });
         });
 

--- a/src/window/application.rs
+++ b/src/window/application.rs
@@ -128,8 +128,13 @@ impl Application {
         let cmd_line_settings = settings.get::<CmdLineSettings>();
         let idle = cmd_line_settings.idle;
 
-        let window_wrapper =
-            WinitWindowWrapper::new(initial_window_size, initial_config, settings.clone());
+        let clipboard_handle = clipboard::ClipboardHandle::new(&clipboard);
+        let window_wrapper = WinitWindowWrapper::new(
+            initial_window_size,
+            initial_config,
+            settings.clone(),
+            clipboard_handle,
+        );
 
         Self {
             idle,

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -57,6 +57,7 @@ use crate::{
 pub use application::Application;
 pub use application::ShouldRender;
 pub use error_window::show_error_window;
+pub use mouse_manager::{MessageSelectionEvent, MouseEventResult, OverlayEvent};
 pub use settings::{ThemeSettings, WindowSettings, WindowSettingsChanged};
 pub use window_wrapper::WinitWindowWrapper;
 


### PR DESCRIPTION
fixes https://github.com/neovide/neovide/issues/2368

introducing a client renderer Message selection overlay keyed by grid id and grid coordinates, driven by mouse drag in the message window. since we only have per-cell characters for message output, with no hard-wrap metadata, selection becomes a necessity to be grid based.

we keep this feature strictly client-side to avoid keybinding conflicts and leave the editor grid untouched. selection is mouse-drag only and scoped to *Message* window, with clipping the window borders and no auto-scroll beyond the visible area (for now).
