### PR TITLE
macos: preserve caller cwd for --reuse-instance requests

### DIFF
--- a/src/ipc/handoff.rs
+++ b/src/ipc/handoff.rs
@@ -28,13 +28,14 @@ const LISTENER_POLL_INTERVAL: Duration = Duration::from_millis(100);
 pub struct HandoffRequest {
     pub version: String,
     pub files_to_open: Vec<String>,
+    pub cwd: Option<String>,
     pub tabs: bool,
 }
 
 impl HandoffRequest {
     #[allow(dead_code)]
     pub fn new() -> Self {
-        Self { version: BUILD_VERSION.to_owned(), files_to_open: Vec::new(), tabs: true }
+        Self { version: BUILD_VERSION.to_owned(), files_to_open: Vec::new(), cwd: None, tabs: true }
     }
 }
 
@@ -206,7 +207,11 @@ fn handle_request(
 ) -> HandoffResponse {
     if !request.files_to_open.is_empty() {
         let payload = EventPayload {
-            payload: UserEvent::OpenFiles { files: request.files_to_open, tabs: request.tabs },
+            payload: UserEvent::OpenFiles {
+                files: request.files_to_open,
+                cwd: request.cwd,
+                tabs: request.tabs,
+            },
             target: EventTarget::Focused,
         };
 
@@ -268,6 +273,7 @@ mod tests {
         let request = HandoffRequest::new();
         assert_eq!(request.version, BUILD_VERSION);
         assert!(request.files_to_open.is_empty());
+        assert!(request.cwd.is_none());
         assert!(request.tabs);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -294,6 +294,7 @@ fn maybe_handoff(settings: &Settings) -> HandoffOutcome {
     let request = ipc::handoff::HandoffRequest {
         version: BUILD_VERSION.to_owned(),
         files_to_open: cmdline_settings.files_to_open.clone(),
+        cwd: std::env::current_dir().ok().map(|dir| dir.to_string_lossy().into_owned()),
         tabs: cmdline_settings.tabs,
     };
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,6 +2,9 @@ mod ring_buffer;
 #[cfg(test)]
 mod test;
 
+#[cfg(target_os = "macos")]
+use std::path::Path;
+
 #[cfg(target_os = "windows")]
 use wslpath_rs::windows_to_wsl;
 
@@ -61,6 +64,19 @@ pub fn expand_tilde(path: &str) -> String {
     }
 
     home.to_string_lossy().into()
+}
+
+#[cfg(target_os = "macos")]
+pub fn resolve_relative_path(path: &str, cwd: Option<&Path>) -> String {
+    if Path::new(path).is_absolute() {
+        return path.to_owned();
+    }
+
+    let Some(cwd) = cwd else {
+        return path.to_owned();
+    };
+
+    cwd.join(path).to_string_lossy().into_owned()
 }
 
 #[cfg(test)]

--- a/src/window/application.rs
+++ b/src/window/application.rs
@@ -3,6 +3,13 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[cfg(target_os = "macos")]
+use {
+    crate::bridge::{send_or_queue_file_drop, set_active_route_handler},
+    crate::utils::resolve_relative_path,
+    std::path::PathBuf,
+};
+
 use glamour::Size2;
 use rustc_hash::FxHashMap;
 use winit::{
@@ -17,8 +24,6 @@ use super::{
     CmdLineSettings, EventPayload, EventTarget, RouteId, WindowSettings, WindowSize,
     WinitWindowWrapper, save_window_size,
 };
-#[cfg(target_os = "macos")]
-use crate::bridge::{send_or_queue_file_drop, set_active_route_handler};
 use crate::{
     clipboard::{Clipboard, ClipboardHandle},
     profiling::{tracy_plot, tracy_zone},
@@ -634,7 +639,7 @@ impl ApplicationHandler<EventPayload> for Application {
         match payload {
             UserEvent::ConfigsChanged(config) => self.handle_config_changed(target, *config),
             #[cfg(target_os = "macos")]
-            UserEvent::OpenFiles { files, tabs } => {
+            UserEvent::OpenFiles { files, cwd, tabs } => {
                 if let Some(window_id) = self.window_wrapper.get_focused_route() {
                     if let Some(route_id) = self.window_wrapper.route_id_for_window(window_id) {
                         set_active_route_handler(route_id);
@@ -643,7 +648,9 @@ impl ApplicationHandler<EventPayload> for Application {
                     self.window_wrapper.activate_and_focus_window(window_id);
                 }
 
+                let cwd = cwd.as_deref().map(PathBuf::from);
                 for path in files {
+                    let path = resolve_relative_path(&path, cwd.as_deref());
                     send_or_queue_file_drop(path, Some(tabs));
                 }
             }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -135,6 +135,7 @@ pub enum UserEvent {
     #[cfg(target_os = "macos")]
     OpenFiles {
         files: Vec<String>,
+        cwd: Option<String>,
         tabs: bool,
     },
     WindowCommand(WindowCommand),


### PR DESCRIPTION
the handoff path was forwarding files, but not its context. as current cwd for the request.

- absolute paths stay unchanged
- relative paths are joined against the caller cwd
- otherwise relative paths are preserved as-is

(also needed for the future smart routing matching path)