### PR TITLE
macos: improve handoff resolved cwd from chdir if needed

### DIFF
--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -10,6 +10,8 @@ use clap::{
     ArgAction, Parser, ValueEnum,
     builder::{FalseyValueParser, Styles, styling},
 };
+#[cfg(target_os = "macos")]
+use clap::{CommandFactory, parser::ValueSource};
 use winit::window::CursorIcon;
 
 #[cfg(target_os = "windows")]
@@ -275,6 +277,15 @@ pub fn handle_command_line_arguments(args: Vec<String>, settings: &Settings) -> 
 
     settings.set::<CmdLineSettings>(&cmdline);
     Ok(())
+}
+
+#[cfg(target_os = "macos")]
+pub fn argv_chdir() -> Option<String> {
+    let matches = CmdLineSettings::command().try_get_matches_from(std::env::args_os()).ok()?;
+
+    (matches.value_source("chdir") == Some(ValueSource::CommandLine))
+        .then(|| matches.get_one::<String>("chdir").cloned())
+        .flatten()
 }
 
 pub fn maybe_passthrough_to_neovim(

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,9 @@ pub use windows_utils::*;
 
 use crate::settings::{Config, Settings, load_last_window_settings};
 
+#[cfg(target_os = "macos")]
+use crate::utils::resolved_cwd;
+
 pub use profiling::startup_profiler;
 
 #[cfg(target_os = "macos")]
@@ -294,7 +297,7 @@ fn maybe_handoff(settings: &Settings) -> HandoffOutcome {
     let request = ipc::handoff::HandoffRequest {
         version: BUILD_VERSION.to_owned(),
         files_to_open: cmdline_settings.files_to_open.clone(),
-        cwd: std::env::current_dir().ok().map(|dir| dir.to_string_lossy().into_owned()),
+        cwd: resolved_cwd(cmd_line::argv_chdir().as_deref()),
         tabs: cmdline_settings.tabs,
     };
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,7 +3,7 @@ mod ring_buffer;
 mod test;
 
 #[cfg(target_os = "macos")]
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[cfg(target_os = "windows")]
 use wslpath_rs::windows_to_wsl;
@@ -64,6 +64,19 @@ pub fn expand_tilde(path: &str) -> String {
     }
 
     home.to_string_lossy().into()
+}
+
+#[cfg(target_os = "macos")]
+pub fn resolved_cwd(chdir: Option<&str>) -> Option<String> {
+    let current_dir = std::env::current_dir().ok();
+
+    let cwd = match chdir {
+        Some(dir) if Path::new(dir).is_absolute() => PathBuf::from(dir),
+        Some(dir) => current_dir?.join(dir),
+        None => current_dir?,
+    };
+
+    Some(cwd.to_string_lossy().into_owned())
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
this is actually an improvement to the `--reuse-instance` handoff case. we should follow the `cwd` semantics of the request the user actually dispatched, not whatever happened to be loaded, so we split the problem properly.
