### PR TITLE
fix: remove theme option from config file

### DIFF
--- a/website/docs/config-file.md
+++ b/website/docs/config-file.md
@@ -50,7 +50,6 @@ system-pinned-hotkey = "cmd+ctrl+z" # macOS only
 system-switcher-hotkey = "cmd+ctrl+n" # macOS only, requires system-native-tabs = true
 system-tab-prev-hotkey = "cmd+shift+[" # macOS only
 system-tab-next-hotkey = "cmd+shift+]" # macOS only
-theme = "auto"
 title-hidden = false
 vsync = true
 # wayland-app-id = "neovide"


### PR DESCRIPTION
we mistakenly added a theme option to the config file, but it is not actually used anywhere, must be impl in the future.