### PR TITLE
fix: don't clear hidden window titles

### DIFF
--- a/lua/init.lua
+++ b/lua/init.lua
@@ -22,6 +22,20 @@ vim.g.neovide_version = args.neovide_version
 vim.o.lazyredraw = false
 vim.o.termguicolors = true
 
+local function set_default_window_title()
+    local title_info = vim.api.nvim_get_option_info2("title", {})
+    local titlestring_info = vim.api.nvim_get_option_info2("titlestring", {})
+
+    if title_info.was_set or titlestring_info.was_set then
+        return
+    end
+
+    vim.o.title = true
+    vim.o.titlestring = "%F"
+end
+
+set_default_window_title()
+
 local function rpcnotify(method, ...)
     vim.rpcnotify(vim.g.neovide_channel_id, method, ...)
 end

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -372,7 +372,6 @@ impl MacosWindowFeature {
         if cmd_line_settings.title_hidden {
             ns_window.setTitleVisibility(NSWindowTitleVisibility::Hidden);
             ns_window.setTitlebarAppearsTransparent(true);
-            ns_window.setTitle(ns_string!(""));
         }
 
         let mut extra_titlebar_height_in_pixel: u32 = 0;


### PR DESCRIPTION
First, we now set a sane default window title.

we already handle title updates from nvim, but the default startup behavior was still effectively "call everything Neovide" until otherwise. that's not very useful. mainly for the multi-window feature.

now, if the user hasn't configured either `title` or `titlestring`, we enable titles and use `%F` so the window follows the current path. *but we don't override user configuration. if either option was already set, we leave it alone.*

---

The second, `title-hidden` option means "don't show the title", not "make the window stop having one"

On macOS we got that wrong. when title hiding was enabled, we hid the title visually and then also **cleared** the underlying `NSWindow` title by setting it to an empty string.

That broke the native bookkeeping for secondary windows. The window itself was created fine and the native tab showed up, but `AppKit` no longer had a real title to use for the Window menu entry. So the second window ended up effectively unnamed there.

we fix it by leaving the `NSWindow` title alone. keeping the title hidden from the titlebar, but preserve it for the platform APIs that actually need it as the multi-window feature.