### PR TITLE
macos: add a bedside handoff IPC transport for instances

### DIFF
--- a/src/bridge/setup.rs
+++ b/src/bridge/setup.rs
@@ -9,6 +9,7 @@ use super::{
 use crate::{
     bridge::NeovimWriter,
     settings::{SettingLocation, Settings, config::config_path},
+    version::BUILD_VERSION,
 };
 
 const INIT_LUA: &str = include_str!("../../lua/init.lua");
@@ -76,7 +77,7 @@ pub async fn setup_neovide_specific_state(
         INIT_LUA,
         call_args![nvim_dict! {
             "neovide_channel_id" => api_information.channel,
-            "neovide_version" => env!("NEOVIDE_BUILD_VERSION"),
+            "neovide_version" => BUILD_VERSION,
             "config_path" => config_path().to_string_lossy().into_owned(),
             "register_clipboard" => register_clipboard,
             "register_right_click" => register_right_click,

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -2,6 +2,7 @@ use std::{iter, process::ExitStatus};
 
 use crate::{
     bridge::create_blocking_nvim_command, dimensions::Dimensions, frame::Frame, settings::*,
+    version::BUILD_VERSION,
 };
 
 use anyhow::{Context, Result};
@@ -27,7 +28,7 @@ fn get_styles() -> Styles {
 }
 
 #[derive(Clone, Debug, Parser)]
-#[command(version = env!("NEOVIDE_BUILD_VERSION"), about, long_about = None, styles = get_styles())]
+#[command(version = BUILD_VERSION, about, long_about = None, styles = get_styles())]
 pub struct CmdLineSettings {
     /// Files to open (usually plainly appended to NeoVim args, except when --wsl is used)
     #[arg(

--- a/src/ipc/handoff.rs
+++ b/src/ipc/handoff.rs
@@ -1,0 +1,261 @@
+use std::{
+    fs,
+    io::{BufRead, BufReader, BufWriter, ErrorKind, Write},
+    os::unix::net::{UnixListener, UnixStream},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread::{self, JoinHandle},
+};
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use std::time::Duration;
+use winit::event_loop::EventLoopProxy;
+
+use crate::{
+    settings::neovide_std_datapath,
+    version::{BUILD_VERSION, release_channel},
+    window::EventPayload,
+};
+
+const CLIENT_IO_TIMEOUT: Duration = Duration::from_secs(2);
+const LISTENER_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HandoffRequest {
+    pub version: String,
+}
+
+impl HandoffRequest {
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        Self { version: BUILD_VERSION.to_owned() }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum HandoffResult {
+    Accepted,
+    NoListener,
+    Failed(String),
+    Rejected(String),
+}
+
+pub struct ListenerGuard {
+    shutdown: Arc<AtomicBool>,
+    join_handle: Option<JoinHandle<()>>,
+    endpoint: std::path::PathBuf,
+}
+
+impl Drop for ListenerGuard {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+
+        let _ = std::os::unix::net::UnixStream::connect(&self.endpoint);
+
+        if let Some(join_handle) = self.join_handle.take() {
+            let _ = join_handle.join();
+        }
+
+        let _ = std::fs::remove_file(&self.endpoint);
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HandoffResponse {
+    accepted: bool,
+    error: Option<String>,
+}
+
+#[allow(dead_code)]
+pub fn try_handoff(request: &HandoffRequest) -> HandoffResult {
+    let endpoint = endpoint_path();
+    let stream = match UnixStream::connect(&endpoint) {
+        Ok(stream) => stream,
+        Err(error) => match error.kind() {
+            ErrorKind::NotFound | ErrorKind::ConnectionRefused => return HandoffResult::NoListener,
+            _ => {
+                return HandoffResult::Failed(format!(
+                    "failed to connect to instance IPC listener at {}: {error}",
+                    endpoint.display()
+                ));
+            }
+        },
+    };
+
+    let _ = stream.set_read_timeout(Some(CLIENT_IO_TIMEOUT));
+    let _ = stream.set_write_timeout(Some(CLIENT_IO_TIMEOUT));
+
+    let mut writer = match stream.try_clone() {
+        Ok(stream) => BufWriter::new(stream),
+        Err(error) => {
+            return HandoffResult::Failed(format!(
+                "failed to clone instance IPC stream for writing: {error}"
+            ));
+        }
+    };
+
+    if let Err(error) = write_message(&mut writer, request) {
+        return HandoffResult::Failed(format!("failed to send instance IPC request: {error}"));
+    }
+
+    let mut reader = BufReader::new(stream);
+    match read_message::<HandoffResponse, _>(&mut reader) {
+        Ok(response) if response.accepted => HandoffResult::Accepted,
+        Ok(response) => HandoffResult::Rejected(
+            response.error.unwrap_or_else(|| "instance IPC request was rejected".to_owned()),
+        ),
+        Err(error) => {
+            HandoffResult::Failed(format!("failed to read instance IPC response: {error}"))
+        }
+    }
+}
+
+pub fn start_listener(_proxy: EventLoopProxy<EventPayload>) -> Result<ListenerGuard> {
+    let endpoint = endpoint_path();
+    fs::create_dir_all(neovide_std_datapath()).with_context(|| {
+        format!("failed to create instance IPC data directory {}", neovide_std_datapath().display())
+    })?;
+
+    if endpoint.exists() {
+        match UnixStream::connect(&endpoint) {
+            Ok(_) => {
+                bail!("instance IPC listener is already running at {}", endpoint.display());
+            }
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused
+                ) =>
+            {
+                fs::remove_file(&endpoint).with_context(|| {
+                    format!("failed to remove stale instance IPC socket {}", endpoint.display())
+                })?;
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "failed to validate existing instance IPC socket {}",
+                        endpoint.display()
+                    )
+                });
+            }
+        }
+    }
+
+    let listener = UnixListener::bind(&endpoint).with_context(|| {
+        format!("failed to bind instance IPC listener at {}", endpoint.display())
+    })?;
+
+    listener
+        .set_nonblocking(true)
+        .context("failed to configure instance IPC listener as nonblocking")?;
+
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let listener_shutdown = shutdown.clone();
+    let join_handle = thread::Builder::new()
+        .name("instance-ipc-listener".to_owned())
+        .spawn(move || {
+            while !listener_shutdown.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        if let Err(error) = handle_connection(stream) {
+                            log::warn!("instance IPC connection failed: {error:#}");
+                        }
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(LISTENER_POLL_INTERVAL);
+                    }
+                    Err(error) => {
+                        log::error!("instance IPC listener failed: {error}");
+                        break;
+                    }
+                }
+            }
+        })
+        .context("failed to spawn instance IPC listener thread")?;
+
+    Ok(ListenerGuard { shutdown, join_handle: Some(join_handle), endpoint })
+}
+
+fn handle_connection(stream: std::os::unix::net::UnixStream) -> Result<()> {
+    let _ = stream.set_read_timeout(Some(CLIENT_IO_TIMEOUT));
+    let _ = stream.set_write_timeout(Some(CLIENT_IO_TIMEOUT));
+
+    let mut reader = BufReader::new(stream.try_clone().context("failed to clone IPC stream")?);
+    let request: HandoffRequest =
+        read_message(&mut reader).context("failed to decode instance IPC request")?;
+
+    let response = handle_request(request);
+    let mut writer = BufWriter::new(stream);
+    write_message(&mut writer, &response).context("failed to encode instance IPC response")
+}
+
+fn handle_request(_request: HandoffRequest) -> HandoffResponse {
+    HandoffResponse { accepted: true, error: None }
+}
+
+fn endpoint_path() -> std::path::PathBuf {
+    neovide_std_datapath().join(format!("neovide-{}.sock", release_channel()))
+}
+
+fn write_message<T, W>(writer: &mut W, value: &T) -> Result<()>
+where
+    T: Serialize,
+    W: Write,
+{
+    serde_json::to_writer(&mut *writer, value).context("failed to serialize JSON message")?;
+    writer.write_all(b"\n").context("failed to terminate JSON message")?;
+    writer.flush().context("failed to flush JSON message")
+}
+
+fn read_message<T, R>(reader: &mut R) -> Result<T>
+where
+    T: DeserializeOwned,
+    R: BufRead,
+{
+    let mut buffer = Vec::new();
+    let bytes_read =
+        reader.read_until(b'\n', &mut buffer).context("failed to read JSON message")?;
+
+    if bytes_read == 0 {
+        bail!("connection closed before a JSON message was received");
+    }
+
+    if matches!(buffer.last(), Some(b'\n')) {
+        buffer.pop();
+    }
+
+    serde_json::from_slice(&buffer).context("failed to deserialize JSON message")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HandoffRequest, read_message, write_message};
+    use crate::version::BUILD_VERSION;
+    use std::io::Cursor;
+
+    #[test]
+    fn handoff_request_new_sets_build_version() {
+        let request = HandoffRequest::new();
+        assert_eq!(request.version, BUILD_VERSION);
+    }
+
+    #[test]
+    fn json_line_roundtrip_preserves_request() {
+        let request = HandoffRequest::new();
+
+        let mut encoded = Vec::new();
+        write_message(&mut encoded, &request).unwrap();
+
+        let mut cursor = Cursor::new(encoded);
+        let decoded: HandoffRequest = read_message(&mut cursor).unwrap();
+
+        assert_eq!(decoded, request);
+    }
+}

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -1,0 +1,1 @@
+pub mod handoff;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,8 @@ mod dimensions;
 mod editor;
 mod error_handling;
 mod frame;
+#[cfg(target_os = "macos")]
+mod ipc;
 mod platform;
 mod profiling;
 mod renderer;
@@ -29,6 +31,7 @@ mod running_tracker;
 mod settings;
 mod units;
 mod utils;
+mod version;
 mod window;
 
 #[cfg(target_os = "windows")]
@@ -62,6 +65,7 @@ use error_handling::handle_startup_errors;
 use renderer::{
     RendererSettings, cursor_renderer::CursorSettings, progress_bar::ProgressBarSettings,
 };
+use version::BUILD_VERSION;
 use window::{
     Application, EventPayload, WindowSettings, create_event_loop, determine_grid_size,
     determine_window_size,
@@ -135,6 +139,15 @@ fn main() -> ExitCode {
         clipboard,
         clipboard_handle,
     );
+
+    #[cfg(target_os = "macos")]
+    let _handoff_listener = match ipc::handoff::start_listener(event_loop.create_proxy()) {
+        Ok(listener) => Some(listener),
+        Err(error) => {
+            log::warn!("failed to start handoff listener: {error:#}");
+            None
+        }
+    };
 
     let result = application.run(event_loop);
     match result {
@@ -250,7 +263,7 @@ fn setup(proxy: EventLoopProxy<EventPayload>, settings: Arc<Settings>) -> Result
     #[cfg(not(test))]
     init_logger(&settings);
 
-    trace!("Neovide version: {}", env!("NEOVIDE_BUILD_VERSION"));
+    trace!("Neovide version: {}", BUILD_VERSION);
 
     Ok(config)
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,28 @@
+pub const BUILD_VERSION: &str = env!("NEOVIDE_BUILD_VERSION");
+
+#[cfg(target_os = "macos")]
+pub fn release_channel() -> &'static str {
+    release_channel_for_build_version(BUILD_VERSION)
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn release_channel_for_build_version(build_version: &str) -> &'static str {
+    if build_version.starts_with("nightly-") { "nightly" } else { "stable" }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::release_channel_for_build_version;
+
+    #[test]
+    fn release_channel_detects_nightly_builds() {
+        assert_eq!(release_channel_for_build_version("nightly-104+g438415298449"), "nightly");
+        assert_eq!(release_channel_for_build_version("nightly-104+g438415298449-dirty"), "nightly");
+    }
+
+    #[test]
+    fn release_channel_defaults_to_stable() {
+        assert_eq!(release_channel_for_build_version("0.15.2"), "stable");
+        assert_eq!(release_channel_for_build_version("0.15.2-dirty"), "stable");
+    }
+}


### PR DESCRIPTION
here we add a small IPC layer to enable cross communication.

this is the very first bedside work forward to make reusable neovide instances  possible. first on macOS only since it is my primary development platform, but the design is not macOS-specific. we will acomplish some of the features by having the new handoff listener to be cross-platform in the future.

the request currently have a `BUILD_VERSION` for `identity/debugging`, but it's important to say that we *do not reject* on protocol version mismatch. that kind of check sounds cleaner than it is. In a daily basis it can lead into incompatible transports when an older Neovide process is still running.

^ this can be rethinked in the future. but there is no need for a real securit boundary anyway right now. The real problem is silent schema drift, so the wire structs use `deny_unknown_fields` and the transport stays small enough to reason about directly.

route requests into a window or open files request are not implemented yet, but the transport is ready to be used for that.

As I said, it's a bedside work.

