### PR TITLE
feat: add opt-in cell color fallback on cursor

### DIFF
--- a/src/editor/cursor.rs
+++ b/src/editor/cursor.rs
@@ -72,18 +72,78 @@ impl Cursor {
         }
     }
 
-    pub fn foreground(&self, default_colors: &Colors) -> Color4f {
-        self.style
-            .as_ref()
-            .and_then(|s| s.colors.foreground)
-            .unwrap_or_else(|| default_colors.background.unwrap())
+    fn default_cell_colors(&self, default_colors: &Colors) -> (Color4f, Color4f) {
+        let foreground = default_colors
+            .foreground
+            .expect("cursor rendering requires a default foreground color");
+        let background = default_colors
+            .background
+            .expect("cursor rendering requires a default background color");
+
+        (foreground, background)
     }
 
-    pub fn background(&self, default_colors: &Colors) -> Color4f {
-        self.style
+    fn cell_colors(&self, default_colors: &Colors) -> (Color4f, Color4f) {
+        self.grid_cell
+            .1
             .as_ref()
-            .and_then(|s| s.colors.background)
-            .unwrap_or_else(|| default_colors.foreground.unwrap())
+            .map(|style| (style.foreground(default_colors), style.background(default_colors)))
+            .unwrap_or_else(|| self.default_cell_colors(default_colors))
+    }
+
+    fn default_cursor_colors(&self, default_colors: &Colors) -> (Color4f, Color4f) {
+        self.reverse_colors(self.default_cell_colors(default_colors))
+    }
+
+    fn reverse_colors(&self, (foreground, background): (Color4f, Color4f)) -> (Color4f, Color4f) {
+        (background, foreground)
+    }
+
+    fn style_colors(
+        &self,
+        style: &Style,
+        fallback_colors: (Color4f, Color4f),
+        apply_reverse: bool,
+    ) -> (Color4f, Color4f) {
+        let (fallback_foreground, fallback_background) = fallback_colors;
+        let colors = (
+            style.colors.foreground.unwrap_or(fallback_foreground),
+            style.colors.background.unwrap_or(fallback_background),
+        );
+
+        match (apply_reverse, style.reverse) {
+            (true, true) => self.reverse_colors(colors),
+            _ => colors,
+        }
+    }
+
+    fn resolve_colors(
+        &self,
+        default_colors: &Colors,
+        cell_color_fallback: bool,
+    ) -> (Color4f, Color4f) {
+        let default_cursor_colors = self.default_cursor_colors(default_colors);
+        let cell_colors = self.cell_colors(default_colors);
+        let style_fallback_colors = match cell_color_fallback {
+            true => cell_colors,
+            false => default_cursor_colors,
+        };
+
+        self.style
+            .as_deref()
+            .map(|style| self.style_colors(style, style_fallback_colors, cell_color_fallback))
+            .unwrap_or_else(|| match cell_color_fallback {
+                true => self.reverse_colors(cell_colors),
+                false => default_cursor_colors,
+            })
+    }
+
+    pub fn foreground(&self, default_colors: &Colors, cell_color_fallback: bool) -> Color4f {
+        self.resolve_colors(default_colors, cell_color_fallback).0
+    }
+
+    pub fn background(&self, default_colors: &Colors, cell_color_fallback: bool) -> Color4f {
+        self.resolve_colors(default_colors, cell_color_fallback).1
     }
 
     pub fn alpha(&self) -> u8 {
@@ -129,6 +189,11 @@ mod tests {
     };
 
     const NONE_COLORS: Colors = Colors { foreground: None, background: None, special: None };
+    const CELL_COLORS: Colors = Colors {
+        foreground: Some(Color4f::new(0.4, 0.1, 0.1, 0.1)),
+        background: Some(Color4f::new(0.5, 0.1, 0.1, 0.1)),
+        special: Some(Color4f::new(0.6, 0.1, 0.1, 0.1)),
+    };
 
     #[test]
     fn test_from_type_name() {
@@ -142,12 +207,35 @@ mod tests {
         let mut cursor = Cursor::new();
         let style = Some(Arc::new(Style::new(COLORS)));
 
-        assert_eq!(cursor.foreground(&DEFAULT_COLORS), DEFAULT_COLORS.background.unwrap());
+        assert_eq!(cursor.foreground(&DEFAULT_COLORS, false), DEFAULT_COLORS.background.unwrap());
         cursor.style = style;
-        assert_eq!(cursor.foreground(&DEFAULT_COLORS), COLORS.foreground.unwrap());
+        assert_eq!(cursor.foreground(&DEFAULT_COLORS, false), COLORS.foreground.unwrap());
 
         cursor.style = Some(Arc::new(Style::new(NONE_COLORS)));
-        assert_eq!(cursor.foreground(&DEFAULT_COLORS), DEFAULT_COLORS.background.unwrap());
+        assert_eq!(cursor.foreground(&DEFAULT_COLORS, false), DEFAULT_COLORS.background.unwrap());
+    }
+
+    #[test]
+    fn test_foreground_falls_back_to_cell_background() {
+        let mut cursor = Cursor::new();
+        cursor.grid_cell = ("x".to_string(), Some(Arc::new(Style::new(CELL_COLORS))));
+
+        assert_eq!(cursor.foreground(&DEFAULT_COLORS, true), CELL_COLORS.background.unwrap());
+
+        cursor.style = Some(Arc::new(Style::new(NONE_COLORS)));
+        assert_eq!(cursor.foreground(&DEFAULT_COLORS, true), CELL_COLORS.foreground.unwrap());
+    }
+
+    #[test]
+    fn test_foreground_reverse_swaps_cell_fallback_colors() {
+        let mut cursor = Cursor::new();
+        cursor.grid_cell = ("x".to_string(), Some(Arc::new(Style::new(CELL_COLORS))));
+
+        let mut reverse_cursor_style = Style::new(NONE_COLORS);
+        reverse_cursor_style.reverse = true;
+        cursor.style = Some(Arc::new(reverse_cursor_style));
+
+        assert_eq!(cursor.foreground(&DEFAULT_COLORS, true), CELL_COLORS.background.unwrap());
     }
 
     #[test]
@@ -155,12 +243,35 @@ mod tests {
         let mut cursor = Cursor::new();
         let style = Some(Arc::new(Style::new(COLORS)));
 
-        assert_eq!(cursor.background(&DEFAULT_COLORS), DEFAULT_COLORS.foreground.unwrap());
+        assert_eq!(cursor.background(&DEFAULT_COLORS, false), DEFAULT_COLORS.foreground.unwrap());
         cursor.style = style;
-        assert_eq!(cursor.background(&DEFAULT_COLORS), COLORS.background.unwrap());
+        assert_eq!(cursor.background(&DEFAULT_COLORS, false), COLORS.background.unwrap());
 
         cursor.style = Some(Arc::new(Style::new(NONE_COLORS)));
-        assert_eq!(cursor.background(&DEFAULT_COLORS), DEFAULT_COLORS.foreground.unwrap());
+        assert_eq!(cursor.background(&DEFAULT_COLORS, false), DEFAULT_COLORS.foreground.unwrap());
+    }
+
+    #[test]
+    fn test_background_falls_back_to_cell_foreground() {
+        let mut cursor = Cursor::new();
+        cursor.grid_cell = ("x".to_string(), Some(Arc::new(Style::new(CELL_COLORS))));
+
+        assert_eq!(cursor.background(&DEFAULT_COLORS, true), CELL_COLORS.foreground.unwrap());
+
+        cursor.style = Some(Arc::new(Style::new(NONE_COLORS)));
+        assert_eq!(cursor.background(&DEFAULT_COLORS, true), CELL_COLORS.background.unwrap());
+    }
+
+    #[test]
+    fn test_background_reverse_swaps_cell_fallback_colors() {
+        let mut cursor = Cursor::new();
+        cursor.grid_cell = ("x".to_string(), Some(Arc::new(Style::new(CELL_COLORS))));
+
+        let mut reverse_cursor_style = Style::new(NONE_COLORS);
+        reverse_cursor_style.reverse = true;
+        cursor.style = Some(Arc::new(reverse_cursor_style));
+
+        assert_eq!(cursor.background(&DEFAULT_COLORS, true), CELL_COLORS.foreground.unwrap());
     }
 
     #[test]

--- a/src/renderer/cursor_renderer/cursor_vfx.rs
+++ b/src/renderer/cursor_renderer/cursor_vfx.rs
@@ -14,6 +14,7 @@ pub trait CursorVfx {
     fn update(
         &mut self,
         settings: &CursorSettings,
+        base_color: Color,
         current_cursor_destination: PixelPos<f32>,
         cursor_dimensions: PixelSize<f32>,
         immediate_movement: bool,
@@ -155,6 +156,7 @@ impl CursorVfx for PointHighlight {
     fn update(
         &mut self,
         settings: &CursorSettings,
+        _base_color: Color,
         current_cursor_destination: PixelPos<f32>,
         _cursor_dimensions: PixelSize<f32>,
         _immediate_movement: bool,
@@ -193,7 +195,7 @@ impl CursorVfx for PointHighlight {
         paint.set_blend_mode(BlendMode::SrcOver);
 
         let colors = &grid_renderer.default_style.colors;
-        let base_color: Color = cursor.background(colors).to_color();
+        let base_color: Color = cursor.background(colors, settings.cell_color_fallback).to_color();
         let alpha = ease(ease_in_quad, settings.vfx_opacity, 0.0, self.t) as u8;
         let color = Color::from_argb(alpha, base_color.r(), base_color.g(), base_color.b());
 
@@ -234,6 +236,7 @@ struct ParticleData {
     speed: PixelVec<f32>,
     rotation_speed: f32,
     lifetime: f32,
+    color: Color,
 }
 
 pub struct ParticleTrail {
@@ -261,8 +264,9 @@ impl ParticleTrail {
         speed: PixelVec<f32>,
         rotation_speed: f32,
         lifetime: f32,
+        color: Color,
     ) {
-        self.particles.push(ParticleData { pos, speed, rotation_speed, lifetime });
+        self.particles.push(ParticleData { pos, speed, rotation_speed, lifetime, color });
     }
 
     // Note this method doesn't keep particles in order
@@ -276,6 +280,7 @@ impl CursorVfx for ParticleTrail {
     fn update(
         &mut self,
         settings: &CursorSettings,
+        base_color: Color,
         current_cursor_dest: PixelPos<f32>,
         cursor_dimensions: PixelSize<f32>,
         immediate_movement: bool,
@@ -364,6 +369,7 @@ impl CursorVfx for ParticleTrail {
                         speed,
                         rotation_speed,
                         t * settings.vfx_particle_lifetime,
+                        base_color,
                     );
                 }
             }
@@ -386,7 +392,7 @@ impl CursorVfx for ParticleTrail {
         settings: &CursorSettings,
         canvas: &Canvas,
         grid_renderer: &mut GridRenderer,
-        cursor: &Cursor,
+        _cursor: &Cursor,
     ) {
         let mut paint = Paint::new(skia_safe::colors::WHITE, None);
         let font_dimensions = GridSize::new(1.0, 1.0) * grid_renderer.grid_scale;
@@ -398,15 +404,13 @@ impl CursorVfx for ParticleTrail {
             _ => {}
         }
 
-        let colors = &grid_renderer.default_style.colors;
-        let base_color: Color = cursor.background(colors).to_color();
-
         paint.set_blend_mode(BlendMode::SrcOver);
 
         self.particles.iter().for_each(|particle| {
             let lifetime = particle.lifetime / settings.vfx_particle_lifetime;
             let alpha = (lifetime * settings.vfx_opacity) as u8;
-            let color = Color::from_argb(alpha, base_color.r(), base_color.g(), base_color.b());
+            let color =
+                Color::from_argb(alpha, particle.color.r(), particle.color.g(), particle.color.b());
             paint.set_color(color);
 
             let radius = match self.trail_mode {

--- a/src/renderer/cursor_renderer/mod.rs
+++ b/src/renderer/cursor_renderer/mod.rs
@@ -56,6 +56,7 @@ pub struct CursorSettings {
     trail_size: f32,
     unfocused_outline_width: f32,
     smooth_blink: bool,
+    cell_color_fallback: bool,
 
     vfx_mode: cursor_vfx::VfxModeList,
     vfx_opacity: f32,
@@ -78,6 +79,7 @@ impl Default for CursorSettings {
             trail_size: 1.0,
             unfocused_outline_width: 1.0 / 8.0,
             smooth_blink: false,
+            cell_color_fallback: false,
             vfx_mode: cursor_vfx::VfxModeList::default(),
             vfx_opacity: 200.0,
             vfx_particle_lifetime: 0.5,
@@ -352,7 +354,7 @@ impl CursorRenderer {
         // Draw Background
         let background_color = self
             .cursor
-            .background(&grid_renderer.default_style.colors)
+            .background(&grid_renderer.default_style.colors, settings.cell_color_fallback)
             .to_color()
             .with_a((opacity * alpha) as u8);
         paint.set_color(background_color);
@@ -367,7 +369,7 @@ impl CursorRenderer {
         // Draw foreground
         let foreground_color = self
             .cursor
-            .foreground(&grid_renderer.default_style.colors)
+            .foreground(&grid_renderer.default_style.colors, settings.cell_color_fallback)
             .to_color()
             .with_a((opacity * alpha) as u8);
         paint.set_color(foreground_color);
@@ -498,10 +500,15 @@ impl CursorRenderer {
             }
 
             let mut vfx_animating = false;
+            let vfx_base_color = self
+                .cursor
+                .background(&grid_renderer.default_style.colors, settings.cell_color_fallback)
+                .to_color();
 
             for vfx in self.cursor_vfxs.iter_mut() {
                 let ret = vfx.update(
                     &settings,
+                    vfx_base_color,
                     center_destination,
                     cursor_dimensions,
                     immediate_movement,

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -1147,6 +1147,25 @@ If enabled, the cursor will smoothly animate the transition between the cursor's
 The built in `guicursor` neovim option needs to be configured to enable blinking by having a value
 set for both `blinkoff`, `blinkon` and `blinkwait` for this setting to apply.
 
+#### Use covered cell colors for cursor fallback
+
+VimScript:
+
+```vim
+let g:neovide_cursor_cell_color_fallback = v:false
+```
+
+Lua:
+
+```lua
+vim.g.neovide_cursor_cell_color_fallback = false
+```
+
+If enabled, Neovide will use the resolved colors of the grid cell under the cursor when the
+`guicursor` highlight does not explicitly define cursor foreground or background colors. This makes
+the block cursor adapt to the text highlighting beneath it. Explicit cursor colors still take
+precedence.
+
 ### Cursor Particles
 
 There are a number of vfx modes you can enable which produce particles behind the cursor. These are


### PR DESCRIPTION
we already know the style of the cell under the cursor. Not using the cell color fallback when `guicursor` leaves fg/bg unset, means the block cursor ignores the actual colors being shown in that cell. In fact instead, neovim ui protocol leave this responsability up the client to impl, which is reasonable.

we also add `neovide_cursor_cell_color_fallback` as an opt-in. If enabled, the cursor falls back to the covered cell colors, while explicit cursor colors still override them.

the trail vfx now keep a stable per-particle emission color. each particle captures the cursor color when it is spawned, and rendering uses that stored color instead of re-resolving from the current cursor position.

https://github.com/user-attachments/assets/46f78029-798c-4157-bde0-ea00a767b64a


https://github.com/user-attachments/assets/f40371d2-795e-4776-ac80-2c3c8cc8ac08


https://github.com/user-attachments/assets/c9244f4b-37c8-445c-98a8-c0faeedb09a8

