### PR TITLE
fix: fill the trailing right-edge gap

### DIFF
--- a/src/renderer/grid_renderer.rs
+++ b/src/renderer/grid_renderer.rs
@@ -1,7 +1,9 @@
 use std::{ops::Range, sync::Arc};
 
 use log::trace;
-use skia_safe::{colors, dash_path_effect, BlendMode, Canvas, Color, Paint, PathBuilder, HSV};
+use skia_safe::{
+    colors, dash_path_effect, BlendMode, Canvas, Color, Color4f, Paint, PathBuilder, HSV,
+};
 
 use crate::{
     editor::{Colors, LineFragment, Style, UnderlineStyle},
@@ -121,6 +123,30 @@ impl GridRenderer {
         let alpha = opacity * (100 - self.default_style.blend) as f32 / 100.0;
         self.get_default_background_color()
             .with_a((alpha * 255.0) as u8)
+    }
+
+    pub fn background_paint_color(&self, style: &Option<Arc<Style>>, opacity: f32) -> Color4f {
+        let style = style.as_ref().unwrap_or(&self.default_style);
+        let style_background = style.background(&self.default_style.colors).to_color();
+
+        let mut paint = Paint::default();
+        paint.set_anti_alias(false);
+        paint.set_blend_mode(BlendMode::Src);
+        paint.set_color(style_background);
+
+        let is_default_background = style_background == self.get_default_background_color();
+        let normal_opacity = self.settings.get::<WindowSettings>().normal_opacity;
+
+        let alpha = if normal_opacity < 1.0 && is_default_background {
+            normal_opacity
+        } else if style.blend > 0 {
+            ((100 - style.blend) as f32 / 100.0) * opacity
+        } else {
+            opacity
+        };
+
+        paint.set_alpha_f(alpha);
+        paint.color4f()
     }
 
     /// Draws a single background cell with the same style

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -43,7 +43,7 @@ use crate::{
         rendered_layer::{group_windows, FloatingLayer},
     },
     settings::*,
-    units::{to_skia_rect, GridPos, GridRect, GridScale, GridSize, PixelPos},
+    units::{to_skia_rect, GridPos, GridRect, GridScale, GridSize, PixelPos, PixelRect},
     window::{EventPayload, ShouldRender},
     WindowSettings,
 };
@@ -241,7 +241,12 @@ impl Renderer {
         self.cursor_renderer.prepare_frame()
     }
 
-    pub fn draw_frame(&mut self, root_canvas: &Canvas, dt: f32) {
+    pub fn draw_frame(
+        &mut self,
+        root_canvas: &Canvas,
+        content_region: Option<&PixelRect<f32>>,
+        dt: f32,
+    ) {
         tracy_zone!("renderer_draw_frame");
         let window_settings = self.settings.get::<WindowSettings>();
         let opacity = if window_settings.normal_opacity < 1.0 {
@@ -260,7 +265,9 @@ impl Renderer {
         root_canvas.save();
         root_canvas.reset_matrix();
 
-        if let Some(root_window) = self.rendered_windows.get(&1) {
+        if let Some(content_region) = content_region {
+            root_canvas.clip_rect(to_skia_rect(content_region), None, Some(false));
+        } else if let Some(root_window) = self.rendered_windows.get(&1) {
             let clip_rect = to_skia_rect(&root_window.pixel_region(grid_scale));
             root_canvas.clip_rect(clip_rect, None, Some(false));
         }
@@ -336,15 +343,32 @@ impl Renderer {
         };
 
         let settings = self.settings.get::<RendererSettings>();
+        let max_root_x = max_window_max_x(&root_windows, grid_scale);
         let root_window_regions = root_windows
             .into_iter()
-            .map(|window| window.draw(root_canvas, default_background, grid_scale))
+            .map(|window| {
+                let region = window.pixel_region(grid_scale);
+                let rightmost_root_window = is_rightmost_window_edge(region.max.x, max_root_x);
+                window.draw(
+                    root_canvas,
+                    default_background,
+                    grid_scale,
+                    content_region.copied(),
+                    rightmost_root_window,
+                )
+            })
             .collect_vec();
 
         let floating_window_regions = floating_layers
             .into_iter()
             .flat_map(|mut layer| {
-                layer.draw(root_canvas, &settings, default_background, grid_scale)
+                layer.draw(
+                    root_canvas,
+                    &settings,
+                    default_background,
+                    grid_scale,
+                    content_region.copied(),
+                )
             })
             .collect_vec();
 
@@ -615,6 +639,17 @@ impl Renderer {
             DEFAULT_GRID_SIZE
         }
     }
+}
+
+pub fn is_rightmost_window_edge(region_max_x: f32, max_x: f32) -> bool {
+    max_x.is_finite() && (region_max_x - max_x).abs() <= f32::EPSILON
+}
+
+pub fn max_window_max_x(windows: &[&mut RenderedWindow], grid_scale: GridScale) -> f32 {
+    windows.iter().fold(f32::NEG_INFINITY, |max_x, window| {
+        let region = window.pixel_region(grid_scale);
+        max_x.max(region.max.x)
+    })
 }
 
 /// Defines how floating windows are sorted.

--- a/src/renderer/rendered_layer.rs
+++ b/src/renderer/rendered_layer.rs
@@ -13,7 +13,7 @@ use crate::{
     units::{to_skia_rect, GridScale, PixelRect},
 };
 
-use super::{RenderedWindow, RendererSettings, WindowDrawDetails};
+use super::{is_rightmost_window_edge, RenderedWindow, RendererSettings, WindowDrawDetails};
 
 struct LayerWindow<'w> {
     window: &'w mut RenderedWindow,
@@ -25,27 +25,59 @@ pub struct FloatingLayer<'w> {
 }
 
 impl FloatingLayer<'_> {
+    fn build_draw_clip_and_bounds(
+        &self,
+        mut draw_clip: Path,
+        mut draw_bound_rect: Rect,
+        expanded_regions: &[PixelRect<f32>],
+        grid_scale: GridScale,
+    ) -> (Path, Rect) {
+        for (window, region) in self.windows.iter().zip(expanded_regions.iter().copied()) {
+            if let Some((path, bounds)) = window.trailing_fill_path_and_bounds(region, grid_scale) {
+                if let Some(unioned) = draw_clip.op(&path, PathOp::Union) {
+                    draw_clip = unioned;
+                }
+                draw_bound_rect = Rect::join2(draw_bound_rect, bounds);
+            }
+        }
+
+        (draw_clip, draw_bound_rect)
+    }
+
     pub fn draw(
         &mut self,
         root_canvas: &Canvas,
         settings: &RendererSettings,
         default_background: Color,
         grid_scale: GridScale,
+        content_region: Option<PixelRect<f32>>,
     ) -> Vec<WindowDrawDetails> {
         let pixel_regions = self
             .windows
             .iter()
             .map(|window| window.pixel_region(grid_scale))
             .collect::<Vec<_>>();
+        let max_layer_x = max_region_max_x(&pixel_regions);
+        let regions = self
+            .windows
+            .iter()
+            .zip(pixel_regions.iter().copied())
+            .map(|(window, region)| {
+                let rightmost_window = is_rightmost_window_edge(region.max.x, max_layer_x);
+                window.expanded_pixel_region(region, content_region, grid_scale, rightmost_window)
+            })
+            .collect::<Vec<_>>();
+
         let (silhouette, bound_rect) = build_silhouette(&pixel_regions, settings, grid_scale);
+        let (draw_clip, draw_bound_rect) =
+            self.build_draw_clip_and_bounds(silhouette.clone(), bound_rect, &regions, grid_scale);
         let has_transparency = self.windows.iter().any(|window| window.has_transparency());
 
         self._draw_shadow(root_canvas, &silhouette, settings);
 
         root_canvas.save();
-        root_canvas.clip_path(&silhouette, None, Some(false));
+        root_canvas.clip_path(&draw_clip, None, Some(false));
         let need_blur = has_transparency || settings.floating_blur;
-
         if need_blur {
             if let Some(blur) = blur(
                 (
@@ -62,7 +94,7 @@ impl FloatingLayer<'_> {
                     .to_owned();
                 let save_layer_rec = SaveLayerRec::default()
                     .backdrop(&blur)
-                    .bounds(&bound_rect)
+                    .bounds(&draw_bound_rect)
                     .paint(&paint);
                 root_canvas.save_layer(&save_layer_rec);
                 root_canvas.restore();
@@ -74,24 +106,19 @@ impl FloatingLayer<'_> {
             .set_blend_mode(BlendMode::SrcOver)
             .to_owned();
 
-        let save_layer_rec = SaveLayerRec::default().bounds(&bound_rect).paint(&paint);
+        let save_layer_rec = SaveLayerRec::default()
+            .bounds(&draw_bound_rect)
+            .paint(&paint);
 
         root_canvas.save_layer(&save_layer_rec);
         let background_paint = Paint::default().set_color(default_background).to_owned();
-        root_canvas.draw_path(&silhouette, &background_paint);
-
-        let regions = self
-            .windows
-            .iter()
-            .map(|window| window.pixel_region(grid_scale))
-            .collect::<Vec<_>>();
-
+        root_canvas.draw_path(&draw_clip, &background_paint);
         let mut ret = vec![];
 
         (0..self.windows.len()).for_each(|i| {
             let window = &mut self.windows[i];
-            window.draw_background_surface(root_canvas, regions[i], grid_scale);
-            window.draw_foreground_surface(root_canvas, regions[i], grid_scale);
+            window.draw_background_surface(root_canvas, pixel_regions[i], grid_scale);
+            window.draw_foreground_surface(root_canvas, pixel_regions[i], grid_scale);
             ret.push(WindowDrawDetails {
                 id: window.id,
                 region: regions[i],
@@ -99,6 +126,10 @@ impl FloatingLayer<'_> {
                 window_type: window.window_type,
             });
         });
+
+        for (window, region) in self.windows.iter().zip(regions.iter().copied()) {
+            window.draw_trailing_background_surface(root_canvas, region, grid_scale);
+        }
 
         root_canvas.restore();
 
@@ -227,6 +258,12 @@ fn build_silhouette(
         .unwrap();
 
     (silhouette, bounding_rect)
+}
+
+fn max_region_max_x(regions: &[PixelRect<f32>]) -> f32 {
+    regions
+        .iter()
+        .fold(f32::NEG_INFINITY, |max_x, region| max_x.max(region.max.x))
 }
 
 fn rect_to_round_rect_path(rect: Rect, settings: &RendererSettings, grid_scale: GridScale) -> Path {

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -1,6 +1,8 @@
 use std::{cell::RefCell, rc::Rc};
 
-use skia_safe::{Canvas, Color, Matrix, Picture, PictureRecorder, Rect};
+use skia_safe::{
+    Canvas, Color, Color4f, Matrix, Paint, Path, PathBuilder, Picture, PictureRecorder, Rect,
+};
 
 use crate::{
     bridge::WindowAnchor,
@@ -16,6 +18,13 @@ use crate::{
 #[cfg(target_os = "macos")]
 pub const BASE_GRID_ID: u64 = 1;
 pub const NO_MULTIGRID_GRID_ID: u64 = 0;
+
+// Window layouts can leave a tiny remainder to the right of the last full
+// grid cell when the content width is not an exact multiple of the cell
+// width. We extend the last column's background slightly into that gap, capped
+// to a few cell widths so the line never appears visibly stretched if the grid
+// briefly lags a resize.
+const MAX_TRAILING_FILL_CELLS: f32 = 1.0;
 
 #[derive(Debug)]
 pub struct ViewportMargins {
@@ -66,8 +75,14 @@ struct RenderedLine {
     background_picture: Option<Picture>,
     foreground_picture: Option<Picture>,
     boxchar_picture: Option<(Picture, PixelPos<f32>)>,
+    trailing_background: Option<Color4f>,
     has_transparency: bool,
     is_valid: bool,
+}
+
+struct TrailingFillRect {
+    rect: Rect,
+    color: Color4f,
 }
 
 pub struct RenderedWindow {
@@ -247,8 +262,11 @@ impl RenderedWindow {
                 pics += 1;
             }
         }
+
         log::trace!("region: {pixel_region:?}, inner: {inner_region:?}, pics: {pics}");
         canvas.restore();
+
+        self.draw_trailing_background_surface(canvas, pixel_region, grid_scale);
     }
 
     pub fn draw_foreground_surface(
@@ -314,9 +332,17 @@ impl RenderedWindow {
         root_canvas: &Canvas,
         default_background: Color,
         grid_scale: GridScale,
+        content_region: Option<PixelRect<f32>>,
+        rightmost_window: bool,
     ) -> WindowDrawDetails {
         let pixel_region_box = self.pixel_region(grid_scale);
-        let pixel_region = to_skia_rect(&pixel_region_box);
+        let draw_region_box = self.expanded_pixel_region(
+            pixel_region_box,
+            content_region,
+            grid_scale,
+            rightmost_window,
+        );
+        let pixel_region = to_skia_rect(&draw_region_box);
 
         if !self.valid {
             return WindowDrawDetails {
@@ -331,17 +357,174 @@ impl RenderedWindow {
         root_canvas.clip_rect(pixel_region, None, Some(false));
         root_canvas.clear(default_background);
 
-        self.draw_background_surface(root_canvas, pixel_region_box, grid_scale);
-        self.draw_foreground_surface(root_canvas, pixel_region_box, grid_scale);
+        self.draw_background_surface(root_canvas, draw_region_box, grid_scale);
+        self.draw_foreground_surface(root_canvas, draw_region_box, grid_scale);
 
         root_canvas.restore();
 
         WindowDrawDetails {
             id: self.id,
-            region: pixel_region_box,
+            region: draw_region_box,
             grid_size: self.grid_size,
             window_type: self.window_type,
         }
+    }
+
+    pub fn expanded_pixel_region(
+        &self,
+        pixel_region: PixelRect<f32>,
+        content_region: Option<PixelRect<f32>>,
+        grid_scale: GridScale,
+        rightmost_window: bool,
+    ) -> PixelRect<f32> {
+        let Some(content_region) = content_region else {
+            return pixel_region;
+        };
+
+        let mut region = pixel_region;
+        let right_gap = content_region.max.x - region.max.x;
+        if rightmost_window
+            && right_gap > 0.0
+            && right_gap <= grid_scale.width() * MAX_TRAILING_FILL_CELLS + f32::EPSILON
+        {
+            region.max.x = content_region.max.x;
+        }
+
+        region
+    }
+
+    pub fn draw_trailing_background_surface(
+        &self,
+        canvas: &Canvas,
+        pixel_region: PixelRect<f32>,
+        grid_scale: GridScale,
+    ) {
+        let mut paint = Paint::default();
+        paint.set_anti_alias(false);
+        paint.set_blend_mode(skia_safe::BlendMode::SrcOver);
+
+        // the trailing fill follows the same clipping model as the normal
+        // background pass. fixed rows like border and margins rows can
+        // paint across the full window region, but scrollable rows need
+        // stay inside the inner viewport. So keeping those as separate
+        // clip scopes prevents the buffered scroll rows from leaking into
+        // fixed UI rows.
+        canvas.save();
+        canvas.clip_rect(to_skia_rect(&pixel_region), None, false);
+
+        for fill in self.trailing_fill_rects(pixel_region, grid_scale) {
+            paint.set_color4f(fill.color, None);
+            canvas.draw_rect(fill.rect, &paint);
+        }
+
+        canvas.restore();
+    }
+
+    pub fn trailing_fill_path_and_bounds(
+        &self,
+        pixel_region: PixelRect<f32>,
+        grid_scale: GridScale,
+    ) -> Option<(Path, Rect)> {
+        let mut builder = PathBuilder::new();
+        let mut bounds = None;
+
+        for fill in self.trailing_fill_rects(pixel_region, grid_scale) {
+            self.push_trailing_fill_rect_path(&mut builder, &mut bounds, fill.rect);
+        }
+
+        bounds.map(|bounds| (builder.detach(), bounds))
+    }
+
+    fn trailing_fill_rects(
+        &self,
+        pixel_region: PixelRect<f32>,
+        grid_scale: GridScale,
+    ) -> Vec<TrailingFillRect> {
+        let base_region = self.pixel_region(grid_scale);
+        let inner_region = self.inner_region(pixel_region, grid_scale);
+        let extra_width = (pixel_region.max.x - base_region.max.x)
+            .min(grid_scale.width() * MAX_TRAILING_FILL_CELLS);
+
+        if extra_width <= 0.0 {
+            return Vec::new();
+        }
+
+        let mut fills = Vec::new();
+        for (i, line) in self.iter_border_lines() {
+            let line = line.borrow();
+            let Some(color) = line.trailing_background else {
+                continue;
+            };
+
+            fills.push(TrailingFillRect {
+                rect: self.trailing_fill_rect(
+                    base_region.max.x,
+                    extra_width,
+                    pixel_region.min.y + i as f32 * grid_scale.height(),
+                    grid_scale.height(),
+                ),
+                color,
+            });
+        }
+
+        // this fill is part of the rendered grid background, not a separete
+        // overlay. when the window is mid-scroll, the scrollable rows can
+        // sit at a fractional cell offset, so this fill has to use that
+        // same pixel offset too.
+        //
+        // See https://github.com/neovide/neovide/pull/3387
+        let scroll_offset_lines = self.scroll_animation.position.floor();
+        let scroll_offset = scroll_offset_lines - self.scroll_animation.position;
+        let scroll_offset_pixels = (scroll_offset * grid_scale.height()).round();
+        for (i, line) in self.iter_scrollable_lines() {
+            let line = line.borrow();
+            let Some(color) = line.trailing_background else {
+                continue;
+            };
+
+            let y = pixel_region.min.y
+                + scroll_offset_pixels
+                + (i + self.viewport_margins.top as isize) as f32 * grid_scale.height();
+            let top = y.max(inner_region.top);
+            let bottom = (y + grid_scale.height()).min(inner_region.bottom);
+            if bottom <= top {
+                continue;
+            }
+
+            fills.push(TrailingFillRect {
+                rect: self.trailing_fill_rect(base_region.max.x, extra_width, top, bottom - top),
+                color,
+            });
+        }
+
+        fills
+    }
+
+    fn trailing_fill_rect(&self, left: f32, width: f32, top: f32, height: f32) -> Rect {
+        Rect::from_xywh(left, top, width, height)
+    }
+
+    fn push_trailing_fill_rect_path(
+        &self,
+        builder: &mut PathBuilder,
+        bounds: &mut Option<Rect>,
+        rect: Rect,
+    ) {
+        if rect.is_empty() {
+            return;
+        }
+
+        builder
+            .move_to((rect.left, rect.top))
+            .line_to((rect.right, rect.top))
+            .line_to((rect.right, rect.bottom))
+            .line_to((rect.left, rect.bottom))
+            .close();
+
+        *bounds = Some(match *bounds {
+            Some(current) => Rect::join2(current, rect),
+            None => rect,
+        });
     }
 
     fn line_for_row(&self, row: u32) -> Option<Rc<RefCell<RenderedLine>>> {
@@ -517,6 +700,7 @@ impl RenderedWindow {
                     background_picture: None,
                     foreground_picture: None,
                     boxchar_picture: None,
+                    trailing_background: None,
                     has_transparency: false,
                     is_valid: false,
                 };
@@ -783,9 +967,17 @@ impl RenderedWindow {
                 position,
             ));
 
+            let trailing_background = line
+                .line
+                .fragments()
+                .filter(|fragment| fragment.cells.end == self.grid_size.width)
+                .last()
+                .map(|fragment| grid_renderer.background_paint_color(fragment.style, opacity));
+
             line.background_picture = background_picture;
             line.foreground_picture = foreground_picture;
             line.boxchar_picture = boxchar_picture;
+            line.trailing_background = trailing_background;
             line.has_transparency = has_transparency;
             line.is_valid = true;
         };

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -17,7 +17,7 @@ use super::{
 
 #[cfg(target_os = "macos")]
 use {
-    crate::units::{GridPos, Pixel, PixelRect},
+    crate::units::{GridPos, Pixel},
     crate::window::macos::tab_navigation::{TabNavigationAction, TabNavigationHotkeys},
     crate::window::macos::{
         hide_application, is_focus_suppressed, is_tab_overview_active, native_tab_bar_enabled,
@@ -46,7 +46,7 @@ use crate::{
         clamped_grid_size, font::FontSettings, load_last_window_settings, Config, HotReloadConfigs,
         Settings, SettingsChanged, DEFAULT_GRID_SIZE, MIN_GRID_SIZE,
     },
-    units::{GridRect, GridScale, GridSize, PixelPos, PixelSize},
+    units::{GridRect, GridScale, GridSize, PixelPos, PixelRect, PixelSize},
     window::{
         create_window, determine_grid_size, determine_window_size, PhysicalSize, ShouldRender,
         ThemeSettings,
@@ -1354,9 +1354,13 @@ impl WinitWindowWrapper {
 
     pub fn draw_frame(&mut self, window_id: WindowId, dt: f32) {
         tracy_zone!("draw_frame");
+
+        let content_rect = self.get_content_pixel_rect_from_window(window_id);
+
         let Some(route) = self.routes.get_mut(&window_id) else {
             return;
         };
+
         let mut renderer = route.window.renderer.borrow_mut();
         let window = route.window.winit_window.clone();
         let mut skia_renderer = route.window.skia_renderer.borrow_mut();
@@ -1364,17 +1368,21 @@ impl WinitWindowWrapper {
             return;
         };
 
-        renderer.draw_frame(skia_renderer.canvas(), dt);
+        renderer.draw_frame(skia_renderer.canvas(), Some(&content_rect), dt);
+
         skia_renderer.flush();
+
         {
             tracy_gpu_zone!("wait for vsync");
             vsync.wait_for_vsync();
         }
+
         skia_renderer.swap_buffers();
         if self.ui_state == UIState::FirstFrame {
             window.set_visible(true);
             self.ui_state = UIState::Showing;
         }
+
         tracy_frame();
         tracy_gpu_collect();
     }
@@ -2380,6 +2388,31 @@ impl WinitWindowWrapper {
             })
             .unwrap_or_else(|| PixelPos::new(0, 0).cast() / grid_scale);
         GridRect::<f32>::from_origin_and_size(pos, size)
+    }
+
+    fn get_content_pixel_rect_from_window(&self, window_id: WindowId) -> PixelRect<f32> {
+        let Some(route) = self.routes.get(&window_id) else {
+            return PixelRect::new(PixelPos::new(0.0, 0.0), PixelPos::new(0.0, 0.0));
+        };
+
+        let window_padding = route.state.window_padding;
+        let window_padding_size: PixelSize<u32> = PixelSize::new(
+            window_padding.left + window_padding.right,
+            window_padding.top + window_padding.bottom,
+        );
+
+        let content_size = PixelSize::new(
+            route.state.saved_inner_size.width,
+            route.state.saved_inner_size.height,
+        ) - window_padding_size;
+
+        let min = PixelPos::new(window_padding.left as f32, window_padding.top as f32);
+        let max = PixelPos::new(
+            (window_padding.left + content_size.width) as f32,
+            (window_padding.top + content_size.height) as f32,
+        );
+
+        PixelRect::new(min, max)
     }
 
     fn update_grid_size_from_window(&mut self, window_id: WindowId) {


### PR DESCRIPTION
this is a very specific bug - if we can consider it as one.

when the content width is not an exact multiple of the grid cell width, we can end up with a tiny strip to the right of the last column. the fullscreen tends to hide it because the geometry lines up differently, but in a normal window the seam is visible as soon as the trailing cell background is not the default one.

*Note: this is not really a grid sizing bug. The grid still has to snap to whole cells. The actual problem is that we were leaving the fractional remainder completely unpainted.* So we fix it in the renderer instead. Extend the trailing background slightly into that remainder and cap the fill to a few cell widths so we do not visibly stretch the last column if the grid briefly lags a resize.


before the fix

<img width="366" height="332" alt="CleanShot 2026-03-06 at 20 08 05@2x" src="https://github.com/user-attachments/assets/7423cd8a-dd50-499d-b74b-76e06d93a107" />


---

after


<img width="886" height="484" alt="CleanShot 2026-03-06 at 20 06 21@2x" src="https://github.com/user-attachments/assets/89ac93e3-82fe-4202-b07c-e3771a491433" />
