### PR TITLE
fix: handle nvim-initiated too-large resizes

### DIFF
--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -2449,6 +2449,19 @@ impl WinitWindowWrapper {
             let mut skia_renderer = route.window.skia_renderer.borrow_mut();
             skia_renderer.resize();
         }
+
+        // Read back the actual window size after the resize request. The OS may
+        // constrain the window (e.g. to screen bounds), so the actual size can differ
+        // from what was requested. When that happens, correct Neovim's grid size to
+        // match the real window dimensions.
+        let actual_size = window.inner_size();
+        if actual_size != new_size {
+            if let Some(route) = self.routes.get_mut(&window_id) {
+                route.state.saved_inner_size = actual_size;
+                route.window.last_synced_grid_size = None;
+            }
+            self.update_grid_size_from_window(window_id);
+        }
     }
 
     fn get_grid_size_from_window(


### PR DESCRIPTION
If you do `set lines=40` followed by `set lines=999`, Neovide detects that it couldn't make the window 999 lines tall and updates itself to the correct value. But if you issue another `set lines=999`, the window size doesn't change, so Neovide doesn't do the check. This change just causes Neovide to check the real window size after it attempts to resize, in case the attempt to resize the window failed for some reason (like it was already the maximum allowable size).

I don't think this is a breaking change. Should be a safe improvement.