### PR TITLE
hotreload: support title-hidden and add a minimal split for renderer/window configs

### DIFF
--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -369,11 +369,6 @@ impl MacosWindowFeature {
             merge_all_windows_if_native_tabs(&ns_window);
         }
 
-        if cmd_line_settings.title_hidden {
-            ns_window.setTitleVisibility(NSWindowTitleVisibility::Hidden);
-            ns_window.setTitlebarAppearsTransparent(true);
-        }
-
         let mut extra_titlebar_height_in_pixel: u32 = 0;
         let mut buttonless_padding = false;
         let has_transparent_titlebar = matches!(frame, Frame::Transparent);
@@ -429,6 +424,7 @@ impl MacosWindowFeature {
         };
 
         let mut macos_window_feature = macos_window_feature;
+        macos_window_feature.set_title_hidden(cmd_line_settings.title_hidden);
         macos_window_feature.set_simple_fullscreen_mode(simple_fullscreen);
         macos_window_feature.update_background();
 
@@ -1007,6 +1003,20 @@ impl MacosWindowFeature {
             self.settings.get::<WindowSettings>();
         let opaque = opacity.min(normal_opacity) >= 1.0;
         self.update_ns_background(opaque, show_border);
+    }
+
+    pub fn set_title_hidden(&self, title_hidden: bool) {
+        let frame = self.settings.get::<CmdLineSettings>().frame;
+        let transparent = matches!(frame, Frame::Transparent | Frame::Buttonless);
+        let transparent_titlebar = title_hidden || transparent;
+        let hidden = if title_hidden {
+            NSWindowTitleVisibility::Hidden
+        } else {
+            NSWindowTitleVisibility::Visible
+        };
+
+        self.ns_window.setTitleVisibility(hidden);
+        self.ns_window.setTitlebarAppearsTransparent(transparent_titlebar);
     }
 
     pub fn handle_settings_changed(&mut self, changed_setting: WindowSettingsChanged) {

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -476,9 +476,10 @@ impl Renderer {
         animating
     }
 
-    pub fn handle_config_changed(&mut self, config: HotReloadConfigs) {
+    pub fn handle_config_changed(&mut self, config: RendererHotReloadConfigs) {
         match config {
-            HotReloadConfigs::Font(font) => {
+            RendererHotReloadConfigs::Font(font) => {
+                let font = *font;
                 let mut font_config_state = self.settings.get::<FontConfigState>();
                 font_config_state.has_font = font.is_some();
                 self.settings.set(&font_config_state);
@@ -491,7 +492,7 @@ impl Renderer {
                     }
                 }
             }
-            HotReloadConfigs::BoxDrawing(settings) => {
+            RendererHotReloadConfigs::BoxDrawing(settings) => {
                 self.grid_renderer.handle_box_drawing_update(settings.unwrap_or_default())
             }
         }

--- a/src/settings/config.rs
+++ b/src/settings/config.rs
@@ -81,8 +81,19 @@ pub struct Config {
 #[derive(Debug, Clone, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub enum HotReloadConfigs {
-    Font(Option<FontSettings>),
+    Renderer(RendererHotReloadConfigs),
+    Window(WindowHotReloadConfigs),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum RendererHotReloadConfigs {
+    Font(Box<Option<FontSettings>>),
     BoxDrawing(Option<BoxDrawingSettings>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum WindowHotReloadConfigs {
+    TitleHidden(Option<bool>),
 }
 
 impl Config {
@@ -244,14 +255,27 @@ fn watcher_thread(init_config: Config, event_loop_proxy: EventLoopProxy<EventPay
         if config.font != previous_config.font {
             event_loop_proxy
                 .send_event(EventPayload::all(UserEvent::ConfigsChanged(Box::new(
-                    HotReloadConfigs::Font(config.font.clone()),
+                    HotReloadConfigs::Renderer(RendererHotReloadConfigs::Font(Box::new(
+                        config.font.clone(),
+                    ))),
                 ))))
                 .unwrap();
         }
         if config.box_drawing != previous_config.box_drawing {
             event_loop_proxy
                 .send_event(EventPayload::all(UserEvent::ConfigsChanged(Box::new(
-                    HotReloadConfigs::BoxDrawing(config.box_drawing.clone()),
+                    HotReloadConfigs::Renderer(RendererHotReloadConfigs::BoxDrawing(
+                        config.box_drawing.clone(),
+                    )),
+                ))))
+                .unwrap();
+        }
+        if config.title_hidden != previous_config.title_hidden {
+            event_loop_proxy
+                .send_event(EventPayload::all(UserEvent::ConfigsChanged(Box::new(
+                    HotReloadConfigs::Window(WindowHotReloadConfigs::TitleHidden(
+                        config.title_hidden,
+                    )),
                 ))))
                 .unwrap();
         }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -23,7 +23,7 @@ pub use window_size::{
 };
 
 pub mod config;
-pub use config::{Config, HotReloadConfigs};
+pub use config::{Config, HotReloadConfigs, RendererHotReloadConfigs, WindowHotReloadConfigs};
 
 pub trait SettingGroup {
     type ChangedEvent: Debug + Clone + Send + Sync + Any;

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -44,8 +44,9 @@ use crate::{
     },
     running_tracker::RunningTracker,
     settings::{
-        Config, DEFAULT_GRID_SIZE, HotReloadConfigs, MIN_GRID_SIZE, Settings, SettingsChanged,
-        clamped_grid_size, font::FontSettings, load_last_window_settings,
+        Config, DEFAULT_GRID_SIZE, HotReloadConfigs, MIN_GRID_SIZE, RendererHotReloadConfigs,
+        Settings, SettingsChanged, WindowHotReloadConfigs, clamped_grid_size, font::FontSettings,
+        load_last_window_settings,
     },
     units::{GridRect, GridScale, GridSize, PixelPos, PixelRect, PixelSize},
     window::{
@@ -1888,12 +1889,53 @@ impl WinitWindowWrapper {
 
     fn handle_config_changed(&mut self, config: HotReloadConfigs) {
         tracy_zone!("handle_config_changed");
+        match config {
+            HotReloadConfigs::Window(config) => {
+                self.handle_window_config_changed(config);
+            }
+            HotReloadConfigs::Renderer(config) => {
+                self.handle_renderer_config_changed(config);
+            }
+        }
+    }
+
+    fn handle_window_config_changed(&mut self, config: WindowHotReloadConfigs) {
+        match config {
+            WindowHotReloadConfigs::TitleHidden(title_hidden) => {
+                self.handle_config_title_hidden_changed(title_hidden);
+            }
+        }
+    }
+
+    fn handle_renderer_config_changed(&mut self, config: RendererHotReloadConfigs) {
         let Some(route) = self.focused_route_mut() else {
             return;
         };
+
         let mut renderer = route.window.renderer.borrow_mut();
         renderer.handle_config_changed(config);
         route.state.font_changed_last_frame = true;
+    }
+
+    fn handle_config_title_hidden_changed(&mut self, title_hidden: Option<bool>) {
+        let title_hidden = title_hidden.unwrap_or(false);
+        let mut cmd_line_settings = self.settings.get::<CmdLineSettings>();
+        if cmd_line_settings.title_hidden == title_hidden {
+            return;
+        }
+
+        cmd_line_settings.title_hidden = title_hidden;
+        self.settings.set(&cmd_line_settings);
+
+        #[cfg(target_os = "macos")]
+        {
+            let window_ids: Vec<WindowId> = self.routes.keys().copied().collect();
+            for window_id in window_ids {
+                if let Some(macos_feature) = self.macos_feature_for_window(window_id) {
+                    macos_feature.borrow_mut().set_title_hidden(title_hidden);
+                }
+            }
+        }
     }
 
     fn handle_progress_bar(&mut self, target: EventTarget, percent: f32) {


### PR DESCRIPTION
we had a single `HotReloadConfigs` and a dispatch path that made every config type go through. That worked fine but the `hot reload` was just meant to "renderer properties" at the moment. so we added a window-level option as well to act as a bedside for the other properties within window.

now the watcher emits categorized reload events, the renderer only accepts renderer configs and the window wrapper owns window-level application of window config.