### PR TITLE
bump skia-safe to 0.93.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2176,6 +2176,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
 name = "objc2-uniform-type-identifiers"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2839,9 +2851,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "skia-bindings"
-version = "0.91.0"
+version = "0.93.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd9bbd87993cbe4c0caa5fa6ca69c7d2ed38dcf5cd967b200392840c3bc666"
+checksum = "cbb363ec9c62e2b0f48c7f62f1cb53ede1a4fcaec4640205197e27e8bfad07d2"
 dependencies = [
  "bindgen",
  "cc",
@@ -2856,11 +2868,18 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.91.1"
+version = "0.93.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c13e5913d17403753fd8cc2c15402e8d9ba8278d1b82a12aa7264a63f9c6325"
+checksum = "f5b1e4737fcde38a2bbe414ba4fbdaaec9e925f13642e4a81941225d399b007c"
 dependencies = [
  "bitflags 2.10.0",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "objc2-ui-kit 0.3.2",
+ "raw-window-handle",
  "skia-bindings",
  "windows",
 ]
@@ -4030,7 +4049,7 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
- "objc2-ui-kit",
+ "objc2-ui-kit 0.2.2",
  "orbclient",
  "percent-encoding",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ scoped-env = "2.1.0"
 serial_test = "3.2.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-skia-safe = { version = "0.91.1", features = ["gl", "d3d", "textlayout"] }
+skia-safe = { version = "0.93.0", features = ["gl", "d3d", "textlayout"] }
 # This needs to match the version used by skia
 windows = { version = "0.62.0", features = [
   "Win32_Graphics_Direct3D",
@@ -179,11 +179,11 @@ objc2-metal = { version = "0.3.1", default-features = false, features = [
   "MTLCommandQueue",
   "MTLCommandBuffer",
 ] }
-skia-safe = { version = "0.91.1", features = ["metal", "gl", "textlayout"] }
+skia-safe = { version = "0.93.0", features = ["metal", "gl", "textlayout"] }
 uzers = "0.12.1"
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos")))'.dependencies]
-skia-safe = { version = "0.91.1", features = ["gl", "textlayout"] }
+skia-safe = { version = "0.93.0", features = ["gl", "textlayout"] }
 
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
 csscolorparser = "0.7.0"


### PR DESCRIPTION
shouldn't have any breaking changes.