### PR TITLE
fix: defer cold-start file drops until ui_attach completes

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -218,6 +218,9 @@ async fn create_neovim_session(
         .await
         .context("Could not attach ui to neovim process")?;
 
+    #[cfg(target_os = "macos")]
+    ui_commands::mark_file_drop_handler_ready(&handler);
+
     info!("Neovim process attached");
 
     Ok(session)

--- a/src/bridge/ui_commands.rs
+++ b/src/bridge/ui_commands.rs
@@ -3,6 +3,9 @@ use std::{
     sync::{Arc, LazyLock, Mutex},
 };
 
+#[cfg(target_os = "macos")]
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use anyhow::{Context, Result};
 use indoc::indoc;
 use log::trace;
@@ -34,13 +37,19 @@ pub static ROUTE_HANDLER_REGISTRY: LazyLock<Mutex<HashMap<RouteId, NeovimHandler
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Startup buffer for macOS cold start. file drops that can arrive before any
-/// neovim handler is active. Flushed when the first route handler registers
+/// ready to replay them safely.
 #[cfg(target_os = "macos")]
 type PendingFileDrop = (String, Option<bool>);
 
 #[cfg(target_os = "macos")]
 static PENDING_FILE_DROPS: LazyLock<Mutex<Vec<PendingFileDrop>>> =
     LazyLock::new(|| Mutex::new(Vec::new()));
+
+/// macOS cold-start file opens must wait until the first embedded neovim has
+/// completed ui_attach, otherwise they can run before filetype/syntax
+/// autocommands exist.
+#[cfg(target_os = "macos")]
+static FILE_DROP_HANDLER_READY: AtomicBool = AtomicBool::new(false);
 
 pub fn get_active_handler() -> Option<NeovimHandler> {
     HANDLER_REGISTRY.lock().unwrap().clone()
@@ -52,9 +61,11 @@ pub fn require_active_handler() -> NeovimHandler {
 
 #[cfg(target_os = "macos")]
 pub fn send_or_queue_file_drop(path: String, tabs: Option<bool>) {
-    if let Some(handler) = get_active_handler() {
-        send_ui(ParallelCommand::FileDrop { path, tabs }, &handler);
-        return;
+    if FILE_DROP_HANDLER_READY.load(Ordering::SeqCst) {
+        if let Some(handler) = get_active_handler() {
+            send_ui(ParallelCommand::FileDrop { path, tabs }, &handler);
+            return;
+        }
     }
 
     PENDING_FILE_DROPS.lock().unwrap().push((path, tabs));
@@ -70,6 +81,19 @@ fn flush_pending_file_drops(handler: &NeovimHandler) {
     for (path, tabs) in pending {
         send_ui(ParallelCommand::FileDrop { path, tabs }, handler);
     }
+}
+
+#[cfg(target_os = "macos")]
+fn flush_pending_file_drops_when_ready(handler: &NeovimHandler) {
+    if FILE_DROP_HANDLER_READY.load(Ordering::SeqCst) {
+        flush_pending_file_drops(handler);
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn mark_file_drop_handler_ready(handler: &NeovimHandler) {
+    FILE_DROP_HANDLER_READY.store(true, Ordering::SeqCst);
+    flush_pending_file_drops(handler);
 }
 
 async fn ime_call(
@@ -389,7 +413,7 @@ pub fn start_ui_command_handler(
     handler.update_current_neovim(nvim, can_support_ime_api);
     register_route_handler(route_id, handler.clone());
     #[cfg(target_os = "macos")]
-    flush_pending_file_drops(&handler);
+    flush_pending_file_drops_when_ready(&handler);
     if handler.mark_ui_command_started() {
         return;
     }


### PR DESCRIPTION
the real problem is that neovim handle wasnt really ready yet. The queued file-open events e.g from finder were being flushed as soon as the first handler registered, but the handler registration happens before ui_attach and in embedded mode neovim does not finish startup until the UI attaches.

we were replaying `:drop` into an instance that had not finished loading a bunch of of things like filetype detection, syntax setup or user startup scripts/config.

see: https://github.com/neovide/neovide/issues/3444
