### PR TITLE
fix: set font state before ui_attach to avoid default guifont override

### DIFF
--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -236,8 +236,7 @@ async fn skip_default_guifont(
     settings: &Settings,
     nvim: &Neovim<NeovimWriter>,
 ) -> bool {
-    let from_config = settings.get::<FontConfigState>().has_font;
-    if !from_config || !is_guifont_option_set(event) {
+    if !settings.get::<FontConfigState>().has_font || !is_guifont_option_set(event) {
         return false;
     }
 

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -315,6 +315,7 @@ impl NeovimRuntime {
         grid_size: Option<GridSize<u32>>,
         running_tracker: RunningTracker,
         settings: Arc<Settings>,
+        config: &Config,
     ) -> Result<()> {
         let mut colorscheme_stream = self.colorscheme_stream();
         let handler = self.handler(event_loop_proxy.clone(), running_tracker, settings.clone());
@@ -322,6 +323,10 @@ impl NeovimRuntime {
             .runtime()
             .block_on(initial_background_from_stream(&mut colorscheme_stream));
         self.set_background_preference(&initial_background);
+
+        let mut font_config_state = settings.get::<FontConfigState>();
+        font_config_state.has_font = config.font.is_some();
+        settings.set(&font_config_state);
 
         let session = match self.runtime().block_on(launch(
             handler,

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,7 +275,7 @@ fn setup(
     };
 
     let mut runtime = NeovimRuntime::new(clipboard)?;
-    runtime.launch(proxy, grid_size, running_tracker, settings)?;
+    runtime.launch(proxy, grid_size, running_tracker, settings, &config)?;
 
     Ok((window_size, config, runtime))
 }


### PR DESCRIPTION
mistakenly moved has_font setup to after ui_attach.
