### PR TITLE
macos: focus the reused window

### DIFF
--- a/src/window/application.rs
+++ b/src/window/application.rs
@@ -639,6 +639,8 @@ impl ApplicationHandler<EventPayload> for Application {
                     if let Some(route_id) = self.window_wrapper.route_id_for_window(window_id) {
                         set_active_route_handler(route_id);
                     }
+
+                    self.window_wrapper.activate_and_focus_window(window_id);
                 }
 
                 for path in files {

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -2165,6 +2165,16 @@ impl WinitWindowWrapper {
         self.routes.keys().next().copied()
     }
 
+    #[cfg(target_os = "macos")]
+    pub fn activate_and_focus_window(&self, window_id: WindowId) -> bool {
+        let Some(feature) = self.macos_feature_for_window(window_id) else {
+            return false;
+        };
+
+        feature.borrow().activate_and_focus();
+        true
+    }
+
     pub fn window_id_for_route(&self, route_id: RouteId) -> Option<WindowId> {
         self.routes
             .iter()


### PR DESCRIPTION
reusing an existing instance but leaving the app in the background is not correct for a default workflow,

so if `--reuse-instance` succeeds we activate the target window.
