### PR TITLE
feat: add --no-embed-arg command line argument

### DIFF
--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -35,9 +35,11 @@ pub fn create_nvim_command(settings: &Settings) -> TokioCommand {
     create_tokio_nvim_command(&cmdline_settings, true)
 }
 
-pub fn create_restart_nvim_command(details: &RestartDetails) -> TokioCommand {
+pub fn create_restart_nvim_command(settings: &Settings, details: &RestartDetails) -> TokioCommand {
     let mut cmd = TokioCommand::new(&details.progpath);
-    cmd.arg("--embed");
+    if !settings.get::<CmdLineSettings>().no_embed_arg {
+        cmd.arg("--embed");
+    }
     for arg in details.argv.iter().skip(1) {
         cmd.arg(arg);
     }
@@ -77,7 +79,7 @@ fn build_nvim_command_parts(
         .clone()
         .unwrap_or_else(|| "nvim".to_owned());
     let mut args = Vec::new();
-    if embed {
+    if embed && !cmdline_settings.no_embed_arg {
         args.push("--embed".to_string());
     }
     args.extend(cmdline_settings.neovim_args.clone());

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -96,7 +96,9 @@ async fn neovim_instance(
     restart: Option<&RestartDetails>,
 ) -> Result<NeovimInstance> {
     if let Some(info) = restart {
-        return Ok(NeovimInstance::Embedded(create_restart_nvim_command(info)));
+        return Ok(NeovimInstance::Embedded(create_restart_nvim_command(
+            settings, info,
+        )));
     }
 
     if let Some(address) = settings.get::<CmdLineSettings>().server {

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -155,6 +155,10 @@ pub struct CmdLineSettings {
     #[arg(long = "neovim-bin", env = "NEOVIM_BIN")]
     pub neovim_bin: Option<String>,
 
+    /// Do not automatically append `--embed` to neovim_args
+    #[arg(long = "no-embed-arg", action = ArgAction::SetTrue, value_parser = FalseyValueParser::new())]
+    pub no_embed_arg: bool,
+
     /// The app ID to show to the compositor (Wayland only, useful for setting WM rules)
     #[arg(
         long = "wayland_app_id",

--- a/website/docs/command-line-reference.md
+++ b/website/docs/command-line-reference.md
@@ -281,6 +281,32 @@ Sets where to find neovim's executable. If unset, neovide will try to find `nvim
 environment variable instead. If you're running a Unix-alike, be sure that binary has the executable
 permission bit set.
 
+### Neovim Binary Arguments
+
+```sh
+-- extra args passed to nvim binary
+```
+
+Any arguments beyond a `--` are passed unchanged as arguments to `--neovim-bin`.
+
+`--embed` is automatically prepended to the arguments given here, unless `--no-embed-arg` is given.
+
+`-p` is automatically prepended to the arguments given here, unless `--no-tabs` is given.
+
+Any files to open are prepended to the arguments given here.
+
+### Disabling automatic --embed argument
+
+```sh
+--no-embed-arg
+```
+
+**Nightly.**
+
+Neovide automatically prepends `--embed` to the command line of `--neovim-bin`. Passing
+`--no-embed-arg` to neovide prevents this. If you use this option, you likely want to add `--embed`
+yourself to the argument list in some fashion.
+
 ### Wayland / X11
 
 ```sh


### PR DESCRIPTION
I'm a silly goose. I want this to work:

```sh
neovide --neovim-bin ssh -- my-server nvim
```

but it doesn't:

- `-p` is automatically **prepended** to the arguments to neovim-bin (able to be disabled with `--no-tabs`)
- `--embed` is automatically **prepended** with no way to disable it

resulting in the neovim-bin commandline being `ssh --embed -p my-server nvim`, which obviously fails - it needs to be `ssh my-server nvim --embed -p`.

there's two ways of fixing this:

- make `--embed` be **appended** rather than **prepended**
- add a `--no-embed-arg` to disable the automatic addition of the `--embed` argument

this PR implements the second option. (I can open a PR with the first option if you'd prefer that instead!). So, this works, with this PR:

```sh
target/debug/neovide --no-embed-arg --no-tabs --neovim-bin ssh -- my-server nvim --embed
```