### PR TITLE
macos: add --reuse-instance through the handoff path

### DIFF
--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -36,7 +36,11 @@ pub static ROUTE_HANDLER_REGISTRY: LazyLock<Mutex<HashMap<RouteId, NeovimHandler
 /// Startup buffer for macOS cold start. file drops that can arrive before any
 /// neovim handler is active. Flushed when the first route handler registers
 #[cfg(target_os = "macos")]
-static PENDING_FILE_DROPS: LazyLock<Mutex<Vec<String>>> = LazyLock::new(|| Mutex::new(Vec::new()));
+type PendingFileDrop = (String, Option<bool>);
+
+#[cfg(target_os = "macos")]
+static PENDING_FILE_DROPS: LazyLock<Mutex<Vec<PendingFileDrop>>> =
+    LazyLock::new(|| Mutex::new(Vec::new()));
 
 pub fn get_active_handler() -> Option<NeovimHandler> {
     HANDLER_REGISTRY.lock().unwrap().clone()
@@ -47,13 +51,13 @@ pub fn require_active_handler() -> NeovimHandler {
 }
 
 #[cfg(target_os = "macos")]
-pub fn send_or_queue_file_drop(path: String) {
+pub fn send_or_queue_file_drop(path: String, tabs: Option<bool>) {
     if let Some(handler) = get_active_handler() {
-        send_ui(ParallelCommand::FileDrop(path), &handler);
+        send_ui(ParallelCommand::FileDrop { path, tabs }, &handler);
         return;
     }
 
-    PENDING_FILE_DROPS.lock().unwrap().push(path);
+    PENDING_FILE_DROPS.lock().unwrap().push((path, tabs));
 }
 
 #[cfg(target_os = "macos")]
@@ -63,8 +67,8 @@ fn flush_pending_file_drops(handler: &NeovimHandler) {
         std::mem::take(&mut *pending)
     };
 
-    for path in pending {
-        send_ui(ParallelCommand::FileDrop(path), handler);
+    for (path, tabs) in pending {
+        send_ui(ParallelCommand::FileDrop { path, tabs }, handler);
     }
 }
 
@@ -233,7 +237,7 @@ impl SerialCommand {
 pub enum ParallelCommand {
     Quit,
     Resize { width: u64, height: u64 },
-    FileDrop(String),
+    FileDrop { path: String, tabs: Option<bool> },
     FocusLost,
     FocusGained,
     DisplayAvailableFonts(Vec<String>),
@@ -312,7 +316,7 @@ impl ParallelCommand {
             ParallelCommand::FocusGained => {
                 nvim.ui_set_focus(true).await.context("FocusGained failed")
             }
-            ParallelCommand::FileDrop(path) => nvim
+            ParallelCommand::FileDrop { path, tabs } => nvim
                 .exec_lua(
                     "neovide.private.dropfile(...)",
                     call_args![
@@ -320,7 +324,7 @@ impl ParallelCommand {
                             .first()
                             .unwrap()
                             .to_string(),
-                        settings.get::<CmdLineSettings>().tabs
+                        tabs.unwrap_or(settings.get::<CmdLineSettings>().tabs)
                     ],
                 )
                 .await

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -54,6 +54,11 @@ pub struct CmdLineSettings {
     #[arg(long, alias = "remote-tcp", env = "NEOVIDE_SERVER", value_name = "ADDRESS")]
     pub server: Option<String>,
 
+    /// Open files in an existing Neovide app instance if one is already running
+    #[cfg(target_os = "macos")]
+    #[arg(long = "reuse-instance", action = ArgAction::SetTrue, default_value = "0", value_parser = FalseyValueParser::new())]
+    pub reuse_instance: bool,
+
     /// Run NeoVim in WSL rather than on the host
     #[arg(long, env = "NEOVIDE_WSL")]
     pub wsl: bool,
@@ -398,6 +403,18 @@ mod tests {
             settings.get::<CmdLineSettings>().geometry.grid,
             Some(Some(Dimensions { width: 420, height: 240 })),
         );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_reuse_instance_flag() {
+        let settings = Settings::new();
+        let args: Vec<String> =
+            ["neovide", "--reuse-instance", "./foo.txt"].iter().map(|s| s.to_string()).collect();
+
+        handle_command_line_arguments(args, &settings).expect("Could not parse arguments");
+        assert!(settings.get::<CmdLineSettings>().reuse_instance);
+        assert_eq!(settings.get::<CmdLineSettings>().files_to_open, vec!["./foo.txt"]);
     }
 
     #[test]

--- a/src/ipc/handoff.rs
+++ b/src/ipc/handoff.rs
@@ -28,17 +28,17 @@ const LISTENER_POLL_INTERVAL: Duration = Duration::from_millis(100);
 pub struct HandoffRequest {
     pub version: String,
     pub files_to_open: Vec<String>,
+    pub tabs: bool,
 }
 
 impl HandoffRequest {
     #[allow(dead_code)]
     pub fn new() -> Self {
-        Self { version: BUILD_VERSION.to_owned(), files_to_open: Vec::new() }
+        Self { version: BUILD_VERSION.to_owned(), files_to_open: Vec::new(), tabs: true }
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[allow(dead_code)]
 pub enum HandoffResult {
     Accepted,
     NoListener,
@@ -73,7 +73,6 @@ struct HandoffResponse {
     error: Option<String>,
 }
 
-#[allow(dead_code)]
 pub fn try_handoff(request: &HandoffRequest) -> HandoffResult {
     let endpoint = endpoint_path();
     let stream = match UnixStream::connect(&endpoint) {
@@ -207,7 +206,7 @@ fn handle_request(
 ) -> HandoffResponse {
     if !request.files_to_open.is_empty() {
         let payload = EventPayload {
-            payload: UserEvent::OpenFiles(request.files_to_open),
+            payload: UserEvent::OpenFiles { files: request.files_to_open, tabs: request.tabs },
             target: EventTarget::Focused,
         };
 
@@ -269,6 +268,7 @@ mod tests {
         let request = HandoffRequest::new();
         assert_eq!(request.version, BUILD_VERSION);
         assert!(request.files_to_open.is_empty());
+        assert!(request.tabs);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,6 +255,12 @@ fn setup(proxy: EventLoopProxy<EventPayload>, settings: Arc<Settings>) -> Result
             std::process::exit(cmd_line::exit_status_code(status));
         }
     }
+    #[cfg(target_os = "macos")]
+    match maybe_handoff(settings.as_ref()) {
+        HandoffOutcome::Continue => {}
+        HandoffOutcome::Exit => std::process::exit(0),
+        HandoffOutcome::Error(error) => return Err(anyhow::anyhow!(error)),
+    }
     #[cfg(not(target_os = "windows"))]
     maybe_disown(&settings);
 
@@ -266,6 +272,41 @@ fn setup(proxy: EventLoopProxy<EventPayload>, settings: Arc<Settings>) -> Result
     trace!("Neovide version: {}", BUILD_VERSION);
 
     Ok(config)
+}
+
+#[cfg(target_os = "macos")]
+enum HandoffOutcome {
+    Continue,
+    Exit,
+    Error(String),
+}
+
+#[cfg(target_os = "macos")]
+fn maybe_handoff(settings: &Settings) -> HandoffOutcome {
+    let cmdline_settings = settings.get::<CmdLineSettings>();
+    if !cmdline_settings.reuse_instance
+        || cmdline_settings.server.is_some()
+        || cmdline_settings.files_to_open.is_empty()
+    {
+        return HandoffOutcome::Continue;
+    }
+
+    let request = ipc::handoff::HandoffRequest {
+        version: BUILD_VERSION.to_owned(),
+        files_to_open: cmdline_settings.files_to_open.clone(),
+        tabs: cmdline_settings.tabs,
+    };
+
+    match ipc::handoff::try_handoff(&request) {
+        ipc::handoff::HandoffResult::Accepted => HandoffOutcome::Exit,
+        ipc::handoff::HandoffResult::NoListener => HandoffOutcome::Continue,
+        ipc::handoff::HandoffResult::Rejected(error) => {
+            HandoffOutcome::Error(format!("reuse-instance request was rejected: {error}"))
+        }
+        ipc::handoff::HandoffResult::Failed(error) => {
+            HandoffOutcome::Error(format!("reuse-instance request failed: {error}"))
+        }
+    }
 }
 
 #[cfg(not(test))]

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -1747,7 +1747,7 @@ pub fn is_tab_overview_active() -> bool {
 pub fn register_file_handler() {
     fn dispatch_file_drops(filenames: &NSArray<NSString>) {
         for filename in filenames.iter() {
-            send_or_queue_file_drop(filename.to_string());
+            send_or_queue_file_drop(filename.to_string(), None);
         }
     }
 

--- a/src/window/application.rs
+++ b/src/window/application.rs
@@ -634,7 +634,7 @@ impl ApplicationHandler<EventPayload> for Application {
         match payload {
             UserEvent::ConfigsChanged(config) => self.handle_config_changed(target, *config),
             #[cfg(target_os = "macos")]
-            UserEvent::OpenFiles(files) => {
+            UserEvent::OpenFiles { files, tabs } => {
                 if let Some(window_id) = self.window_wrapper.get_focused_route() {
                     if let Some(route_id) = self.window_wrapper.route_id_for_window(window_id) {
                         set_active_route_handler(route_id);
@@ -642,7 +642,7 @@ impl ApplicationHandler<EventPayload> for Application {
                 }
 
                 for path in files {
-                    send_or_queue_file_drop(path);
+                    send_or_queue_file_drop(path, Some(tabs));
                 }
             }
             UserEvent::NeovimExited => {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -133,7 +133,10 @@ pub enum MacShortcutCommand {
 pub enum UserEvent {
     DrawCommandBatch(Vec<DrawCommand>),
     #[cfg(target_os = "macos")]
-    OpenFiles(Vec<String>),
+    OpenFiles {
+        files: Vec<String>,
+        tabs: bool,
+    },
     WindowCommand(WindowCommand),
     SettingsChanged(SettingsChanged),
     ConfigsChanged(Box<HotReloadConfigs>),

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -900,7 +900,10 @@ impl WinitWindowWrapper {
                             return false;
                         }
                     };
-                    send_ui(ParallelCommand::FileDrop(file_path), neovim_handler);
+                    send_ui(
+                        ParallelCommand::FileDrop { path: file_path, tabs: None },
+                        neovim_handler,
+                    );
                 }
                 WindowEvent::Focused(focus) => {
                     tracy_zone!("Focused");


### PR DESCRIPTION
this turns the handoff transport into an actual startup path instead of just a socket we can reproduce calling the IPC by hand.

we now accept it from the cli. if there is no listener, startup should continue. if the request is rejected or the transport fails, we return an explicit startup outcome.

the other important fix here is tabs handling. The original file-drop path always read the `tabs` from the running instance. That would have made `neovide --reuse-instance --no-tabs file.txt` silently use whatever tab setting the runtime uses, which is wrong.

An optional `tabs` override through the existing file-drop pipeline.

fixes https://github.com/neovide/neovide/issues/1586