### PR TITLE
fix: reintroduce error window for launch failures

### DIFF
--- a/src/window/application.rs
+++ b/src/window/application.rs
@@ -22,7 +22,7 @@ use winit::{
 
 use super::{
     CmdLineSettings, EventPayload, EventTarget, RouteId, WindowSettings, WindowSize,
-    WinitWindowWrapper, save_window_size,
+    WinitWindowWrapper, error_window, save_window_size,
 };
 use crate::{
     clipboard::{Clipboard, ClipboardHandle},
@@ -124,6 +124,7 @@ pub struct Application {
     #[allow(dead_code)]
     initial_grid_size: Option<Size2<Grid<u32>>>,
     render_states: FxHashMap<WindowId, RenderState>,
+    error_windows: FxHashMap<WindowId, (error_window::State, String)>,
 
     pub window_wrapper: WinitWindowWrapper,
     create_window_allowed: bool,
@@ -161,6 +162,7 @@ impl Application {
             idle,
             initial_grid_size,
             render_states: FxHashMap::default(),
+            error_windows: FxHashMap::default(),
 
             window_wrapper,
             create_window_allowed: false,
@@ -648,6 +650,37 @@ impl ApplicationHandler<EventPayload> for Application {
         event: winit::event::WindowEvent,
     ) {
         tracy_zone!("window_event");
+
+        if self.error_windows.contains_key(&window_id) {
+            match &event {
+                WindowEvent::CloseRequested => {
+                    self.error_windows.remove(&window_id);
+                }
+                WindowEvent::RedrawRequested => {
+                    if let Some((error_state, _)) = self.error_windows.get_mut(&window_id) {
+                        error_state.render();
+                    }
+                }
+                _ => {
+                    let message = self
+                        .error_windows
+                        .get(&window_id)
+                        .map(|(_, m)| m.clone())
+                        .unwrap_or_default();
+                    if let Some((error_state, _)) = self.error_windows.get_mut(&window_id) {
+                        error_state.handle_window_event(event, &message);
+                        if error_state.should_close {
+                            self.error_windows.remove(&window_id);
+                        }
+                    }
+                }
+            }
+            if self.window_wrapper.is_empty() && self.error_windows.is_empty() {
+                event_loop.exit();
+            }
+            return;
+        }
+
         self.ensure_render_state(window_id);
         match event {
             WindowEvent::RedrawRequested => {
@@ -713,7 +746,7 @@ impl ApplicationHandler<EventPayload> for Application {
                 if let Some(window_id) = window_id {
                     self.render_states.remove(&window_id);
                 }
-                if self.window_wrapper.is_empty() {
+                if self.window_wrapper.is_empty() && self.error_windows.is_empty() {
                     event_loop.exit();
                 }
             }
@@ -796,6 +829,18 @@ impl ApplicationHandler<EventPayload> for Application {
                 self.window_wrapper.handle_mac_shortcut(command);
                 self.mark_should_render_all();
             }
+            UserEvent::NeovimLaunchError { message } => {
+                let window_config = error_window::create_error_window(event_loop, &self.settings);
+                let clipboard_handle = ClipboardHandle::new(self.clipboard.as_ref().unwrap());
+                let state = error_window::State::new(
+                    &message,
+                    window_config,
+                    self.settings.clone(),
+                    clipboard_handle,
+                );
+                let window_id = state.window_id();
+                self.error_windows.insert(window_id, (state, message));
+            }
             UserEvent::NeovimRestart(details) => {
                 let route_id = self.route_id_for_target(target);
                 let Some(route_id) = route_id else {
@@ -841,6 +886,7 @@ impl ApplicationHandler<EventPayload> for Application {
     fn exiting(&mut self, event_loop: &ActiveEventLoop) {
         tracy_zone!("exiting");
         self.teardown();
+        self.error_windows.clear();
         self.window_wrapper.exit();
         self.schedule_next_event(event_loop);
     }

--- a/src/window/application.rs
+++ b/src/window/application.rs
@@ -365,13 +365,12 @@ impl Application {
         }
     }
 
-    fn get_event_deadline(&self) -> Instant {
-        let now = Instant::now();
-        self.render_states
-            .values()
-            .map(|state| self.get_event_deadline_for(state))
-            .min()
-            .unwrap_or(now)
+    fn get_event_deadline(&self) -> Option<Instant> {
+        self.render_states.values().map(|state| self.get_event_deadline_for(state)).min()
+    }
+
+    fn next_control_flow(&self, now: Instant) -> ControlFlow {
+        next_control_flow_for(self.get_event_deadline(), !self.error_windows.is_empty(), now)
     }
 
     fn schedule_next_event(&mut self, event_loop: &ActiveEventLoop) {
@@ -381,7 +380,31 @@ impl Application {
         if self.create_window_allowed && self.window_wrapper.has_pending_window_creation() {
             self.window_wrapper.try_create_window(event_loop, &self.proxy, None, None);
         }
-        event_loop.set_control_flow(ControlFlow::WaitUntil(self.get_event_deadline()));
+        event_loop.set_control_flow(self.next_control_flow(Instant::now()));
+    }
+
+    fn handle_error_window_event(
+        &mut self,
+        window_id: WindowId,
+        event: WindowEvent,
+    ) -> Option<WindowEvent> {
+        let Some((mut error_state, message)) = self.error_windows.remove(&window_id) else {
+            return Some(event);
+        };
+
+        error_state.handle_window_event(event, &message);
+
+        if !error_state.should_close {
+            self.error_windows.insert(window_id, (error_state, message));
+        }
+
+        None
+    }
+
+    fn exit_if_no_windows_remain(&self, event_loop: &ActiveEventLoop) {
+        if self.window_wrapper.is_empty() && self.error_windows.is_empty() {
+            event_loop.exit();
+        }
     }
 
     fn teardown(&mut self) {
@@ -651,35 +674,10 @@ impl ApplicationHandler<EventPayload> for Application {
     ) {
         tracy_zone!("window_event");
 
-        if self.error_windows.contains_key(&window_id) {
-            match &event {
-                WindowEvent::CloseRequested => {
-                    self.error_windows.remove(&window_id);
-                }
-                WindowEvent::RedrawRequested => {
-                    if let Some((error_state, _)) = self.error_windows.get_mut(&window_id) {
-                        error_state.render();
-                    }
-                }
-                _ => {
-                    let message = self
-                        .error_windows
-                        .get(&window_id)
-                        .map(|(_, m)| m.clone())
-                        .unwrap_or_default();
-                    if let Some((error_state, _)) = self.error_windows.get_mut(&window_id) {
-                        error_state.handle_window_event(event, &message);
-                        if error_state.should_close {
-                            self.error_windows.remove(&window_id);
-                        }
-                    }
-                }
-            }
-            if self.window_wrapper.is_empty() && self.error_windows.is_empty() {
-                event_loop.exit();
-            }
+        let Some(event) = self.handle_error_window_event(window_id, event) else {
+            self.exit_if_no_windows_remain(event_loop);
             return;
-        }
+        };
 
         self.ensure_render_state(window_id);
         match event {
@@ -746,9 +744,7 @@ impl ApplicationHandler<EventPayload> for Application {
                 if let Some(window_id) = window_id {
                     self.render_states.remove(&window_id);
                 }
-                if self.window_wrapper.is_empty() && self.error_windows.is_empty() {
-                    event_loop.exit();
-                }
+                self.exit_if_no_windows_remain(event_loop);
             }
             UserEvent::RedrawRequested => match target {
                 EventTarget::Window(window_id) => {
@@ -895,5 +891,17 @@ impl ApplicationHandler<EventPayload> for Application {
 impl Drop for Application {
     fn drop(&mut self) {
         self.teardown();
+    }
+}
+
+fn next_control_flow_for(
+    deadline: Option<Instant>,
+    has_error_windows: bool,
+    now: Instant,
+) -> ControlFlow {
+    match deadline {
+        Some(deadline) => ControlFlow::WaitUntil(deadline),
+        None if has_error_windows => ControlFlow::Wait,
+        None => ControlFlow::WaitUntil(now),
     }
 }

--- a/src/window/error_window.rs
+++ b/src/window/error_window.rs
@@ -70,7 +70,7 @@ struct Paragraphs {
     help_messages: [Paragraph; PossibleScrollDirection::COUNT],
 }
 
-struct State {
+pub struct State {
     skia_renderer: Box<dyn SkiaRenderer>,
     font_collection: FontCollection,
     size: PhysicalSize<u32>,
@@ -81,6 +81,7 @@ struct State {
     modifiers: Modifiers,
     mouse_scroll_accumulator: f32,
     clipboard: ClipboardHandle,
+    pub should_close: bool,
 }
 
 struct ErrorWindow<'a> {
@@ -104,15 +105,19 @@ impl ApplicationHandler<EventPayload> for ErrorWindow<'_> {
         event: WindowEvent,
     ) {
         let state = self.state.as_mut().unwrap();
-        state.handle_window_event(event, event_loop, self.message);
+        state.handle_window_event(event, self.message);
+        if state.should_close {
+            event_loop.exit();
+        }
     }
 
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         if self.state.is_none() {
             if let Some(clipboard) = self.clipboard.as_ref() {
+                let window_config = create_error_window(event_loop, &self.settings);
                 self.state = Some(State::new(
                     self.message,
-                    event_loop,
+                    window_config,
                     self.settings.clone(),
                     ClipboardHandle::new(clipboard),
                 ));
@@ -127,9 +132,9 @@ impl ApplicationHandler<EventPayload> for ErrorWindow<'_> {
 }
 
 impl State {
-    fn new(
+    pub fn new(
         message: &str,
-        event_loop: &ActiveEventLoop,
+        window_config: WindowConfig,
         settings: Arc<Settings>,
         clipboard: ClipboardHandle,
     ) -> Self {
@@ -141,16 +146,11 @@ impl State {
 
         let srgb = SRGB_DEFAULT == "1";
         let vsync = true;
-        let window = create_window(event_loop, &settings);
-        let skia_renderer = create_skia_renderer(&window, srgb, vsync, settings);
-        window.window.set_visible(true);
-        let scale_factor = window.window.scale_factor();
-        let size = window.window.inner_size();
+        let skia_renderer = create_skia_renderer(&window_config, srgb, vsync, settings);
+        window_config.window.set_visible(true);
+        let scale_factor = window_config.window.scale_factor();
+        let size = window_config.window.inner_size();
         let paragraphs = create_paragraphs(message, scale_factor as f32, &font_collection);
-        let scroll = Scroll::None;
-        let current_position = 0;
-        let modifiers = Modifiers::default();
-        let mouse_scroll_accumulator = 0.0;
 
         Self {
             skia_renderer,
@@ -158,23 +158,23 @@ impl State {
             size,
             scale_factor,
             paragraphs,
-            scroll,
-            current_position,
-            modifiers,
-            mouse_scroll_accumulator,
+            scroll: Scroll::None,
+            current_position: 0,
+            modifiers: Modifiers::default(),
+            mouse_scroll_accumulator: 0.0,
             clipboard,
+            should_close: false,
         }
     }
 
-    fn handle_window_event(
-        &mut self,
-        event: WindowEvent,
-        event_loop: &ActiveEventLoop,
-        message: &str,
-    ) {
+    pub fn window_id(&self) -> winit::window::WindowId {
+        self.skia_renderer.window().id()
+    }
+
+    pub fn handle_window_event(&mut self, event: WindowEvent, message: &str) {
         match event {
             WindowEvent::CloseRequested => {
-                event_loop.exit();
+                self.should_close = true;
             }
             WindowEvent::RedrawRequested => {
                 self.render();
@@ -189,7 +189,7 @@ impl State {
                     create_paragraphs(message, scale_factor as f32, &self.font_collection);
             }
             WindowEvent::KeyboardInput { event, is_synthetic: false, .. } => {
-                if self.handle_keyboard_input(event, event_loop, message) {
+                if self.handle_keyboard_input(event, message) {
                     self.skia_renderer.window().request_redraw();
                 }
             }
@@ -209,7 +209,7 @@ impl State {
         }
     }
 
-    fn render(&mut self) {
+    pub fn render(&mut self) {
         let (message_rect, help_message_rect) = self.layout();
 
         let (offset, possible_scroll_direction) =
@@ -231,12 +231,7 @@ impl State {
         self.skia_renderer.swap_buffers();
     }
 
-    fn handle_keyboard_input(
-        &mut self,
-        event: KeyEvent,
-        event_loop: &ActiveEventLoop,
-        message: &str,
-    ) -> bool {
+    fn handle_keyboard_input(&mut self, event: KeyEvent, message: &str) -> bool {
         if event.state != ElementState::Pressed {
             return false;
         }
@@ -266,7 +261,7 @@ impl State {
                         true
                     }
                     "q" => {
-                        event_loop.exit();
+                        self.should_close = true;
                         true
                     }
                     "y" => {
@@ -292,7 +287,7 @@ impl State {
                         true
                     }
                     NamedKey::Escape => {
-                        event_loop.exit();
+                        self.should_close = true;
                         true
                     }
                     _ => false,
@@ -494,7 +489,7 @@ fn create_paragraphs(
     Paragraphs { message: create_message(message, &normal_text), help_messages }
 }
 
-fn create_window(event_loop: &ActiveEventLoop, settings: &Settings) -> WindowConfig {
+pub fn create_error_window(event_loop: &ActiveEventLoop, settings: &Settings) -> WindowConfig {
     let cmd_line_settings = settings.get::<CmdLineSettings>();
     let icon = load_icon(cmd_line_settings.icon.as_ref());
 

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -146,6 +146,9 @@ pub enum UserEvent {
     #[allow(dead_code)]
     RedrawRequested,
     NeovimExited,
+    NeovimLaunchError {
+        message: String,
+    },
     NeovimRestart(RestartDetails),
     ShowProgressBar {
         percent: f32,

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -256,14 +256,18 @@ impl WinitWindowWrapper {
         }
     }
 
+    fn report_startup_error(&self, proxy: &EventLoopProxy<EventPayload>, message: String) {
+        self.runtime_tracker.quit_with_code(1, &message);
+        let _ = proxy.send_event(EventPayload::all(UserEvent::NeovimLaunchError { message }));
+    }
+
     pub fn request_window_creation(&mut self, proxy: &EventLoopProxy<EventPayload>) {
         if !self.routes.is_empty() || !self.route_cores.is_empty() {
             return;
         }
 
         if let Some(error) = self.startup_error.take() {
-            let _ = proxy
-                .send_event(EventPayload::all(UserEvent::NeovimLaunchError { message: error }));
+            self.report_startup_error(proxy, error);
             return;
         }
 
@@ -301,8 +305,7 @@ impl WinitWindowWrapper {
             Err(err) => {
                 let msg = format!("Failed to launch neovim runtime: {err:?}");
                 log::error!("{msg}");
-                let _ = proxy
-                    .send_event(EventPayload::all(UserEvent::NeovimLaunchError { message: msg }));
+                self.report_startup_error(proxy, msg);
                 return;
             }
         };

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -205,6 +205,7 @@ pub struct WinitWindowWrapper {
 
     settings: Arc<Settings>,
     clipboard: ClipboardHandle,
+    startup_error: Option<String>,
 
     #[cfg(target_os = "macos")]
     window_mru: VecDeque<WindowId>,
@@ -223,20 +224,27 @@ impl WinitWindowWrapper {
         runtime_tracker: RunningTracker,
         clipboard_handle: ClipboardHandle,
     ) -> Self {
-        let runtime =
-            NeovimRuntime::new(clipboard_handle.clone()).expect("Failed to create neovim runtime");
+        let (runtime, startup_error) = match NeovimRuntime::new(clipboard_handle.clone()) {
+            Ok(rt) => (Some(rt), None),
+            Err(e) => {
+                let msg = format!("Failed to create neovim runtime: {e:?}");
+                log::error!("{msg}");
+                (None, Some(msg))
+            }
+        };
 
         Self {
             routes: Default::default(),
             route_cores: FxHashMap::default(),
             pending_window_creation_route: None,
-            runtime: Some(runtime),
+            runtime,
             runtime_tracker,
             pending_restart: FxHashMap::default(),
             keyboard_manager: KeyboardManager::new(settings.clone()),
             ui_state: UIState::Initing,
             settings: settings.clone(),
             clipboard: clipboard_handle,
+            startup_error,
             #[cfg(target_os = "macos")]
             window_mru: VecDeque::new(),
             #[cfg(target_os = "macos")]
@@ -250,6 +258,12 @@ impl WinitWindowWrapper {
 
     pub fn request_window_creation(&mut self, proxy: &EventLoopProxy<EventPayload>) {
         if !self.routes.is_empty() || !self.route_cores.is_empty() {
+            return;
+        }
+
+        if let Some(error) = self.startup_error.take() {
+            let _ = proxy
+                .send_event(EventPayload::all(UserEvent::NeovimLaunchError { message: error }));
             return;
         }
 
@@ -273,18 +287,25 @@ impl WinitWindowWrapper {
         let route_id = RouteId::next();
         let runtime = self.runtime.as_mut().expect("Neovim runtime has not been initialized");
 
-        let neovim_handler = runtime
-            .launch(
-                route_id,
-                proxy.clone(),
-                desired_grid_size,
-                self.runtime_tracker.clone(),
-                self.settings.clone(),
-                &config,
-                None,
-                OpenMode::Startup,
-            )
-            .expect("Failed to launch neovim runtime");
+        let neovim_handler = match runtime.launch(
+            route_id,
+            proxy.clone(),
+            desired_grid_size,
+            self.runtime_tracker.clone(),
+            self.settings.clone(),
+            &config,
+            None,
+            OpenMode::Startup,
+        ) {
+            Ok(handler) => handler,
+            Err(err) => {
+                let msg = format!("Failed to launch neovim runtime: {err:?}");
+                log::error!("{msg}");
+                let _ = proxy
+                    .send_event(EventPayload::all(UserEvent::NeovimLaunchError { message: msg }));
+                return;
+            }
+        };
 
         self.route_cores.insert(
             route_id,
@@ -1500,18 +1521,26 @@ impl WinitWindowWrapper {
 
                 let runtime =
                     self.runtime.as_mut().expect("Neovim runtime has not been initialized");
-                let neovim_handler = runtime
-                    .launch(
-                        route_id,
-                        proxy.clone(),
-                        desired_grid_size,
-                        self.runtime_tracker.clone(),
-                        self.settings.clone(),
-                        &config,
-                        cwd,
-                        args.map_or(OpenMode::None, OpenMode::Args),
-                    )
-                    .expect("Failed to launch neovim runtime");
+                let neovim_handler = match runtime.launch(
+                    route_id,
+                    proxy.clone(),
+                    desired_grid_size,
+                    self.runtime_tracker.clone(),
+                    self.settings.clone(),
+                    &config,
+                    cwd,
+                    args.map_or(OpenMode::None, OpenMode::Args),
+                ) {
+                    Ok(handler) => handler,
+                    Err(err) => {
+                        let msg = format!("Failed to launch neovim runtime: {err:?}");
+                        log::error!("{msg}");
+                        let _ = proxy.send_event(EventPayload::all(UserEvent::NeovimLaunchError {
+                            message: msg,
+                        }));
+                        return;
+                    }
+                };
 
                 (renderer, neovim_handler, None, cwd.map(Path::to_path_buf))
             };


### PR DESCRIPTION
Multi-window support changed from using the error window to using `.expect`. This means that if nvim fails to start in a new window, the entire Neovide process aborts, ending all of your nvim sessions. This change catches these errors and sends them to the main loop as `NeovimLaunchError`, and extends the main loop to be able to handle arbitrarily many of these error windows without blocking.

Tested by:
1. `open -a Neovide --args --wsl`
2. `open -na Neovide --args --reuse-instance --new-window --neovim-bin=false`

Before this would abort Neovide, now it shows the error window again.