### PR TITLE
fix: apply neovide_scale_factor at startup and on updates correctly

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -511,8 +511,22 @@ impl Renderer {
         result
     }
 
+    pub fn sync_scale_factor(&mut self) {
+        let user_scale_factor = self.settings.get::<WindowSettings>().scale_factor.into();
+        self.handle_user_scale_factor_change(user_scale_factor);
+    }
+
+    pub fn handle_user_scale_factor_change(&mut self, user_scale_factor: f64) {
+        self.user_scale_factor = user_scale_factor;
+        self.update_scale_factor();
+    }
+
     pub fn handle_os_scale_factor_change(&mut self, os_scale_factor: f64) {
         self.os_scale_factor = os_scale_factor;
+        self.update_scale_factor();
+    }
+
+    fn update_scale_factor(&mut self) {
         self.grid_renderer
             .handle_scale_factor_update(self.os_scale_factor * self.user_scale_factor);
     }
@@ -712,4 +726,46 @@ pub fn create_skia_renderer(
     };
     tracy_create_gpu_context("main_render_context", renderer.as_ref());
     renderer
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    fn create_renderer() -> Renderer {
+        let settings = Arc::new(Settings::new());
+        settings.register::<WindowSettings>();
+        Renderer::new(2.0, Config::default(), settings)
+    }
+
+    #[test]
+    fn user_scale_updates_apply_immediately() {
+        let mut renderer = create_renderer();
+        let initial_size = renderer.grid_renderer.shaper.current_size();
+
+        renderer.handle_user_scale_factor_change(1.5);
+
+        assert_eq!(renderer.user_scale_factor, 1.5);
+        assert_eq!(renderer.grid_renderer.shaper.current_size(), initial_size * 1.5);
+    }
+
+    #[test]
+    fn scale_can_be_resynced_from_settings_after_renderer_creation() {
+        let settings = Arc::new(Settings::new());
+        settings.register::<WindowSettings>();
+
+        let mut renderer = Renderer::new(1.0, Config::default(), settings.clone());
+        let initial_size = renderer.grid_renderer.shaper.current_size();
+
+        let mut window_settings = settings.get::<WindowSettings>();
+        window_settings.scale_factor = 1.5;
+        settings.set(&window_settings);
+
+        renderer.sync_scale_factor();
+
+        assert_eq!(renderer.user_scale_factor, 1.5);
+        assert_eq!(renderer.grid_renderer.shaper.current_size(), initial_size * 1.5);
+    }
 }

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -617,12 +617,7 @@ impl WinitWindowWrapper {
                 for window_id in window_ids.iter() {
                     if let Some(route) = self.routes.get_mut(window_id) {
                         let mut renderer = route.window.renderer.borrow_mut();
-                        let scale_factor = renderer.os_scale_factor;
-                        let renderer_user_scale_factor = renderer.user_scale_factor;
-                        renderer.user_scale_factor = user_scale_factor.into();
-                        renderer
-                            .grid_renderer
-                            .handle_scale_factor_update(scale_factor * renderer_user_scale_factor);
+                        renderer.handle_user_scale_factor_change(user_scale_factor.into());
                         route.state.font_changed_last_frame = true;
                     }
                 }
@@ -1553,6 +1548,7 @@ impl WinitWindowWrapper {
         let scale_factor = window.scale_factor();
         {
             let mut renderer_ref = renderer.borrow_mut();
+            renderer_ref.sync_scale_factor();
             renderer_ref.handle_os_scale_factor_change(scale_factor);
         }
 


### PR DESCRIPTION
fixes https://github.com/neovide/neovide/issues/3447

after the multi-window refactor, the renderer can be created before neovim initial globals are ready.

the runtime path had a second bug: scale factor updates through settings stored the new user scale and then recomputed the grid scale with the old one. so scale changes were always one step behind also reported at https://github.com/neovide/neovide/issues/3447