### PR TITLE
multi-window: rename macos-* settings to system-*

### DIFF
--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -108,33 +108,33 @@ pub struct CmdLineSettings {
     #[arg(long = "no-tabs", action = ArgAction::SetTrue, value_parser = FalseyValueParser::new())]
     _no_tabs: bool,
 
-    /// Keep the native macOS tab bar visible when windows merge together
+    /// Keep the native system tab bar visible when windows merge together
     #[cfg(target_os = "macos")]
-    #[arg(long = "macos-native-tabs", env = "NEOVIDE_MACOS_NATIVE_TABS", action = ArgAction::SetTrue, default_value = "0", value_parser = FalseyValueParser::new())]
-    pub macos_native_tabs: bool,
+    #[arg(long = "system-native-tabs", env = "NEOVIDE_SYSTEM_NATIVE_TABS", action = ArgAction::SetTrue, default_value = "0", value_parser = FalseyValueParser::new())]
+    pub system_native_tabs: bool,
 
-    /// Hide the native macOS tab bar even if the config enables it
+    /// Hide the native system tab bar even if the config enables it
     #[cfg(target_os = "macos")]
-    #[arg(long = "no-macos-native-tabs", action = ArgAction::SetTrue, value_parser = FalseyValueParser::new())]
-    _no_macos_native_tabs: bool,
+    #[arg(long = "no-system-native-tabs", action = ArgAction::SetTrue, value_parser = FalseyValueParser::new())]
+    _no_system_native_tabs: bool,
 
-    /// Cycle to the previous macOS tab when pressed inside Neovide
+    /// Cycle to the previous system tab when pressed inside Neovide
     #[cfg(target_os = "macos")]
     #[arg(
-        long = "macos-tab-prev-hotkey",
-        env = "NEOVIDE_MACOS_TAB_PREV_HOTKEY",
+        long = "system-tab-prev-hotkey",
+        env = "NEOVIDE_SYSTEM_TAB_PREV_HOTKEY",
         default_value = "cmd+shift+["
     )]
-    pub macos_tab_prev_hotkey: String,
+    pub system_tab_prev_hotkey: String,
 
-    /// Cycle to the next macOS tab when pressed inside Neovide
+    /// Cycle to the next system tab when pressed inside Neovide
     #[cfg(target_os = "macos")]
     #[arg(
-        long = "macos-tab-next-hotkey",
-        env = "NEOVIDE_MACOS_TAB_NEXT_HOTKEY",
+        long = "system-tab-next-hotkey",
+        env = "NEOVIDE_SYSTEM_TAB_NEXT_HOTKEY",
         default_value = "cmd+shift+]"
     )]
-    pub macos_tab_next_hotkey: String,
+    pub system_tab_next_hotkey: String,
 
     /// Request sRGB when initializing the window, may help with GPUs with weird pixel
     /// formats. Default on Windows.
@@ -264,8 +264,8 @@ pub fn handle_command_line_arguments(args: Vec<String>, settings: &Settings) -> 
     }
 
     #[cfg(target_os = "macos")]
-    if cmdline._no_macos_native_tabs {
-        cmdline.macos_native_tabs = false;
+    if cmdline._no_system_native_tabs {
+        cmdline.system_native_tabs = false;
     }
 
     if cmdline._no_fork {
@@ -729,35 +729,35 @@ mod tests {
     }
     #[cfg(target_os = "macos")]
     #[test]
-    fn test_macos_native_tabs_flag() {
+    fn test_system_native_tabs_flag() {
         let settings = Settings::new();
         let args: Vec<String> =
-            ["neovide", "--macos-native-tabs"].iter().map(|s| s.to_string()).collect();
+            ["neovide", "--system-native-tabs"].iter().map(|s| s.to_string()).collect();
 
         handle_command_line_arguments(args, &settings).expect("Could not parse arguments");
-        assert!(settings.get::<CmdLineSettings>().macos_native_tabs);
+        assert!(settings.get::<CmdLineSettings>().system_native_tabs);
     }
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn test_macos_native_tabs_env() {
+    fn test_system_native_tabs_env() {
         let settings = Settings::new();
         let args: Vec<String> = ["neovide"].iter().map(|s| s.to_string()).collect();
 
-        let _env = ScopedEnv::set("NEOVIDE_MACOS_NATIVE_TABS", "1");
+        let _env = ScopedEnv::set("NEOVIDE_SYSTEM_NATIVE_TABS", "1");
         handle_command_line_arguments(args, &settings).expect("Could not parse arguments");
-        assert!(settings.get::<CmdLineSettings>().macos_native_tabs);
+        assert!(settings.get::<CmdLineSettings>().system_native_tabs);
     }
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn test_macos_native_tabs_override_env() {
+    fn test_system_native_tabs_override_env() {
         let settings = Settings::new();
         let args: Vec<String> =
-            ["neovide", "--no-macos-native-tabs"].iter().map(|s| s.to_string()).collect();
+            ["neovide", "--no-system-native-tabs"].iter().map(|s| s.to_string()).collect();
 
-        let _env = ScopedEnv::set("NEOVIDE_MACOS_NATIVE_TABS", "1");
+        let _env = ScopedEnv::set("NEOVIDE_SYSTEM_NATIVE_TABS", "1");
         handle_command_line_arguments(args, &settings).expect("Could not parse arguments");
-        assert!(!settings.get::<CmdLineSettings>().macos_native_tabs);
+        assert!(!settings.get::<CmdLineSettings>().system_native_tabs);
     }
 }

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -354,7 +354,7 @@ impl MacosWindowFeature {
         let window_settings = settings.get::<WindowSettings>();
         let simple_fullscreen = window_settings.macos_simple_fullscreen;
         let enable_native_tabs = frame != Frame::None && !simple_fullscreen;
-        let show_native_tabs = cmd_line_settings.macos_native_tabs && enable_native_tabs;
+        let show_native_tabs = cmd_line_settings.system_native_tabs && enable_native_tabs;
         ENABLE_NATIVE_TAB_BAR.store(enable_native_tabs, Ordering::Relaxed);
         SHOW_NATIVE_TAB_BAR.store(show_native_tabs, Ordering::Relaxed);
 

--- a/src/settings/config.rs
+++ b/src/settings/config.rs
@@ -61,16 +61,16 @@ pub struct Config {
     pub no_multigrid: Option<bool>,
     pub srgb: Option<bool>,
     pub tabs: Option<bool>,
-    pub macos_native_tabs: Option<bool>,
+    pub system_native_tabs: Option<bool>,
     pub mouse_cursor_icon: Option<String>,
     pub title_hidden: Option<bool>,
     pub vsync: Option<bool>,
     pub wsl: Option<bool>,
     pub backtraces_path: Option<PathBuf>,
-    pub macos_pinned_hotkey: Option<String>,
-    pub macos_switcher_hotkey: Option<String>,
-    pub macos_tab_prev_hotkey: Option<String>,
-    pub macos_tab_next_hotkey: Option<String>,
+    pub system_pinned_hotkey: Option<String>,
+    pub system_switcher_hotkey: Option<String>,
+    pub system_tab_prev_hotkey: Option<String>,
+    pub system_tab_next_hotkey: Option<String>,
     pub icon: Option<String>,
     pub chdir: Option<PathBuf>,
     pub opengl: Option<bool>,
@@ -170,20 +170,20 @@ impl Config {
         if let Some(tabs) = &self.tabs {
             env::set_var("NEOVIDE_TABS", tabs.to_string());
         }
-        if let Some(macos_native_tabs) = &self.macos_native_tabs {
-            env::set_var("NEOVIDE_MACOS_NATIVE_TABS", macos_native_tabs.to_string());
+        if let Some(system_native_tabs) = &self.system_native_tabs {
+            env::set_var("NEOVIDE_SYSTEM_NATIVE_TABS", system_native_tabs.to_string());
         }
-        if let Some(pinned_hotkey) = &self.macos_pinned_hotkey {
-            env::set_var("NEOVIDE_MACOS_PINNED_HOTKEY", pinned_hotkey);
+        if let Some(pinned_hotkey) = &self.system_pinned_hotkey {
+            env::set_var("NEOVIDE_SYSTEM_PINNED_HOTKEY", pinned_hotkey);
         }
-        if let Some(switcher_hotkey) = &self.macos_switcher_hotkey {
-            env::set_var("NEOVIDE_MACOS_SWITCHER_HOTKEY", switcher_hotkey);
+        if let Some(switcher_hotkey) = &self.system_switcher_hotkey {
+            env::set_var("NEOVIDE_SYSTEM_SWITCHER_HOTKEY", switcher_hotkey);
         }
-        if let Some(tab_prev_hotkey) = &self.macos_tab_prev_hotkey {
-            env::set_var("NEOVIDE_MACOS_TAB_PREV_HOTKEY", tab_prev_hotkey);
+        if let Some(tab_prev_hotkey) = &self.system_tab_prev_hotkey {
+            env::set_var("NEOVIDE_SYSTEM_TAB_PREV_HOTKEY", tab_prev_hotkey);
         }
-        if let Some(tab_next_hotkey) = &self.macos_tab_next_hotkey {
-            env::set_var("NEOVIDE_MACOS_TAB_NEXT_HOTKEY", tab_next_hotkey);
+        if let Some(tab_next_hotkey) = &self.system_tab_next_hotkey {
+            env::set_var("NEOVIDE_SYSTEM_TAB_NEXT_HOTKEY", tab_next_hotkey);
         }
         if let Some(icon) = &self.icon {
             env::set_var("NEOVIDE_ICON", icon);

--- a/src/window/macos/hotkey.rs
+++ b/src/window/macos/hotkey.rs
@@ -13,8 +13,8 @@ use winit::event_loop::EventLoopProxy;
 
 use crate::window::{EventPayload, MacShortcutCommand, UserEvent};
 
-const PINNED_ENV_VAR: &str = "NEOVIDE_MACOS_PINNED_HOTKEY";
-const SWITCHER_ENV_VAR: &str = "NEOVIDE_MACOS_SWITCHER_HOTKEY";
+const PINNED_ENV_VAR: &str = "NEOVIDE_SYSTEM_PINNED_HOTKEY";
+const SWITCHER_ENV_VAR: &str = "NEOVIDE_SYSTEM_SWITCHER_HOTKEY";
 const LEGACY_ENV_VAR: &str = "NEOVIDE_MACOS_ACTIVATION_HOTKEY";
 
 const PINNED_DEFAULT: &str = "cmd+ctrl+z";

--- a/src/window/macos/tab_navigation.rs
+++ b/src/window/macos/tab_navigation.rs
@@ -22,8 +22,8 @@ impl TabNavigationHotkeys {
     pub(crate) fn new(settings: &Settings) -> Self {
         let cmdline = settings.get::<CmdLineSettings>();
         Self {
-            next: KeyCombo::parse(&cmdline.macos_tab_next_hotkey),
-            prev: KeyCombo::parse(&cmdline.macos_tab_prev_hotkey),
+            next: KeyCombo::parse(&cmdline.system_tab_next_hotkey),
+            prev: KeyCombo::parse(&cmdline.system_tab_prev_hotkey),
         }
     }
 

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -1001,7 +1001,7 @@ impl WinitWindowWrapper {
 
     #[cfg(target_os = "macos")]
     fn sync_native_tabs_resize(&mut self, source_window_id: WindowId) {
-        if !native_tab_bar_enabled() || !self.settings.get::<CmdLineSettings>().macos_native_tabs {
+        if !native_tab_bar_enabled() || !self.settings.get::<CmdLineSettings>().system_native_tabs {
             return;
         }
 
@@ -1016,7 +1016,7 @@ impl WinitWindowWrapper {
         let shared_inner_size = source_route.window.winit_window.inner_size();
         let window_ids: Vec<WindowId> = self.routes.keys().copied().collect();
 
-        // macOS native tabs share one visual surface. Keep all routes in sync so
+        // System native tabs share one visual surface. Keep all routes in sync so
         // fullscreen transitions trigger immediate grid updates for every tab.
         for window_id in window_ids {
             if let Some(route) = self.routes.get_mut(&window_id) {
@@ -1249,7 +1249,7 @@ impl WinitWindowWrapper {
 
         if is_active {
             let uses_native_tabs = native_tab_bar_enabled()
-                && self.settings.get::<CmdLineSettings>().macos_native_tabs;
+                && self.settings.get::<CmdLineSettings>().system_native_tabs;
 
             if uses_native_tabs {
                 hide_application();

--- a/website/docs/command-line-reference.md
+++ b/website/docs/command-line-reference.md
@@ -253,10 +253,10 @@ If no handoff listener is running, Neovide falls back to normal startup. In that
 `--tabs`, `--no-tabs` and `--chdir <path>` still apply to the forwarded request in the same way
 as with `--reuse-instance` works.
 
-### macOS Native Tabs
+### System Native Tabs
 
 ```sh
---no-macos-native-tabs, --macos-native-tabs or $NEOVIDE_MACOS_NATIVE_TABS=0|1
+--no-system-native-tabs, --system-native-tabs or $NEOVIDE_SYSTEM_NATIVE_TABS=0|1
 ```
 
 Neovide merges macOS windows into a single host window automatically and hides the native tab bar by
@@ -264,14 +264,14 @@ default to mimic a standalone window. Enable this option to keep the tab bar vis
 shows up as a tab immediately. The setting applies to windows opened through both global shortcuts
 and the Editors menu entry.
 
-### macOS Tab Navigation
+### System Tab Navigation
 
 ```sh
---macos-tab-prev-hotkey <combo> or $NEOVIDE_MACOS_TAB_PREV_HOTKEY
---macos-tab-next-hotkey <combo> or $NEOVIDE_MACOS_TAB_NEXT_HOTKEY
+--system-tab-prev-hotkey <combo> or $NEOVIDE_SYSTEM_TAB_PREV_HOTKEY
+--system-tab-next-hotkey <combo> or $NEOVIDE_SYSTEM_TAB_NEXT_HOTKEY
 ```
 
-When `macos-native-tabs` is enabled, these shortcuts let you remap the in-app tab cycling keys
+When `system-native-tabs` is enabled, these shortcuts let you remap the in-app tab cycling keys
 (defaults: `cmd+shift+[` / `cmd+shift+]`). Set them to `false` or leave empty to
 pass the keypress through to Neovim instead.
 

--- a/website/docs/config-file.md
+++ b/website/docs/config-file.md
@@ -45,11 +45,11 @@ opengl = false # macOS/Windows only
 # server = "/tmp/nvim.sock" # or "127.0.0.1:7777"
 srgb = false # platform-specific: false (Linux/macOS) or true (Windows)
 tabs = true
-macos-native-tabs = false # macOS only
-macos-pinned-hotkey = "cmd+ctrl+z" # macOS only
-macos-switcher-hotkey = "cmd+ctrl+n" # macOS only, requires macos-native-tabs = true
-macos-tab-prev-hotkey = "cmd+shift+[" # macOS only
-macos-tab-next-hotkey = "cmd+shift+]" # macOS only
+system-native-tabs = false # macOS only
+system-pinned-hotkey = "cmd+ctrl+z" # macOS only
+system-switcher-hotkey = "cmd+ctrl+n" # macOS only, requires system-native-tabs = true
+system-tab-prev-hotkey = "cmd+shift+[" # macOS only
+system-tab-next-hotkey = "cmd+shift+]" # macOS only
 theme = "auto"
 title-hidden = false
 vsync = true

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -915,7 +915,7 @@ vim.api.nvim_create_autocmd({ "CmdlineEnter", "CmdlineLeave" }, {
 Neovide can show multiple windows on macOS either as separate OS windows or as native tabs inside a
 single host window.
 
-Set `macos-native-tabs = true` to merge windows into a tab group. The native tab bar stays hidden
+Set `system-native-tabs = true` to merge windows into a tab group. The native tab bar stays hidden
 until more than one tab exists to keep a clean single-window look.
 
 Use Window > New Window (cmd+n) or the Dock menu to open another Neovide window. If native tabs
@@ -933,14 +933,14 @@ Neovide registers system-wide shortcuts on macOS:
   to the front.
 - **Editors** <kbd>⌘</kbd> + <kbd>⌃</kbd> + <kbd>N</kbd> opens the Editors (tab overview) view so
   you can pick another Neovide window. This shortcut is only available when
-  `macos-native-tabs = true` and if only one window exists, it behaves the same as the pinned
+  `system-native-tabs = true` and if only one window exists, it behaves the same as the pinned
   shortcut.
 
 Customize them by setting the environment variables:
 
 ```bash
-launchctl setenv NEOVIDE_MACOS_PINNED_HOTKEY "ctrl+shift+z"
-launchctl setenv NEOVIDE_MACOS_SWITCHER_HOTKEY "ctrl+shift+n"
+launchctl setenv NEOVIDE_SYSTEM_PINNED_HOTKEY "ctrl+shift+z"
+launchctl setenv NEOVIDE_SYSTEM_SWITCHER_HOTKEY "ctrl+shift+n"
 ```
 
 Use `cmd`, `ctrl`, `alt`, and `shift` for modifiers and a single character for the key.
@@ -953,15 +953,15 @@ system. Check the Neovide log for warnings.
 You can also configure them inside `config.toml`:
 
 ```toml
-macos-pinned-hotkey = "ctrl+shift+z"
-macos-switcher-hotkey = "ctrl+shift+n"
+system-pinned-hotkey = "ctrl+shift+z"
+system-switcher-hotkey = "ctrl+shift+n"
 ```
 
-When `macos-native-tabs` is enabled, you can also customize the in-app tab navigation shortcuts:
+When `system-native-tabs` is enabled, you can also customize the in-app tab navigation shortcuts:
 
 ```toml
-macos-tab-prev-hotkey = "cmd+shift+["
-macos-tab-next-hotkey = "cmd+shift+]"
+system-tab-prev-hotkey = "cmd+shift+["
+system-tab-next-hotkey = "cmd+shift+]"
 ```
 
 These work only while Neovide is focused so the keypress never reaches Neovim, mirroring the native


### PR DESCRIPTION
naming it for a target OS is not correct, lets keep it generic.