### PR TITLE
fonts: we now make guifont parser non-fatal for partial fallback misses

### DIFF
--- a/src/renderer/fonts/font_options.rs
+++ b/src/renderer/fonts/font_options.rs
@@ -145,6 +145,7 @@ impl FontOptions {
         if let Some(parts) = parts.next() {
             let parsed_font_list = parts
                 .split(FONT_LIST_SEPARATOR)
+                .map(str::trim_ascii)
                 .filter(|fallback| !fallback.is_empty())
                 .map(parse_font_name)
                 .collect_vec();


### PR DESCRIPTION
fixes https://github.com/neovide/neovide/issues/3370

Neovim commit [249f305](https://github.com/neovim/neovim/pull/37175) changed 'guifont' the default from empty to per-platform font loading.

Previously when any candidate failed to load we were about to report a *hard*. error for normal fallback situations. for example missing SF Mono style variants on macOS and others on linux, even when other fallback fonts were available and rendering continued. we now adjust this.

The second neovide parser problem was lack of resilience. due to this neovim upstream change the whitespace prefix loads a failed font. we now trim that parsed font names to avoid whitespace-related font family mismatches in comma-separated guifont lists.