### PR TITLE
improv: on macos use ppid heuristic for gui launch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ csscolorparser = "0.7.0"
 shlex = "1.3.0"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-rustix = { version = "1.0.8", features = ["fs"] }
+rustix = { version = "1.0.8", features = ["fs", "process"] }
 fork = "0.4.0"
 
 [target.'cfg(target_os = "windows")'.build-dependencies]


### PR DESCRIPTION
we now stop using `$TERM` to decide when to wrap neovim in a login shell, so we check and treat ppid as a gui launch signal.

https://en.wikipedia.org/wiki/Launchd#Components
