### PR TITLE
feat: add --new-window cli option

### DIFF
--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -61,6 +61,11 @@ pub struct CmdLineSettings {
     #[arg(long = "reuse-instance", action = ArgAction::SetTrue, default_value = "0", value_parser = FalseyValueParser::new())]
     pub reuse_instance: bool,
 
+    /// Open files in a new window when reusing an existing Neovide instance
+    #[cfg(target_os = "macos")]
+    #[arg(long = "new-window", requires = "reuse_instance", action = ArgAction::SetTrue, default_value = "0", value_parser = FalseyValueParser::new())]
+    pub new_window: bool,
+
     /// Run NeoVim in WSL rather than on the host
     #[arg(long, env = "NEOVIDE_WSL")]
     pub wsl: bool,
@@ -426,6 +431,31 @@ mod tests {
         handle_command_line_arguments(args, &settings).expect("Could not parse arguments");
         assert!(settings.get::<CmdLineSettings>().reuse_instance);
         assert_eq!(settings.get::<CmdLineSettings>().files_to_open, vec!["./foo.txt"]);
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_new_window_flag() {
+        let settings = Settings::new();
+        let args: Vec<String> = ["neovide", "--reuse-instance", "--new-window", "./foo.txt"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        handle_command_line_arguments(args, &settings).expect("Could not parse arguments");
+        assert!(settings.get::<CmdLineSettings>().reuse_instance);
+        assert!(settings.get::<CmdLineSettings>().new_window);
+        assert_eq!(settings.get::<CmdLineSettings>().files_to_open, vec!["./foo.txt"]);
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_new_window_requires_reuse_instance() {
+        let settings = Settings::new();
+        let args: Vec<String> =
+            ["neovide", "--new-window", "./foo.txt"].iter().map(|s| s.to_string()).collect();
+
+        assert!(handle_command_line_arguments(args, &settings).is_err());
     }
 
     #[test]

--- a/src/ipc/handoff.rs
+++ b/src/ipc/handoff.rs
@@ -29,12 +29,19 @@ pub struct HandoffRequest {
     pub files_to_open: Vec<String>,
     pub cwd: Option<String>,
     pub tabs: bool,
+    pub new_window: bool,
 }
 
 impl HandoffRequest {
     #[allow(dead_code)]
     pub fn new() -> Self {
-        Self { version: BUILD_VERSION.to_owned(), files_to_open: Vec::new(), cwd: None, tabs: true }
+        Self {
+            version: BUILD_VERSION.to_owned(),
+            files_to_open: Vec::new(),
+            cwd: None,
+            tabs: true,
+            new_window: false,
+        }
     }
 }
 
@@ -204,12 +211,13 @@ fn handle_request(
     request: HandoffRequest,
     proxy: &EventLoopProxy<EventPayload>,
 ) -> HandoffResponse {
-    if !request.files_to_open.is_empty() {
+    if request.new_window || !request.files_to_open.is_empty() {
         let payload = EventPayload {
             payload: UserEvent::OpenFiles {
                 files: request.files_to_open,
                 cwd: request.cwd,
                 tabs: request.tabs,
+                new_window: request.new_window,
             },
             target: EventTarget::Focused,
         };
@@ -274,11 +282,18 @@ mod tests {
         assert!(request.files_to_open.is_empty());
         assert!(request.cwd.is_none());
         assert!(request.tabs);
+        assert!(!request.new_window);
     }
 
     #[test]
     fn json_line_roundtrip_preserves_request() {
-        let request = HandoffRequest::new();
+        let request = HandoffRequest {
+            files_to_open: vec!["~/project".into()],
+            cwd: Some("/path/to/user".into()),
+            tabs: false,
+            new_window: true,
+            ..HandoffRequest::new()
+        };
 
         let mut encoded = Vec::new();
         write_message(&mut encoded, &request).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,7 +289,7 @@ fn maybe_handoff(settings: &Settings) -> HandoffOutcome {
     let cmdline_settings = settings.get::<CmdLineSettings>();
     if !cmdline_settings.reuse_instance
         || cmdline_settings.server.is_some()
-        || cmdline_settings.files_to_open.is_empty()
+        || (cmdline_settings.files_to_open.is_empty() && !cmdline_settings.new_window)
     {
         return HandoffOutcome::Continue;
     }
@@ -299,6 +299,7 @@ fn maybe_handoff(settings: &Settings) -> HandoffOutcome {
         files_to_open: cmdline_settings.files_to_open.clone(),
         cwd: resolved_cwd(cmd_line::argv_chdir().as_deref()),
         tabs: cmdline_settings.tabs,
+        new_window: cmdline_settings.new_window,
     };
 
     match ipc::handoff::try_handoff(&request) {

--- a/src/window/application.rs
+++ b/src/window/application.rs
@@ -241,6 +241,29 @@ impl Application {
         }
     }
 
+    #[cfg(target_os = "macos")]
+    fn activate_focused_route(&self) {
+        let Some(window_id) = self.window_wrapper.get_focused_route() else {
+            return;
+        };
+
+        if let Some(route_id) = self.window_wrapper.route_id_for_window(window_id) {
+            set_active_route_handler(route_id);
+        }
+
+        self.window_wrapper.activate_and_focus_window(window_id);
+    }
+
+    #[cfg(target_os = "macos")]
+    fn prepare_open_files(&mut self, event_loop: &ActiveEventLoop, new_window: bool) {
+        if new_window {
+            self.window_wrapper.try_create_window(event_loop, &self.proxy);
+            self.mark_should_render_all();
+        }
+
+        self.activate_focused_route();
+    }
+
     fn handle_app_config_changed(&mut self, config: AppHotReloadConfigs) {
         match config {
             AppHotReloadConfigs::Idle(idle) => {
@@ -639,14 +662,8 @@ impl ApplicationHandler<EventPayload> for Application {
         match payload {
             UserEvent::ConfigsChanged(config) => self.handle_config_changed(target, *config),
             #[cfg(target_os = "macos")]
-            UserEvent::OpenFiles { files, cwd, tabs } => {
-                if let Some(window_id) = self.window_wrapper.get_focused_route() {
-                    if let Some(route_id) = self.window_wrapper.route_id_for_window(window_id) {
-                        set_active_route_handler(route_id);
-                    }
-
-                    self.window_wrapper.activate_and_focus_window(window_id);
-                }
+            UserEvent::OpenFiles { files, cwd, tabs, new_window } => {
+                self.prepare_open_files(event_loop, new_window);
 
                 let cwd = cwd.as_deref().map(PathBuf::from);
                 for path in files {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -137,6 +137,7 @@ pub enum UserEvent {
         files: Vec<String>,
         cwd: Option<String>,
         tabs: bool,
+        new_window: bool,
     },
     WindowCommand(WindowCommand),
     SettingsChanged(SettingsChanged),


### PR DESCRIPTION
we simply create a new window and then activate the route that is now focused.