### PR TITLE
fix: preserve terminal launch context on --fork

### DIFF
--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -7,6 +7,9 @@ use crate::{
     bridge::RestartDetails, cmd_line::CmdLineSettings, settings::*, utils::handle_wslpaths,
 };
 
+#[cfg(target_os = "macos")]
+const FORKED_FROM_TTY_ENV_VAR: &str = "NEOVIDE_FORKED_FROM_TTY";
+
 #[derive(Clone)]
 struct CommandSpec {
     program: String,
@@ -169,6 +172,10 @@ fn std_command_from_spec(spec: CommandSpec) -> StdCommand {
 
 #[cfg(target_os = "macos")]
 fn launched_from_desktop() -> bool {
+    if std::env::var_os(FORKED_FROM_TTY_ENV_VAR).is_some() {
+        return false;
+    }
+
     // On macOS, apps launched from Finder or `open` are spawned by launchd = PPID 1.
     // This is more reliable than $TERM for detecting GUI vs terminal launches,
     // so we use this as a heuristic instead of relying on $TERM.
@@ -194,9 +201,6 @@ fn create_command_spec(
         // normal GUI launch. See https://github.com/neovide/neovide/issues/2584
         let user = uzers::get_user_by_uid(uzers::get_current_uid()).unwrap();
         let shell = user.shell();
-        // -f: Bypasses authentication for the already-logged-in user.
-        // -p: Preserves the environment.
-        // -q: Forces quiet logins, as if a .hushlogin is present.
 
         // Convert to a single string and add quotes
         let args =
@@ -204,6 +208,9 @@ fn create_command_spec(
         CommandSpec::new(
             "/usr/bin/login",
             vec![
+                // -f: Bypasses authentication for the already-logged-in user.
+                // -p: Preserves the environment.
+                // -q: Forces quiet logins, as if a .hushlogin is present.
                 "-fpq".to_string(),
                 user.name().to_str().unwrap().to_string(),
                 shell.to_str().unwrap().to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,8 @@ use crate::frame::Frame;
 const DEFAULT_BACKTRACES_FILE: &str = "neovide_backtraces.log";
 const BACKTRACES_FILE_ENV_VAR: &str = "NEOVIDE_BACKTRACES";
 const REQUEST_MESSAGE: &str = "This is a bug and we would love for it to be reported to https://github.com/neovide/neovide/issues";
+#[cfg(not(target_os = "windows"))]
+const FORKED_FROM_TTY_ENV_VAR: &str = "NEOVIDE_FORKED_FROM_TTY";
 
 fn main() -> ExitCode {
     set_hook(Box::new(|panic_info| {
@@ -285,19 +287,18 @@ fn maybe_disown(settings: &Settings) {
         Ok(fork::Fork::Parent(_)) => process::exit(0),
         Ok(fork::Fork::Child) => {
             if let Ok(current_exe) = env::current_exe() {
-                assert!(
-                    process::Command::new(current_exe)
-                        .stdin(process::Stdio::null())
-                        .stdout(process::Stdio::null())
-                        .stderr(process::Stdio::null())
-                        .args(env::args().skip(1))
-                        .spawn()
-                        .is_ok()
-                );
+                let mut command = process::Command::new(current_exe);
+                command
+                    .stdin(process::Stdio::null())
+                    .stdout(process::Stdio::null())
+                    .stderr(process::Stdio::null())
+                    .args(env::args().skip(1));
+                command.env(FORKED_FROM_TTY_ENV_VAR, "1");
+                assert!(command.spawn().is_ok());
                 process::exit(0);
             } else {
                 eprintln!(
-                    "error in disowning process, cannot obtain the path for the current executable, exiting..."
+                    "error in disowning process, cannot obtain the respawn context, exiting..."
                 );
                 process::exit(1);
             }


### PR DESCRIPTION
the bug made neovide ignore the files and open an empty buffer, for example

```
NEOVIDE_FORK=1 cargo run -- ./Cargo.lock
```

or 

```
env -u TMUX tmux new 'cargo run -- ./Cargo.toml --fork; sleep 3'
```