### PR TITLE
fix: avoid nvim default guifont overriding config

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -195,6 +195,9 @@ impl Renderer {
         let scale_factor = user_scale_factor * os_scale_factor;
         let cursor_renderer = CursorRenderer::new(settings.clone());
         let mut grid_renderer = GridRenderer::new(scale_factor, settings.clone());
+        let mut font_config_state = settings.get::<FontConfigState>();
+        font_config_state.has_font = init_config.font.is_some();
+        settings.set(&font_config_state);
         grid_renderer.update_font_options(init_config.font.map(|x| x.into()).unwrap_or_default());
         grid_renderer.handle_box_drawing_update(init_config.box_drawing.unwrap_or_default());
         let current_mode = EditorMode::Unknown(String::from(""));
@@ -480,15 +483,20 @@ impl Renderer {
 
     pub fn handle_config_changed(&mut self, config: HotReloadConfigs) {
         match config {
-            HotReloadConfigs::Font(font) => match font {
-                Some(font) => {
-                    self.grid_renderer.update_font_options(font.into());
+            HotReloadConfigs::Font(font) => {
+                let mut font_config_state = self.settings.get::<FontConfigState>();
+                font_config_state.has_font = font.is_some();
+                self.settings.set(&font_config_state);
+                match font {
+                    Some(font) => {
+                        self.grid_renderer.update_font_options(font.into());
+                    }
+                    None => {
+                        self.grid_renderer
+                            .update_font_options(FontOptions::default());
+                    }
                 }
-                None => {
-                    self.grid_renderer
-                        .update_font_options(FontOptions::default());
-                }
-            },
+            }
             HotReloadConfigs::BoxDrawing(settings) => self
                 .grid_renderer
                 .handle_box_drawing_update(settings.unwrap_or_default()),

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -30,6 +30,17 @@ pub trait SettingGroup {
     fn register(settings: &Settings);
 }
 
+#[derive(Clone, Debug)]
+pub struct FontConfigState {
+    pub has_font: bool,
+}
+
+impl FontConfigState {
+    pub fn new() -> Self {
+        Self { has_font: false }
+    }
+}
+
 // Function types to handle settings updates
 type UpdateHandlerFunc = fn(&Settings, Value) -> SettingsChanged;
 type ReaderHandlerFunc = fn(&Settings) -> Option<Value>;
@@ -58,7 +69,9 @@ pub enum SettingLocation {
 
 impl Settings {
     pub fn new() -> Self {
-        Self::default()
+        let settings = Self::default();
+        settings.set(&FontConfigState::new());
+        settings
     }
 
     pub fn set_setting_handlers(


### PR DESCRIPTION
fixes https://github.com/neovide/neovide/issues/3373

users who relied on config.toml for setting their font were also impacted...
neovim ui sends an option_set guifont on *attach* even when the user never sets it,
that overwrote the font from config.toml which is not what we want

if the user sets guifont explicitly, that should still override config
so we check https://neovim.io/doc/user/api.html#nvim_get_option_info2()
was_set at event time.