### PR TITLE
fix: queue file drops until handler exists on macOS

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -47,7 +47,7 @@ pub use events::*;
 pub use restart::RestartDetails;
 pub use session::NeovimWriter;
 #[cfg(target_os = "macos")]
-pub use ui_commands::get_active_handler;
+pub use ui_commands::send_or_queue_file_drop;
 pub use ui_commands::{
     require_active_handler, send_ui, set_active_route_handler, start_ui_command_handler,
     unregister_route_handler, ParallelCommand, SerialCommand,

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -33,12 +33,39 @@ pub static HANDLER_REGISTRY: LazyLock<Mutex<Option<NeovimHandler>>> =
 pub static ROUTE_HANDLER_REGISTRY: LazyLock<Mutex<HashMap<RouteId, NeovimHandler>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
+/// Startup buffer for macOS cold start. file drops that can arrive before any
+/// neovim handler is active. Flushed when the first route handler registers
+#[cfg(target_os = "macos")]
+static PENDING_FILE_DROPS: LazyLock<Mutex<Vec<String>>> = LazyLock::new(|| Mutex::new(Vec::new()));
+
 pub fn get_active_handler() -> Option<NeovimHandler> {
     HANDLER_REGISTRY.lock().unwrap().clone()
 }
 
 pub fn require_active_handler() -> NeovimHandler {
     get_active_handler().expect("NeovimHandler has not been initialized")
+}
+
+#[cfg(target_os = "macos")]
+pub fn send_or_queue_file_drop(path: String) {
+    if let Some(handler) = get_active_handler() {
+        send_ui(ParallelCommand::FileDrop(path), &handler);
+        return;
+    }
+
+    PENDING_FILE_DROPS.lock().unwrap().push(path);
+}
+
+#[cfg(target_os = "macos")]
+fn flush_pending_file_drops(handler: &NeovimHandler) {
+    let pending = {
+        let mut pending = PENDING_FILE_DROPS.lock().unwrap();
+        std::mem::take(&mut *pending)
+    };
+
+    for path in pending {
+        send_ui(ParallelCommand::FileDrop(path), handler);
+    }
 }
 
 async fn ime_call(
@@ -371,6 +398,8 @@ pub fn start_ui_command_handler(
 ) {
     handler.update_current_neovim(nvim, can_support_ime_api);
     register_route_handler(route_id, handler.clone());
+    #[cfg(target_os = "macos")]
+    flush_pending_file_drops(&handler);
     if handler.mark_ui_command_started() {
         return;
     }

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -31,8 +31,7 @@ use objc2_foundation::{
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
 use crate::bridge::{
-    get_active_handler, require_active_handler, send_ui, NeovimHandler, ParallelCommand,
-    SerialCommand,
+    require_active_handler, send_or_queue_file_drop, send_ui, NeovimHandler, SerialCommand,
 };
 use crate::renderer::fonts::font_options::FontOptions;
 use crate::settings::Settings;
@@ -1768,10 +1767,8 @@ pub fn is_tab_overview_active() -> bool {
 
 pub fn register_file_handler() {
     fn dispatch_file_drops(filenames: &NSArray<NSString>) {
-        if let Some(handler) = get_active_handler() {
-            for filename in filenames.iter() {
-                send_ui(ParallelCommand::FileDrop(filename.to_string()), &handler);
-            }
+        for filename in filenames.iter() {
+            send_or_queue_file_drop(filename.to_string());
         }
     }
 


### PR DESCRIPTION
The multi-window refactor made macOS openFiles depend on the active handler.

now we bring back the old behavior by buffering file drops until the first route handler registers, then flush.