### PR TITLE
handoff: Add neovim-bin and neovim arguments

### DIFF
--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -23,6 +23,8 @@ const FORKED_FROM_TTY_ENV_VAR: &str = "NEOVIDE_FORKED_FROM_TTY";
 pub struct OpenArgs {
     pub files_to_open: Vec<String>,
     pub tabs: bool,
+    pub neovim_bin: Option<String>,
+    pub neovim_args: Option<Vec<String>>,
 }
 
 /// Mode is how neovide should populate argv when launching an embedded nvim instance.
@@ -102,12 +104,26 @@ fn build_nvim_command_parts(
     embed: bool,
     mode: OpenMode,
 ) -> (String, Vec<String>) {
-    let bin = cmdline_settings.neovim_bin.clone().unwrap_or_else(|| "nvim".to_owned());
-    let mut args = cmdline_settings.neovim_args.clone();
+    // For OpenMode::Args (handoff/new-window routes), use the route's own
+    // bin/args. None means "not specified" = default nvim, NOT the global
+    // CmdLineSettings value (which belongs to the original invocation).
+    // For Startup/None modes, use global CmdLineSettings as before.
+    let (bin, mut args) = match &mode {
+        OpenMode::Args(open_args) => {
+            let bin = open_args.neovim_bin.clone().unwrap_or_else(|| "nvim".to_owned());
+            let args = open_args.neovim_args.clone().unwrap_or_default();
+            (bin, args)
+        }
+        _ => {
+            let bin = cmdline_settings.neovim_bin.clone().unwrap_or_else(|| "nvim".to_owned());
+            let args = cmdline_settings.neovim_args.clone();
+            (bin, args)
+        }
+    };
+
     if embed {
         append_embed_arg(&mut args);
     }
-
     args.extend(build_open_args(cmdline_settings, mode));
 
     (bin, args)
@@ -308,12 +324,52 @@ mod tests {
     fn build_nvim_command_parts_uses_route_auto_open_args() {
         let cmdline_settings =
             parse_cmdline_settings(&["neovide", "./foo.txt", "./bar.md", "--grid=420x240"]);
-        let open_args = OpenArgs { files_to_open: vec!["/tmp/project".to_string()], tabs: false };
+        let open_args = OpenArgs {
+            files_to_open: vec!["/tmp/project".to_string()],
+            tabs: false,
+            neovim_bin: None,
+            neovim_args: None,
+        };
 
-        let (_, args) =
+        let (bin, args) =
             build_nvim_command_parts(&cmdline_settings, true, OpenMode::Args(open_args));
 
+        // Route args mode does NOT inherit global cmdline settings
+        assert_eq!(bin, "nvim");
         assert_eq!(args, vec!["--embed", "/tmp/project"]);
+    }
+
+    #[test]
+    fn build_nvim_command_parts_uses_route_neovim_bin_override() {
+        let cmdline_settings = parse_cmdline_settings(&["neovide", "--neovim-bin", "nvim-0.9"]);
+        let open_args = OpenArgs {
+            files_to_open: vec![],
+            tabs: false,
+            neovim_bin: Some("nvim-0.10".to_string()),
+            neovim_args: Some(vec!["--clean".to_string()]),
+        };
+
+        let (bin, args) =
+            build_nvim_command_parts(&cmdline_settings, true, OpenMode::Args(open_args));
+
+        // Uses the route's override, not the global --neovim-bin=nvim-0.9
+        assert_eq!(bin, "nvim-0.10");
+        assert_eq!(args, vec!["--clean", "--embed"]);
+    }
+
+    #[test]
+    fn build_nvim_command_parts_route_none_does_not_inherit_global() {
+        let cmdline_settings =
+            parse_cmdline_settings(&["neovide", "--neovim-bin", "nvim-0.9", "--", "--clean"]);
+        let open_args =
+            OpenArgs { files_to_open: vec![], tabs: false, neovim_bin: None, neovim_args: None };
+
+        let (bin, args) =
+            build_nvim_command_parts(&cmdline_settings, true, OpenMode::Args(open_args));
+
+        // None means default nvim, NOT the global nvim-0.9
+        assert_eq!(bin, "nvim");
+        assert_eq!(args, vec!["--embed"]);
     }
 
     #[test]

--- a/src/ipc/handoff.rs
+++ b/src/ipc/handoff.rs
@@ -31,6 +31,10 @@ pub struct HandoffRequest {
     pub caller_cwd: Option<String>,
     pub tabs: bool,
     pub new_window: bool,
+    #[serde(default)]
+    pub neovim_bin: Option<String>,
+    #[serde(default)]
+    pub neovim_args: Option<Vec<String>>,
 }
 
 impl HandoffRequest {
@@ -43,6 +47,8 @@ impl HandoffRequest {
             caller_cwd: None,
             tabs: true,
             new_window: false,
+            neovim_bin: None,
+            neovim_args: None,
         }
     }
 }
@@ -222,6 +228,8 @@ fn handle_request(
                 caller_cwd: request.caller_cwd,
                 tabs: request.tabs,
                 new_window: request.new_window,
+                neovim_bin: request.neovim_bin,
+                neovim_args: request.neovim_args,
             },
             target: EventTarget::Focused,
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -311,19 +311,18 @@ fn maybe_handoff(settings: &Settings) -> HandoffOutcome {
         return HandoffOutcome::Continue;
     }
 
+    let CmdLineSettings { files_to_open, tabs, new_window, neovim_bin, neovim_args, .. } =
+        cmdline_settings;
+
     let request = ipc::handoff::HandoffRequest {
         version: BUILD_VERSION.to_owned(),
-        files_to_open: cmdline_settings.files_to_open.clone(),
+        files_to_open,
         cwd: resolved_cwd(cmd_line::argv_chdir().as_deref()),
         caller_cwd: resolved_cwd(None),
-        tabs: cmdline_settings.tabs,
-        new_window: cmdline_settings.new_window,
-        neovim_bin: cmdline_settings.neovim_bin.clone(),
-        neovim_args: if cmdline_settings.neovim_args.is_empty() {
-            None
-        } else {
-            Some(cmdline_settings.neovim_args.clone())
-        },
+        tabs,
+        new_window,
+        neovim_bin,
+        neovim_args: (!neovim_args.is_empty()).then_some(neovim_args),
     };
 
     match ipc::handoff::try_handoff(&request) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,6 +318,12 @@ fn maybe_handoff(settings: &Settings) -> HandoffOutcome {
         caller_cwd: resolved_cwd(None),
         tabs: cmdline_settings.tabs,
         new_window: cmdline_settings.new_window,
+        neovim_bin: cmdline_settings.neovim_bin.clone(),
+        neovim_args: if cmdline_settings.neovim_args.is_empty() {
+            None
+        } else {
+            Some(cmdline_settings.neovim_args.clone())
+        },
     };
 
     match ipc::handoff::try_handoff(&request) {

--- a/src/window/application.rs
+++ b/src/window/application.rs
@@ -825,8 +825,17 @@ impl ApplicationHandler<EventPayload> for Application {
             }
             #[cfg(target_os = "macos")]
             UserEvent::CreateWindow => {
-                let args = self.window_wrapper.focused_route_nvim_overrides();
-                self.window_wrapper.try_create_window(event_loop, &self.proxy, None, args);
+                let (cwd, args) = self
+                    .window_wrapper
+                    .focused_route_launch_context()
+                    .map(|(cwd, args)| (cwd, Some(args)))
+                    .unwrap_or((None, None));
+                self.window_wrapper.try_create_window(
+                    event_loop,
+                    &self.proxy,
+                    cwd.as_deref(),
+                    args,
+                );
                 self.sync_render_states();
                 self.mark_should_render_all();
             }

--- a/src/window/application.rs
+++ b/src/window/application.rs
@@ -277,8 +277,7 @@ impl Application {
             return;
         }
 
-        let open_args = (!args.files_to_open.is_empty()).then_some(args);
-        self.window_wrapper.try_create_window(event_loop, &self.proxy, cwd, open_args);
+        self.window_wrapper.try_create_window(event_loop, &self.proxy, cwd, Some(args));
         self.mark_should_render_all();
     }
 
@@ -716,7 +715,15 @@ impl ApplicationHandler<EventPayload> for Application {
         match payload {
             UserEvent::ConfigsChanged(config) => self.handle_config_changed(target, *config),
             #[cfg(target_os = "macos")]
-            UserEvent::OpenFiles { files, cwd, caller_cwd, tabs, new_window } => {
+            UserEvent::OpenFiles {
+                files,
+                cwd,
+                caller_cwd,
+                tabs,
+                new_window,
+                neovim_bin,
+                neovim_args,
+            } => {
                 let cwd = cwd.as_deref().map(Path::new);
                 let caller_cwd = caller_cwd.as_deref().map(Path::new);
                 let open_args = OpenArgs {
@@ -725,6 +732,8 @@ impl ApplicationHandler<EventPayload> for Application {
                         .map(|path| resolve_relative_path(&path, caller_cwd))
                         .collect(),
                     tabs,
+                    neovim_bin,
+                    neovim_args,
                 };
 
                 self.prepare_open_files(event_loop, new_window, cwd, open_args);
@@ -816,7 +825,8 @@ impl ApplicationHandler<EventPayload> for Application {
             }
             #[cfg(target_os = "macos")]
             UserEvent::CreateWindow => {
-                self.window_wrapper.try_create_window(event_loop, &self.proxy, None, None);
+                let args = self.window_wrapper.focused_route_nvim_overrides();
+                self.window_wrapper.try_create_window(event_loop, &self.proxy, None, args);
                 self.sync_render_states();
                 self.mark_should_render_all();
             }

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -139,6 +139,8 @@ pub enum UserEvent {
         caller_cwd: Option<String>,
         tabs: bool,
         new_window: bool,
+        neovim_bin: Option<String>,
+        neovim_args: Option<Vec<String>>,
     },
     WindowCommand(WindowCommand),
     SettingsChanged(SettingsChanged),

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -131,6 +131,10 @@ pub struct Route {
     cwd: Option<PathBuf>,
     pub pending_initial_window_size: Option<WindowSize>,
     state: RouteState,
+    #[cfg(target_os = "macos")]
+    pub neovim_bin: Option<String>,
+    #[cfg(target_os = "macos")]
+    pub neovim_args: Option<Vec<String>>,
 }
 
 impl fmt::Debug for Route {
@@ -1490,6 +1494,26 @@ impl WinitWindowWrapper {
             ..
         } = self.settings.get::<WindowSettings>();
 
+        // Capture per-route nvim overrides before args is consumed into OpenMode.
+        // For the initial window (args is None, uses OpenMode::Startup), pull from
+        // CmdLineSettings so "New Window" can clone the initial invocation's config.
+        #[cfg(target_os = "macos")]
+        let (route_nvim_bin, route_nvim_args) = if let Some(ref a) = args {
+            (a.neovim_bin.clone(), a.neovim_args.clone())
+        } else if creating_initial_window {
+            let cmdline = self.settings.get::<CmdLineSettings>();
+            (
+                cmdline.neovim_bin.clone(),
+                if cmdline.neovim_args.is_empty() {
+                    None
+                } else {
+                    Some(cmdline.neovim_args.clone())
+                },
+            )
+        } else {
+            (None, None)
+        };
+
         let (renderer, neovim_handler, route_pending_initial_window_size, route_cwd) =
             if creating_initial_window {
                 let Some(route_core) = self.route_cores.remove(&route_id) else {
@@ -1724,6 +1748,10 @@ impl WinitWindowWrapper {
             cwd: route_cwd,
             pending_initial_window_size,
             state,
+            #[cfg(target_os = "macos")]
+            neovim_bin: route_nvim_bin,
+            #[cfg(target_os = "macos")]
+            neovim_args: route_nvim_args,
         };
         self.routes.insert(window.id(), route);
         self.apply_theme_for_window(window.id());
@@ -2218,6 +2246,18 @@ impl WinitWindowWrapper {
         }
 
         self.routes.keys().next().copied()
+    }
+
+    #[cfg(target_os = "macos")]
+    pub fn focused_route_nvim_overrides(&self) -> Option<OpenArgs> {
+        let focused_id = self.get_focused_route()?;
+        let route = self.routes.get(&focused_id)?;
+        Some(OpenArgs {
+            files_to_open: vec![],
+            tabs: false,
+            neovim_bin: route.neovim_bin.clone(),
+            neovim_args: route.neovim_args.clone(),
+        })
     }
 
     #[cfg(target_os = "macos")]

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -102,6 +102,27 @@ enum GeometryTarget {
     None,
 }
 
+#[cfg(target_os = "macos")]
+#[derive(Default)]
+struct RouteLaunchConfig {
+    neovim_bin: Option<String>,
+    neovim_args: Option<Vec<String>>,
+}
+
+#[cfg(target_os = "macos")]
+impl RouteLaunchConfig {
+    fn from_open_args(args: &OpenArgs) -> Self {
+        Self { neovim_bin: args.neovim_bin.clone(), neovim_args: args.neovim_args.clone() }
+    }
+
+    fn from_cmdline(cmdline: CmdLineSettings) -> Self {
+        Self {
+            neovim_bin: cmdline.neovim_bin,
+            neovim_args: (!cmdline.neovim_args.is_empty()).then_some(cmdline.neovim_args),
+        }
+    }
+}
+
 pub struct RouteWindow {
     pub skia_renderer: Rc<RefCell<Box<dyn SkiaRenderer>>>,
     pub winit_window: Rc<Window>,
@@ -330,6 +351,23 @@ impl WinitWindowWrapper {
                 font_changed_last_frame: false,
             },
         );
+    }
+
+    #[cfg(target_os = "macos")]
+    fn route_launch_config_for_window_creation(
+        &self,
+        args: Option<&OpenArgs>,
+        creating_initial_window: bool,
+    ) -> RouteLaunchConfig {
+        if let Some(args) = args {
+            return RouteLaunchConfig::from_open_args(args);
+        }
+
+        if !creating_initial_window {
+            return RouteLaunchConfig::default();
+        }
+
+        RouteLaunchConfig::from_cmdline(self.settings.get::<CmdLineSettings>())
     }
 
     pub fn has_pending_window_creation(&self) -> bool {
@@ -1494,25 +1532,12 @@ impl WinitWindowWrapper {
             ..
         } = self.settings.get::<WindowSettings>();
 
-        // Capture per-route nvim overrides before args is consumed into OpenMode.
+        // Capture per-route launch config before args is consumed into OpenMode.
         // For the initial window (args is None, uses OpenMode::Startup), pull from
         // CmdLineSettings so "New Window" can clone the initial invocation's config.
         #[cfg(target_os = "macos")]
-        let (route_nvim_bin, route_nvim_args) = if let Some(ref a) = args {
-            (a.neovim_bin.clone(), a.neovim_args.clone())
-        } else if creating_initial_window {
-            let cmdline = self.settings.get::<CmdLineSettings>();
-            (
-                cmdline.neovim_bin.clone(),
-                if cmdline.neovim_args.is_empty() {
-                    None
-                } else {
-                    Some(cmdline.neovim_args.clone())
-                },
-            )
-        } else {
-            (None, None)
-        };
+        let route_launch_config =
+            self.route_launch_config_for_window_creation(args.as_ref(), creating_initial_window);
 
         let (renderer, neovim_handler, route_pending_initial_window_size, route_cwd) =
             if creating_initial_window {
@@ -1749,9 +1774,9 @@ impl WinitWindowWrapper {
             pending_initial_window_size,
             state,
             #[cfg(target_os = "macos")]
-            neovim_bin: route_nvim_bin,
+            neovim_bin: route_launch_config.neovim_bin,
             #[cfg(target_os = "macos")]
-            neovim_args: route_nvim_args,
+            neovim_args: route_launch_config.neovim_args,
         };
         self.routes.insert(window.id(), route);
         self.apply_theme_for_window(window.id());
@@ -2249,15 +2274,18 @@ impl WinitWindowWrapper {
     }
 
     #[cfg(target_os = "macos")]
-    pub fn focused_route_nvim_overrides(&self) -> Option<OpenArgs> {
+    pub fn focused_route_launch_context(&self) -> Option<(Option<PathBuf>, OpenArgs)> {
         let focused_id = self.get_focused_route()?;
         let route = self.routes.get(&focused_id)?;
-        Some(OpenArgs {
-            files_to_open: vec![],
-            tabs: false,
-            neovim_bin: route.neovim_bin.clone(),
-            neovim_args: route.neovim_args.clone(),
-        })
+        Some((
+            route.cwd.clone(),
+            OpenArgs {
+                files_to_open: vec![],
+                tabs: false,
+                neovim_bin: route.neovim_bin.clone(),
+                neovim_args: route.neovim_args.clone(),
+            },
+        ))
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
Love the multi-window support! I was thrilled to see that land and ported all of my remote ssh commands to using it. Unfortunately, the version in 0.16.0 doesn't allow the windows to use different values for `--neovim-bin` and friends.

This change just adds --neovim-bin, neovim arguments, and files to open to the handoff struct. As a result, I can `neovide --neovim-bin=ssh -- myhost cd directory "&&" exec nvim` and it works with `--reuse-instance --new-window`.

I also put `files_to_open` into the handoff. This is perhaps a bit more contentious, but fixes a minor bug: "new window" would re-open the same files as the initial invocation, which I don't think is generally the desired behavior.

This change will break users who use `neovide --neovim-bin && neovide --reuse-instance --new-window`, because they now need to include the `--neovim-bin` in the subsequent invocations.

I've tested that this works on macOS with `--reuse-instance --new-window`. I think it should not cause problems in other configurations, but would appreciate pointers if I am missing something.