### PR TITLE
intro: ignore padding changes to support banner on nightly release changes

### DIFF
--- a/src/editor/intro.rs
+++ b/src/editor/intro.rs
@@ -177,7 +177,7 @@ fn is_intro_header(text: &str) -> bool {
 }
 
 fn is_neovim_intro_final_line_text(text: &str) -> bool {
-    text.trim() == INTRO_FINAL_LINE
+    text.split_whitespace().eq(INTRO_FINAL_LINE.split_whitespace())
 }
 
 fn classify_intro_line_start(cells: &[GridLineCell]) -> IntroLineKind {


### PR DESCRIPTION
neovim changed the intro line at https://github.com/neovim/neovim/pull/38378

we improve how we compare and detect the final line to support both **stable|nightly** versions.

