### PR TITLE
fix: regression doing extra render work when a frame is already late

### DIFF
--- a/src/window/application.rs
+++ b/src/window/application.rs
@@ -419,7 +419,7 @@ impl Application {
         // There's really no point in trying to render if the frame is skipped
         // (most likely due to the compositor being busy). The animated frame will
         // be rendered at an appropriate time anyway.
-        if self.window_wrapper.routes.is_empty() && !skipped_frame {
+        if skipped_frame || self.window_wrapper.routes.is_empty() {
             return;
         }
 
@@ -545,7 +545,6 @@ impl ApplicationHandler<EventPayload> for Application {
                 self.schedule_next_event(event_loop);
             }
             winit::event::StartCause::ResumeTimeReached { .. } => {
-                self.prepare_and_animate();
                 self.schedule_next_event(event_loop);
             }
             winit::event::StartCause::WaitCancelled { .. } => {


### PR DESCRIPTION
the multi-window *refactor* changed the render loop in two ways, but they both push work into the path where we already know the compositor is behind. *mainly Windows users were seeing a regression on nightly such as typing latency, slow animations.*

first, the `schedule_render()` stopped checking out on `skipped_frame`

that means we can still request another redraw even after deciding that the current frame was missed. *that is backwards*. A skipped frame is not a signal to queue more work, it is a signal to get out of the way and let the already scheduled render finish.

second, `ResumeTimeReached` started calling `prepare_and_animate()`, even though `about_to_wait()` already does the exact same work. So the loop grew a second preparation fraction **for no real gain**. that is just extra churn and on throttled backends it makes missed-frame recovery noisier than it needs to be. 

here we now put the frame preparation back in one place, *as before* and avoids re-arming redraws for frames that we already know they are late. we also match the pre-refactor control flow that did not exhibit the Windows typing-latency regression.

note: that probably went out moving the code around during the refactor.
