### PR TITLE
hotreload: support window geometry as one setting

### DIFF
--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -215,6 +215,28 @@ impl MouseCursorIcon {
     }
 }
 
+impl GeometryArgs {
+    pub fn from_config(
+        size: Option<&str>,
+        grid: Option<&str>,
+        maximized: Option<bool>,
+    ) -> Result<Self, String> {
+        let maximized = maximized.unwrap_or(false);
+        let has_size = size.is_some();
+        let has_grid = grid.is_some();
+        let conflicting = (has_size && has_grid) || (maximized && (has_size || has_grid));
+        if conflicting {
+            return Err("size, grid and maximized are mutually exclusive".to_owned());
+        }
+
+        Ok(Self {
+            grid: grid.map(|grid| grid.parse::<Dimensions>().map(Some)).transpose()?,
+            size: size.map(str::parse::<Dimensions>).transpose()?,
+            maximized,
+        })
+    }
+}
+
 impl Default for CmdLineSettings {
     fn default() -> Self {
         Self::parse_from(iter::empty::<String>())
@@ -426,6 +448,38 @@ mod tests {
         assert_eq!(
             settings.get::<CmdLineSettings>().geometry.size,
             Some(Dimensions { width: 420, height: 240 }),
+        );
+    }
+
+    #[test]
+    fn test_geometry_args_from_config_size() {
+        assert_eq!(
+            GeometryArgs::from_config(Some("420x240"), None, None).unwrap(),
+            GeometryArgs {
+                size: Some(Dimensions { width: 420, height: 240 }),
+                grid: None,
+                maximized: false,
+            }
+        );
+    }
+
+    #[test]
+    fn test_geometry_args_from_config_grid() {
+        assert_eq!(
+            GeometryArgs::from_config(None, Some("80x24"), None).unwrap(),
+            GeometryArgs {
+                size: None,
+                grid: Some(Some(Dimensions { width: 80, height: 24 })),
+                maximized: false,
+            }
+        );
+    }
+
+    #[test]
+    fn test_geometry_args_from_config_rejects_conflicts() {
+        assert_eq!(
+            GeometryArgs::from_config(Some("420x240"), Some("80x24"), None).unwrap_err(),
+            "size, grid and maximized are mutually exclusive"
         );
     }
 

--- a/src/settings/config.rs
+++ b/src/settings/config.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use winit::event_loop::EventLoopProxy;
 
 use crate::{
-    cmd_line::MouseCursorIcon,
+    cmd_line::{GeometryArgs, MouseCursorIcon},
     error_msg,
     frame::Frame,
     renderer::box_drawing::BoxDrawingSettings,
@@ -96,6 +96,7 @@ pub enum RendererHotReloadConfigs {
 pub enum WindowHotReloadConfigs {
     TitleHidden(Option<bool>),
     MouseCursorIcon(MouseCursorIcon),
+    Geometry(GeometryArgs),
 }
 
 impl Config {
@@ -294,6 +295,27 @@ fn watcher_thread(init_config: Config, event_loop_proxy: EventLoopProxy<EventPay
                 }
                 Err(err) => {
                     error_msg!("While reloading config file: invalid mouse-cursor-icon: {err}");
+                }
+            }
+        }
+        if config.size != previous_config.size
+            || config.grid != previous_config.grid
+            || config.maximized != previous_config.maximized
+        {
+            match GeometryArgs::from_config(
+                config.size.as_deref(),
+                config.grid.as_deref(),
+                config.maximized,
+            ) {
+                Ok(geometry) => {
+                    event_loop_proxy
+                        .send_event(EventPayload::all(UserEvent::ConfigsChanged(Box::new(
+                            HotReloadConfigs::Window(WindowHotReloadConfigs::Geometry(geometry)),
+                        ))))
+                        .unwrap();
+                }
+                Err(err) => {
+                    error_msg!("While reloading config file: invalid geometry: {err}");
                 }
             }
         }

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -37,7 +37,7 @@ use crate::{
         set_active_route_handler, unregister_route_handler,
     },
     clipboard::ClipboardHandle,
-    cmd_line::MouseCursorIcon,
+    cmd_line::{GeometryArgs, MouseCursorIcon},
     profiling::{tracy_frame, tracy_gpu_collect, tracy_gpu_zone, tracy_plot, tracy_zone},
     renderer::{
         DrawCommand, MessageSelection, Renderer, RendererSettingsChanged, SkiaRenderer, VSync,
@@ -85,6 +85,13 @@ enum UIState {
     WaitingForWindowCreate,
     FirstFrame,
     Showing, // No pending resizes
+}
+
+enum GeometryTarget {
+    Maximized,
+    Size(PhysicalSize<u32>),
+    Grid(GridSize<u32>),
+    None,
 }
 
 pub struct RouteWindow {
@@ -1908,6 +1915,9 @@ impl WinitWindowWrapper {
             WindowHotReloadConfigs::MouseCursorIcon(mouse_cursor_icon) => {
                 self.handle_config_mouse_cursor_icon_changed(mouse_cursor_icon);
             }
+            WindowHotReloadConfigs::Geometry(geometry) => {
+                self.handle_config_geometry_changed(geometry);
+            }
         }
     }
 
@@ -1954,6 +1964,92 @@ impl WinitWindowWrapper {
         let cursor = Cursor::Icon(mouse_cursor_icon.parse());
         for route in self.routes.values() {
             route.window.winit_window.set_cursor(cursor.clone());
+        }
+    }
+
+    fn handle_config_geometry_changed(&mut self, geometry: GeometryArgs) {
+        let Some(previous_geometry) = self.update_shared_geometry(&geometry) else {
+            return;
+        };
+
+        let window_ids: Vec<WindowId> = self.routes.keys().copied().collect();
+        if Self::should_exit_maximized_state(&previous_geometry, &geometry) {
+            self.set_windows_maximized(&window_ids, false);
+        }
+
+        match Self::geometry_target(geometry) {
+            GeometryTarget::Maximized => self.set_windows_maximized(&window_ids, true),
+            GeometryTarget::Size(size) => self.request_window_size_for(&window_ids, size),
+            GeometryTarget::Grid(grid_size) => self.request_grid_size_for(&window_ids, grid_size),
+            GeometryTarget::None => {}
+        }
+    }
+
+    fn update_shared_geometry(&self, geometry: &GeometryArgs) -> Option<GeometryArgs> {
+        let mut cmd_line_settings = self.settings.get::<CmdLineSettings>();
+        if cmd_line_settings.geometry == *geometry {
+            return None;
+        }
+
+        let previous_geometry = cmd_line_settings.geometry.clone();
+        cmd_line_settings.geometry = geometry.clone();
+        self.settings.set(&cmd_line_settings);
+
+        Some(previous_geometry)
+    }
+
+    fn should_exit_maximized_state(
+        previous_geometry: &GeometryArgs,
+        geometry: &GeometryArgs,
+    ) -> bool {
+        !geometry.maximized
+            && (previous_geometry.maximized
+                || geometry.size.is_some()
+                || matches!(geometry.grid, Some(Some(_))))
+    }
+
+    fn geometry_target(geometry: GeometryArgs) -> GeometryTarget {
+        if geometry.maximized {
+            return GeometryTarget::Maximized;
+        }
+
+        if let Some(size) = geometry.size {
+            return GeometryTarget::Size(PhysicalSize::from(size));
+        }
+
+        let Some(Some(dimensions)) = geometry.grid else {
+            return GeometryTarget::None;
+        };
+
+        GeometryTarget::Grid(clamped_grid_size(&GridSize::new(
+            dimensions.width.try_into().unwrap(),
+            dimensions.height.try_into().unwrap(),
+        )))
+    }
+
+    fn set_windows_maximized(&self, window_ids: &[WindowId], maximized: bool) {
+        for window_id in window_ids {
+            if let Some(route) = self.routes.get(window_id) {
+                route.window.winit_window.set_maximized(maximized);
+            }
+        }
+    }
+
+    fn request_window_size_for(&self, window_ids: &[WindowId], size: PhysicalSize<u32>) {
+        for window_id in window_ids {
+            if let Some(route) = self.routes.get(window_id) {
+                let _ = route.window.winit_window.request_inner_size(size);
+            }
+        }
+    }
+
+    fn request_grid_size_for(&mut self, window_ids: &[WindowId], grid_size: GridSize<u32>) {
+        for &window_id in window_ids {
+            if let Some(route) = self.routes.get_mut(&window_id) {
+                route.state.requested_columns = Some(grid_size.width);
+                route.state.requested_lines = Some(grid_size.height);
+            }
+            self.update_window_size_from_grid(window_id);
         }
     }
 

--- a/website/docs/config-file.md
+++ b/website/docs/config-file.md
@@ -77,6 +77,15 @@ Settings that are mutually exclusive on the command line (for example `size`, `g
 
 ### Runtime settings
 
+#### Window Geometry
+
+**Nightly.**
+
+`size`, `grid` and `maximized` can be hot reloaded from `config.toml`.
+
+They are still mutually exclusive. `size` applies a new pixel size to all live windows, `grid`
+applies a new Neovim grid size, and `maximized` updates the live maximized state.
+
 #### `Font`
 
 **Available since 0.12.1.**


### PR DESCRIPTION
size and grid are not independent runtime options. together with `maximized` they define one mutually exclusive geometry choice, so we don't model them as separate hot reload events.


if reload emitted a size/grid independently, then a transition like size -> grid would depend on event order and could briefly drive an invalid state. in the end, we make geometry hot reload work, but we do it in a way that preserves the actual model.

One geometry setting, one parser, one reload event, one place to apply it.

todo: we need to improve how we declare mutually exclusive config options in the config file.


