### PR TITLE
fix: split route cwd from caller cwd on handoffs

### DIFF
--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -1,5 +1,7 @@
 #[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
+use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command as StdCommand;
 use tokio::process::Command as TokioCommand;
 
@@ -35,17 +37,19 @@ impl CommandSpec {
     }
 }
 
-pub fn create_nvim_command(settings: &Settings) -> TokioCommand {
+pub fn create_restart_nvim_command(
+    settings: &Settings,
+    details: &RestartDetails,
+    cwd: Option<&Path>,
+) -> TokioCommand {
     let cmdline_settings = settings.get::<CmdLineSettings>();
-    create_tokio_nvim_command(&cmdline_settings, true)
-}
-
-pub fn create_restart_nvim_command(settings: &Settings, details: &RestartDetails) -> TokioCommand {
-    let settings = settings.get::<CmdLineSettings>();
-    let spec = create_restart_command_spec(details, &settings);
+    let spec = create_restart_command_spec(details, &cmdline_settings);
 
     #[allow(unused_mut)]
     let mut cmd = tokio_command_from_spec(spec);
+    if let Some(dir) = command_cwd(&cmdline_settings, cwd) {
+        cmd.current_dir(dir);
+    }
 
     #[cfg(target_os = "windows")]
     cmd.creation_flags(windows::Win32::System::Threading::CREATE_NO_WINDOW.0);
@@ -57,20 +61,28 @@ pub fn create_blocking_nvim_command(cmdline_settings: &CmdLineSettings, embed: b
     let (bin, args) = build_nvim_command_parts(cmdline_settings, embed);
     let spec = create_command_spec(&bin, &args, cmdline_settings);
     let mut cmd = std_command_from_spec(spec);
-    if let Some(dir) = &cmdline_settings.chdir {
+    if let Some(dir) = command_cwd(cmdline_settings, None) {
         cmd.current_dir(dir);
     }
     cmd
 }
 
-fn create_tokio_nvim_command(cmdline_settings: &CmdLineSettings, embed: bool) -> TokioCommand {
+pub fn create_tokio_nvim_command(
+    cmdline_settings: &CmdLineSettings,
+    embed: bool,
+    cwd: Option<&Path>,
+) -> TokioCommand {
     let (bin, args) = build_nvim_command_parts(cmdline_settings, embed);
     let spec = create_command_spec(&bin, &args, cmdline_settings);
     let mut cmd = tokio_command_from_spec(spec);
-    if let Some(dir) = &cmdline_settings.chdir {
+    if let Some(dir) = command_cwd(cmdline_settings, cwd) {
         cmd.current_dir(dir);
     }
     cmd
+}
+
+fn command_cwd(settings: &CmdLineSettings, cwd: Option<&Path>) -> Option<PathBuf> {
+    cwd.map(Path::to_path_buf).or_else(|| settings.chdir.as_deref().map(PathBuf::from))
 }
 
 fn build_nvim_command_parts(
@@ -260,6 +272,8 @@ fn create_command_spec(
 
 #[cfg(test)]
 mod tests {
+    use std::path::{Path, PathBuf};
+
     use crate::cmd_line::handle_command_line_arguments;
 
     use super::*;
@@ -269,6 +283,13 @@ mod tests {
         let args = args.iter().map(|arg| arg.to_string()).collect();
         handle_command_line_arguments(args, &settings).expect("Could not parse arguments");
         settings.get::<CmdLineSettings>()
+    }
+
+    fn parse_settings(args: &[&str]) -> Settings {
+        let settings = Settings::new();
+        let args = args.iter().map(|arg| arg.to_string()).collect();
+        handle_command_line_arguments(args, &settings).expect("Could not parse arguments");
+        settings
     }
 
     #[test]
@@ -347,5 +368,49 @@ mod tests {
 
         assert_eq!(program, "nvim");
         assert_eq!(args, vec!["--embed", "-p", "foo.txt"]);
+    }
+
+    #[test]
+    fn command_cwd_prefers_override() {
+        let cmdline_settings = parse_cmdline_settings(&["neovide", "--chdir", "/random/path"]);
+
+        assert_eq!(
+            command_cwd(&cmdline_settings, Some(Path::new("/route/cwd"))),
+            Some(PathBuf::from("/route/cwd"))
+        );
+    }
+
+    #[test]
+    fn command_cwd_falls_back_to_cmdline_setting() {
+        let cmdline_settings = parse_cmdline_settings(&["neovide", "--chdir", "/random/path"]);
+
+        assert_eq!(command_cwd(&cmdline_settings, None), Some(PathBuf::from("/random/path")));
+    }
+
+    #[test]
+    fn create_restart_nvim_command_prefers_route_cwd() {
+        let settings = parse_settings(&["neovide", "--chdir", "/cmdline/cwd"]);
+        let restart_details = RestartDetails {
+            progpath: "nvim".to_string(),
+            argv: vec!["nvim".to_string(), "--clean".to_string()],
+        };
+
+        let command =
+            create_restart_nvim_command(&settings, &restart_details, Some(Path::new("/route/cwd")));
+
+        assert_eq!(command.as_std().get_current_dir(), Some(Path::new("/route/cwd")));
+    }
+
+    #[test]
+    fn create_restart_nvim_command_falls_back_to_cmdline_cwd() {
+        let settings = parse_settings(&["neovide", "--chdir", "/cmdline/cwd"]);
+        let restart_details = RestartDetails {
+            progpath: "nvim".to_string(),
+            argv: vec!["nvim".to_string(), "--clean".to_string()],
+        };
+
+        let command = create_restart_nvim_command(&settings, &restart_details, None);
+
+        assert_eq!(command.as_std().get_current_dir(), Some(Path::new("/cmdline/cwd")));
     }
 }

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -11,6 +11,7 @@ mod ui_commands;
 use std::{
     io::Error,
     ops::Add,
+    path::Path,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -41,8 +42,10 @@ use tokio::{
 };
 use winit::event_loop::EventLoopProxy;
 
+pub use command::create_blocking_nvim_command;
 use command::create_restart_nvim_command;
-pub use command::{create_blocking_nvim_command, create_nvim_command};
+#[cfg(test)]
+pub use command::create_tokio_nvim_command;
 pub use events::*;
 pub use restart::RestartDetails;
 pub use session::NeovimWriter;
@@ -94,16 +97,18 @@ pub struct NeovimRuntime {
 async fn neovim_instance(
     settings: &Settings,
     restart: Option<&RestartDetails>,
+    cwd: Option<&Path>,
 ) -> Result<NeovimInstance> {
     if let Some(info) = restart {
-        return Ok(NeovimInstance::Embedded(create_restart_nvim_command(settings, info)));
+        return Ok(NeovimInstance::Embedded(create_restart_nvim_command(settings, info, cwd)));
     }
 
     if let Some(address) = settings.get::<CmdLineSettings>().server {
         return Ok(NeovimInstance::Server { address });
     }
 
-    Ok(NeovimInstance::Embedded(create_nvim_command(settings)))
+    let cmdline_settings = settings.get::<CmdLineSettings>();
+    Ok(NeovimInstance::Embedded(command::create_tokio_nvim_command(&cmdline_settings, true, cwd)))
 }
 
 pub async fn show_error_message(
@@ -137,8 +142,9 @@ async fn create_neovim_session(
     settings: Arc<Settings>,
     background: &str,
     restart_details: Option<&RestartDetails>,
+    cwd: Option<&Path>,
 ) -> Result<NeovimSession> {
-    let neovim_instance = neovim_instance(settings.as_ref(), restart_details).await?;
+    let neovim_instance = neovim_instance(settings.as_ref(), restart_details, cwd).await?;
     #[allow(unused_mut)]
     let mut session = NeovimSession::new(neovim_instance, handler.clone())
         .await
@@ -311,6 +317,7 @@ impl NeovimRuntime {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn launch(
         &mut self,
         route_id: RouteId,
@@ -319,6 +326,7 @@ impl NeovimRuntime {
         running_tracker: RunningTracker,
         settings: Arc<Settings>,
         config: &Config,
+        cwd: Option<&Path>,
     ) -> Result<NeovimHandler> {
         let mut colorscheme_stream = self.colorscheme_stream();
         let editor_handler = start_editor_handler(
@@ -343,6 +351,7 @@ impl NeovimRuntime {
             settings,
             &initial_background,
             None,
+            cwd,
         )) {
             Ok(session) => session,
             Err(err) => {
@@ -368,6 +377,7 @@ impl NeovimRuntime {
         self.shutdown_timeout(timeout);
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn restart(
         &mut self,
         route_id: RouteId,
@@ -376,6 +386,7 @@ impl NeovimRuntime {
         grid_size: GridSize<u32>,
         settings: Arc<Settings>,
         restart_details: RestartDetails,
+        cwd: Option<&Path>,
     ) -> Result<()> {
         let background = self.current_background();
         let session = self.runtime().block_on(create_neovim_session(
@@ -385,6 +396,7 @@ impl NeovimRuntime {
             settings,
             &background,
             Some(&restart_details),
+            cwd,
         ))?;
 
         self.runtime().spawn(run(route_id, session, event_loop_proxy));

--- a/src/ipc/handoff.rs
+++ b/src/ipc/handoff.rs
@@ -28,6 +28,7 @@ pub struct HandoffRequest {
     pub version: String,
     pub files_to_open: Vec<String>,
     pub cwd: Option<String>,
+    pub caller_cwd: Option<String>,
     pub tabs: bool,
     pub new_window: bool,
 }
@@ -39,6 +40,7 @@ impl HandoffRequest {
             version: BUILD_VERSION.to_owned(),
             files_to_open: Vec::new(),
             cwd: None,
+            caller_cwd: None,
             tabs: true,
             new_window: false,
         }
@@ -216,6 +218,7 @@ fn handle_request(
             payload: UserEvent::OpenFiles {
                 files: request.files_to_open,
                 cwd: request.cwd,
+                caller_cwd: request.caller_cwd,
                 tabs: request.tabs,
                 new_window: request.new_window,
             },
@@ -281,6 +284,7 @@ mod tests {
         assert_eq!(request.version, BUILD_VERSION);
         assert!(request.files_to_open.is_empty());
         assert!(request.cwd.is_none());
+        assert!(request.caller_cwd.is_none());
         assert!(request.tabs);
         assert!(!request.new_window);
     }
@@ -290,6 +294,7 @@ mod tests {
         let request = HandoffRequest {
             files_to_open: vec!["~/project".into()],
             cwd: Some("/path/to/user".into()),
+            caller_cwd: Some("/path/to/worktree".into()),
             tabs: false,
             new_window: true,
             ..HandoffRequest::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -298,6 +298,7 @@ fn maybe_handoff(settings: &Settings) -> HandoffOutcome {
         version: BUILD_VERSION.to_owned(),
         files_to_open: cmdline_settings.files_to_open.clone(),
         cwd: resolved_cwd(cmd_line::argv_chdir().as_deref()),
+        caller_cwd: resolved_cwd(None),
         tabs: cmdline_settings.tabs,
         new_window: cmdline_settings.new_window,
     };

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -263,7 +263,7 @@ mod tests {
     use super::*;
     use crate::{
         bridge::{
-            create_nvim_command,
+            create_tokio_nvim_command,
             session::{NeovimInstance, NeovimSession},
         },
         cmd_line::CmdLineSettings,
@@ -365,10 +365,11 @@ mod tests {
         let settings = Settings::new();
         settings.register::<TestSettings>();
 
-        //create_nvim_command tries to read from CmdLineSettings.neovim_args
+        // create_tokio_nvim_command reads from CmdLineSettings.neovim_args
         settings.set::<CmdLineSettings>(&CmdLineSettings::default());
 
-        let command = create_nvim_command(&settings);
+        let cmdline_settings = settings.get::<CmdLineSettings>();
+        let command = create_tokio_nvim_command(&cmdline_settings, true, None);
         let instance = NeovimInstance::Embedded(command);
         let NeovimSession { neovim: nvim, .. } = NeovimSession::new(instance, NeovimHandler())
             .await

--- a/src/window/application.rs
+++ b/src/window/application.rs
@@ -7,7 +7,7 @@ use std::{
 use {
     crate::bridge::{send_or_queue_file_drop, set_active_route_handler},
     crate::utils::resolve_relative_path,
-    std::path::PathBuf,
+    std::path::Path,
 };
 
 use glamour::Size2;
@@ -255,10 +255,16 @@ impl Application {
     }
 
     #[cfg(target_os = "macos")]
-    fn prepare_open_files(&mut self, event_loop: &ActiveEventLoop, new_window: bool) {
+    fn prepare_open_files(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        new_window: bool,
+        cwd: Option<&Path>,
+    ) {
         if new_window {
-            self.window_wrapper.try_create_window(event_loop, &self.proxy);
+            self.window_wrapper.try_create_window(event_loop, &self.proxy, cwd);
             self.mark_should_render_all();
+            return;
         }
 
         self.activate_focused_route();
@@ -354,7 +360,7 @@ impl Application {
         #[cfg(feature = "profiling")]
         self.aggregate_should_render().plot_tracy();
         if self.create_window_allowed && self.window_wrapper.has_pending_window_creation() {
-            self.window_wrapper.try_create_window(event_loop, &self.proxy);
+            self.window_wrapper.try_create_window(event_loop, &self.proxy, None);
         }
         event_loop.set_control_flow(ControlFlow::WaitUntil(self.get_event_deadline()));
     }
@@ -662,12 +668,13 @@ impl ApplicationHandler<EventPayload> for Application {
         match payload {
             UserEvent::ConfigsChanged(config) => self.handle_config_changed(target, *config),
             #[cfg(target_os = "macos")]
-            UserEvent::OpenFiles { files, cwd, tabs, new_window } => {
-                self.prepare_open_files(event_loop, new_window);
+            UserEvent::OpenFiles { files, cwd, caller_cwd, tabs, new_window } => {
+                let cwd = cwd.as_deref().map(Path::new);
+                let caller_cwd = caller_cwd.as_deref().map(Path::new);
+                self.prepare_open_files(event_loop, new_window, cwd);
 
-                let cwd = cwd.as_deref().map(PathBuf::from);
                 for path in files {
-                    let path = resolve_relative_path(&path, cwd.as_deref());
+                    let path = resolve_relative_path(&path, caller_cwd);
                     send_or_queue_file_drop(path, Some(tabs));
                 }
             }
@@ -760,7 +767,7 @@ impl ApplicationHandler<EventPayload> for Application {
             }
             #[cfg(target_os = "macos")]
             UserEvent::CreateWindow => {
-                self.window_wrapper.try_create_window(event_loop, &self.proxy);
+                self.window_wrapper.try_create_window(event_loop, &self.proxy, None);
                 self.sync_render_states();
                 self.mark_should_render_all();
             }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -136,6 +136,7 @@ pub enum UserEvent {
     OpenFiles {
         files: Vec<String>,
         cwd: Option<String>,
+        caller_cwd: Option<String>,
         tabs: bool,
         new_window: bool,
     },

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -1,4 +1,10 @@
-use std::{cell::RefCell, fmt, rc::Rc, sync::Arc};
+use std::{
+    cell::RefCell,
+    fmt,
+    path::{Path, PathBuf},
+    rc::Rc,
+    sync::Arc,
+};
 
 use log::trace;
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
@@ -122,6 +128,7 @@ impl fmt::Debug for RouteWindow {
 pub struct Route {
     pub route_id: RouteId,
     pub window: RouteWindow,
+    cwd: Option<PathBuf>,
     pub pending_initial_window_size: Option<WindowSize>,
     state: RouteState,
 }
@@ -168,6 +175,7 @@ struct RouteCore {
     route_id: RouteId,
     renderer: Rc<RefCell<Box<Renderer>>>,
     neovim_handler: NeovimHandler,
+    cwd: Option<PathBuf>,
     title: String,
     mouse_enabled: bool,
     pending_initial_window_size: Option<WindowSize>,
@@ -273,6 +281,7 @@ impl WinitWindowWrapper {
                 self.runtime_tracker.clone(),
                 self.settings.clone(),
                 &config,
+                None,
             )
             .expect("Failed to launch neovim runtime");
 
@@ -282,6 +291,7 @@ impl WinitWindowWrapper {
                 route_id,
                 renderer,
                 neovim_handler,
+                cwd: None,
                 title: String::from("Neovide"),
                 mouse_enabled: true,
                 pending_initial_window_size,
@@ -1379,6 +1389,7 @@ impl WinitWindowWrapper {
         &mut self,
         event_loop: &ActiveEventLoop,
         proxy: &EventLoopProxy<EventPayload>,
+        cwd: Option<&Path>,
     ) {
         let creating_initial_window = self.routes.is_empty();
         let route_id = if creating_initial_window {
@@ -1458,7 +1469,7 @@ impl WinitWindowWrapper {
             ..
         } = self.settings.get::<WindowSettings>();
 
-        let (renderer, neovim_handler, route_pending_initial_window_size) =
+        let (renderer, neovim_handler, route_pending_initial_window_size, route_cwd) =
             if creating_initial_window {
                 let Some(route_core) = self.route_cores.remove(&route_id) else {
                     log::warn!("Missing pending route core for initial route {route_id:?}");
@@ -1475,6 +1486,7 @@ impl WinitWindowWrapper {
                     route_core.renderer,
                     route_core.neovim_handler,
                     route_core.pending_initial_window_size,
+                    route_core.cwd,
                 )
             } else {
                 let config = Config::init();
@@ -1494,10 +1506,11 @@ impl WinitWindowWrapper {
                         self.runtime_tracker.clone(),
                         self.settings.clone(),
                         &config,
+                        cwd,
                     )
                     .expect("Failed to launch neovim runtime");
 
-                (renderer, neovim_handler, None)
+                (renderer, neovim_handler, None, cwd.map(Path::to_path_buf))
             };
 
         window.set_ime_allowed(input_ime);
@@ -1677,6 +1690,7 @@ impl WinitWindowWrapper {
                 last_applied_window_size: saved_inner_size,
                 last_synced_grid_size: route_last_synced_grid_size,
             },
+            cwd: route_cwd,
             pending_initial_window_size,
             state,
         };
@@ -1836,6 +1850,7 @@ impl WinitWindowWrapper {
         proxy: &EventLoopProxy<EventPayload>,
     ) -> Result<(), ()> {
         let handler = self.neovim_handler_for_route(route_id).ok_or(())?;
+        let cwd = self.route_cwd(route_id);
         let runtime = self.runtime.as_mut().ok_or(())?;
 
         runtime
@@ -1846,10 +1861,19 @@ impl WinitWindowWrapper {
                 restart.grid_size,
                 self.settings.clone(),
                 restart.details,
+                cwd.as_deref(),
             )
             .map_err(|error| {
                 log::error!("Failed to restart Neovim: {error:?}");
             })
+    }
+
+    fn route_cwd(&self, route_id: RouteId) -> Option<PathBuf> {
+        if let Some(window_id) = self.window_id_for_route(route_id) {
+            return self.routes.get(&window_id).and_then(|route| route.cwd.clone());
+        }
+
+        self.route_cores.get(&route_id).and_then(|route_core| route_core.cwd.clone())
     }
 
     pub fn handle_neovim_exit(


### PR DESCRIPTION
the mistake here was treating `--chdir` and a relative file arg as if they described the same directory from its caller.

they don't.

For a handoff like

```
cd ~/neovide
neovide --reuse-instance --new-window src/main.rs --chdir ~
```

the file comes from the caller shell cwd, so it should still mean `~/neovide/src/main.rs` but the new neovim route itself should start with cwd `~`

now we take both meanings explicitly through the handoff path:
- cwd: the per-route startup cwd
- caller_cwd: the base directory for resolving relative file drops