### PR TITLE
fix: treat clipboard failure as a state, not as fatal

### DIFF
--- a/src/bridge/clipboard.rs
+++ b/src/bridge/clipboard.rs
@@ -1,5 +1,3 @@
-use std::error::Error;
-
 use rmpv::Value;
 
 use crate::clipboard::Clipboard;
@@ -7,9 +5,10 @@ use crate::clipboard::Clipboard;
 pub fn get_clipboard_contents(
     clipboard: &mut Clipboard,
     register: &Value,
-) -> Result<Value, Box<dyn Error + Send + Sync>> {
+) -> Result<Value, String> {
     let register = register.as_str().unwrap_or("+");
-    let clipboard_raw = clipboard.get_contents(register)?.replace('\r', "");
+    let clipboard_raw =
+        clipboard.get_contents(register).map_err(|error| error.to_string())?.replace('\r', "");
     let is_line_paste = clipboard_raw.ends_with('\n');
 
     let lines = clipboard_raw.split('\n').map(Value::from).collect::<Vec<Value>>();
@@ -28,7 +27,7 @@ pub fn set_clipboard_contents(
     clipboard: &mut Clipboard,
     value: &Value,
     register: &Value,
-) -> Result<Value, Box<dyn Error + Send + Sync>> {
+) -> Result<Value, String> {
     #[cfg(not(windows))]
     let endline = "\n";
     #[cfg(windows)]
@@ -44,9 +43,9 @@ pub fn set_clipboard_contents(
                 .collect::<Vec<String>>()
                 .join(endline)
         })
-        .ok_or("can't build string from provided text")?;
+        .ok_or_else(|| "can't build string from provided text".to_string())?;
 
-    clipboard.set_contents(lines, register)?;
+    clipboard.set_contents(lines, register).map_err(|error| error.to_string())?;
 
     Ok(Value::Nil)
 }

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::sync::{
     Arc, Mutex, RwLock,
     atomic::{AtomicBool, Ordering},
@@ -28,6 +29,45 @@ use crate::{
 };
 
 use super::ui_commands::UiCommand;
+
+#[derive(Debug, PartialEq, Eq)]
+enum ClipboardRequestError {
+    Unavailable,
+    LockUnavailable(String),
+    CannotGetContents,
+    CannotSetContents,
+}
+
+impl fmt::Display for ClipboardRequestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unavailable => write!(f, "clipboard unavailable"),
+            Self::LockUnavailable(source) => write!(f, "clipboard unavailable: {source}"),
+            Self::CannotGetContents => write!(f, "cannot get clipboard contents"),
+            Self::CannotSetContents => write!(f, "cannot set clipboard contents"),
+        }
+    }
+}
+
+impl From<ClipboardRequestError> for Value {
+    fn from(error: ClipboardRequestError) -> Self {
+        Value::from(error.to_string())
+    }
+}
+
+fn handle_clipboard_request<T, F>(
+    clipboard_handle: &ClipboardHandle,
+    request: F,
+) -> Result<T, ClipboardRequestError>
+where
+    F: FnOnce(&mut crate::clipboard::Clipboard) -> Result<T, ClipboardRequestError>,
+{
+    let clipboard = clipboard_handle.upgrade().ok_or(ClipboardRequestError::Unavailable)?;
+    let mut clipboard = clipboard
+        .lock()
+        .map_err(|error| ClipboardRequestError::LockUnavailable(error.to_string()))?;
+    request(&mut clipboard)
+}
 
 #[derive(Default)]
 struct NeovimState {
@@ -92,28 +132,24 @@ impl NeovimHandler {
         (self.ui_command_sender.clone(), self.ui_command_receiver.clone())
     }
 
-    pub(crate) fn update_current_neovim(
-        &self,
-        neovim: Neovim<NeovimWriter>,
-        can_support_ime_api: bool,
-    ) {
+    pub fn update_current_neovim(&self, neovim: Neovim<NeovimWriter>, can_support_ime_api: bool) {
         if let Ok(mut guard) = self.current_neovim.write() {
             guard.nvim = Some(neovim);
             guard.can_support_ime_api = can_support_ime_api;
         }
     }
 
-    pub(crate) fn clone_current_neovim(&self) -> Option<Neovim<NeovimWriter>> {
+    pub fn clone_current_neovim(&self) -> Option<Neovim<NeovimWriter>> {
         self.current_neovim.read().ok().and_then(|guard| guard.nvim.as_ref().cloned())
     }
 
-    pub(crate) fn clone_current_neovim_with_ime(&self) -> Option<(Neovim<NeovimWriter>, bool)> {
+    pub fn clone_current_neovim_with_ime(&self) -> Option<(Neovim<NeovimWriter>, bool)> {
         self.current_neovim.read().ok().and_then(|guard| {
             guard.nvim.as_ref().cloned().map(|nvim| (nvim, guard.can_support_ime_api))
         })
     }
 
-    pub(crate) fn mark_ui_command_started(&self) -> bool {
+    pub fn mark_ui_command_started(&self) -> bool {
         self.ui_command_started.swap(true, Ordering::SeqCst)
     }
 }
@@ -131,24 +167,16 @@ impl Handler for NeovimHandler {
         trace!("Neovim request: {:?}", &event_name);
 
         match event_name.as_ref() {
-            "neovide.get_clipboard" => {
-                self.clipboard.upgrade().ok_or(Value::from("clipboard unavailable")).and_then(
-                    |clipboard| {
-                        let mut clipboard = clipboard.lock().unwrap();
-                        get_clipboard_contents(&mut clipboard, &arguments[0])
-                            .map_err(|_| Value::from("cannot get clipboard contents"))
-                    },
-                )
-            }
-            "neovide.set_clipboard" => {
-                self.clipboard.upgrade().ok_or(Value::from("clipboard unavailable")).and_then(
-                    |clipboard| {
-                        let mut clipboard = clipboard.lock().unwrap();
-                        set_clipboard_contents(&mut clipboard, &arguments[0], &arguments[1])
-                            .map_err(|_| Value::from("cannot set clipboard contents"))
-                    },
-                )
-            }
+            "neovide.get_clipboard" => handle_clipboard_request(&self.clipboard, |clipboard| {
+                get_clipboard_contents(clipboard, &arguments[0])
+                    .map_err(|_| ClipboardRequestError::CannotGetContents)
+            })
+            .map_err(Value::from),
+            "neovide.set_clipboard" => handle_clipboard_request(&self.clipboard, |clipboard| {
+                set_clipboard_contents(clipboard, &arguments[0], &arguments[1])
+                    .map_err(|_| ClipboardRequestError::CannotSetContents)
+            })
+            .map_err(Value::from),
             "neovide.quit" => {
                 let error_code =
                     arguments[0].as_i64().expect("Could not parse error code from neovim");
@@ -317,4 +345,62 @@ async fn guifont_was_set(nvim: &Neovim<NeovimWriter>) -> Result<bool, String> {
 
 fn is_guifont_option_set(event: &RedrawEvent) -> bool {
     matches!(event, RedrawEvent::OptionSet { gui_option: GuiOption::GuiFont(_) })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        panic::{AssertUnwindSafe, catch_unwind},
+        sync::{Arc, Mutex},
+    };
+
+    use super::{ClipboardRequestError, handle_clipboard_request};
+    use crate::clipboard::{Clipboard, ClipboardError, ClipboardHandle, ProviderState};
+
+    fn unavailable_clipboard(error: ClipboardError) -> Arc<Mutex<Clipboard>> {
+        Arc::new(Mutex::new(Clipboard::from_provider_states_for_test(
+            ProviderState::unavailable_for_test(error.clone()),
+            #[cfg(target_os = "linux")]
+            ProviderState::unavailable_for_test(error),
+        )))
+    }
+
+    #[test]
+    fn clipboard_request_returns_generic_clipboard_error_message() {
+        let clipboard = unavailable_clipboard(ClipboardError::ProviderInitializationFailed {
+            provider: "clipboard",
+            backend: "x11",
+            source: "setup failed".to_string(),
+        });
+
+        let handle = ClipboardHandle::new(&clipboard);
+        let error = handle_clipboard_request(&handle, |clipboard| {
+            clipboard.get_contents("+").map_err(|_| ClipboardRequestError::CannotGetContents)
+        })
+        .unwrap_err();
+
+        assert_eq!(error, ClipboardRequestError::CannotGetContents);
+    }
+
+    #[test]
+    fn clipboard_request_returns_lock_error_instead_of_panicking() {
+        let clipboard = unavailable_clipboard(ClipboardError::ProviderInitializationFailed {
+            provider: "clipboard",
+            backend: "x11",
+            source: "setup failed".to_string(),
+        });
+
+        let handle = ClipboardHandle::new(&clipboard);
+        let _ = catch_unwind(AssertUnwindSafe(|| {
+            let _guard = clipboard.lock().unwrap();
+            panic!("poison clipboard mutex");
+        }));
+
+        let error = handle_clipboard_request(&handle, |clipboard| {
+            clipboard.get_contents("+").map_err(|_| ClipboardRequestError::CannotGetContents)
+        })
+        .unwrap_err();
+
+        assert!(matches!(error, ClipboardRequestError::LockUnavailable(_)));
+    }
 }

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,4 +1,5 @@
 use std::error::Error;
+use std::fmt;
 use std::sync::{Arc, Mutex, Weak};
 
 use copypasta::{ClipboardContext, ClipboardProvider};
@@ -7,6 +8,7 @@ use copypasta::{
     wayland_clipboard,
     x11_clipboard::{Primary as X11SelectionClipboard, X11ClipboardContext},
 };
+use log::warn;
 use raw_window_handle::HasDisplayHandle;
 #[cfg(target_os = "linux")]
 use raw_window_handle::{RawDisplayHandle, WaylandDisplayHandle};
@@ -14,12 +16,152 @@ use winit::event_loop::EventLoop;
 
 use crate::window::EventPayload;
 
-type Result<T> = std::result::Result<T, Box<dyn Error + Send + Sync + 'static>>;
+type ProviderInitResult<T> = std::result::Result<T, Box<dyn Error + Send + Sync + 'static>>;
+pub type ClipboardResult<T> = std::result::Result<T, ClipboardError>;
+
+const CLIPBOARD_PROVIDER: &str = "clipboard";
+#[cfg(target_os = "linux")]
+const PRIMARY_SELECTION_PROVIDER: &str = "primary selection";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ClipboardError {
+    DisplayHandleUnavailable { source: String },
+    ProviderInitializationFailed { provider: &'static str, backend: &'static str, source: String },
+    ProviderUnavailable { provider: &'static str, register: String, reason: String },
+    GetContentsFailed { provider: &'static str, register: String, source: String },
+    SetContentsFailed { provider: &'static str, register: String, source: String },
+}
+
+impl ClipboardError {
+    fn display_handle_unavailable(error: impl ToString) -> Self {
+        Self::DisplayHandleUnavailable { source: error.to_string() }
+    }
+
+    fn provider_initialization_failed(
+        provider: &'static str,
+        backend: &'static str,
+        error: impl ToString,
+    ) -> Self {
+        Self::ProviderInitializationFailed { provider, backend, source: error.to_string() }
+    }
+
+    fn provider_unavailable(provider: &'static str, register: &str, reason: impl ToString) -> Self {
+        Self::ProviderUnavailable {
+            provider,
+            register: register.to_string(),
+            reason: reason.to_string(),
+        }
+    }
+
+    fn get_contents_failed(provider: &'static str, register: &str, error: impl ToString) -> Self {
+        Self::GetContentsFailed {
+            provider,
+            register: register.to_string(),
+            source: error.to_string(),
+        }
+    }
+
+    fn set_contents_failed(provider: &'static str, register: &str, error: impl ToString) -> Self {
+        Self::SetContentsFailed {
+            provider,
+            register: register.to_string(),
+            source: error.to_string(),
+        }
+    }
+
+    fn unavailability_reason(&self) -> String {
+        match self {
+            Self::DisplayHandleUnavailable { source } => {
+                format!("display handle unavailable: {source}")
+            }
+            Self::ProviderInitializationFailed { backend, source, .. } => {
+                format!("initialization via {backend} failed: {source}")
+            }
+            Self::ProviderUnavailable { reason, .. } => reason.clone(),
+            Self::GetContentsFailed { source, .. } => source.clone(),
+            Self::SetContentsFailed { source, .. } => source.clone(),
+        }
+    }
+}
+
+impl fmt::Display for ClipboardError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DisplayHandleUnavailable { source } => {
+                write!(f, "clipboard display handle unavailable: {source}")
+            }
+            Self::ProviderInitializationFailed { provider, backend, source } => {
+                write!(f, "{provider} provider initialization via {backend} failed: {source}")
+            }
+            Self::ProviderUnavailable { provider, register, reason } => {
+                write!(f, "{provider} for register {register} is unavailable: {reason}")
+            }
+            Self::GetContentsFailed { provider, register, source } => {
+                write!(f, "failed to get contents from {provider} register {register}: {source}")
+            }
+            Self::SetContentsFailed { provider, register, source } => {
+                write!(f, "failed to set contents for {provider} register {register}: {source}")
+            }
+        }
+    }
+}
+
+pub enum ProviderState {
+    Available(Box<dyn ClipboardProvider>),
+    Unavailable(ClipboardError),
+}
+
+impl ProviderState {
+    fn from_init_result(
+        provider: &'static str,
+        backend: &'static str,
+        result: ProviderInitResult<Box<dyn ClipboardProvider>>,
+    ) -> Self {
+        match result {
+            Ok(provider) => Self::Available(provider),
+            Err(error) => {
+                let error =
+                    ClipboardError::provider_initialization_failed(provider, backend, error);
+                warn!("{error}");
+                Self::Unavailable(error)
+            }
+        }
+    }
+
+    fn get_mut(
+        &mut self,
+        provider: &'static str,
+        register: &str,
+    ) -> ClipboardResult<&mut dyn ClipboardProvider> {
+        match self {
+            Self::Available(provider_state) => Ok(provider_state.as_mut()),
+            Self::Unavailable(error) => Err(ClipboardError::provider_unavailable(
+                provider,
+                register,
+                error.unavailability_reason(),
+            )),
+        }
+    }
+
+    fn is_available(&self) -> bool {
+        matches!(self, Self::Available(_))
+    }
+
+    #[cfg(test)]
+    pub fn available_for_test(provider: impl ClipboardProvider + 'static) -> Self {
+        Self::Available(Box::new(provider))
+    }
+
+    #[cfg(test)]
+    pub fn unavailable_for_test(error: ClipboardError) -> Self {
+        Self::Unavailable(error)
+    }
+}
 
 pub struct Clipboard {
-    clipboard: Box<dyn ClipboardProvider>,
+    clipboard: ProviderState,
     #[cfg(target_os = "linux")]
-    selection: Box<dyn ClipboardProvider>,
+    selection: ProviderState,
 }
 
 #[derive(Clone)]
@@ -39,38 +181,250 @@ impl ClipboardHandle {
 
 impl Clipboard {
     pub fn new(event_loop: &EventLoop<EventPayload>) -> Arc<Mutex<Self>> {
-        let clipboard = match event_loop.display_handle().unwrap().as_raw() {
+        let clipboard = match event_loop.display_handle() {
             #[cfg(target_os = "linux")]
-            RawDisplayHandle::Wayland(WaylandDisplayHandle { mut display, .. }) => unsafe {
-                let (selection, clipboard) =
-                    wayland_clipboard::create_clipboards_from_external(display.as_mut());
-                Clipboard { clipboard: Box::new(clipboard), selection: Box::new(selection) }
-            },
-            #[cfg(target_os = "linux")]
-            _ => Clipboard {
-                clipboard: Box::new(ClipboardContext::new().unwrap()),
-                selection: Box::new(X11ClipboardContext::<X11SelectionClipboard>::new().unwrap()),
+            Ok(display_handle) => match display_handle.as_raw() {
+                RawDisplayHandle::Wayland(WaylandDisplayHandle { mut display, .. }) => unsafe {
+                    let (selection, clipboard) =
+                        wayland_clipboard::create_clipboards_from_external(display.as_mut());
+                    Self::with_providers(
+                        ProviderState::Available(Box::new(clipboard)),
+                        ProviderState::Available(Box::new(selection)),
+                    )
+                },
+                _ => Self::new_x11(),
             },
             #[cfg(not(target_os = "linux"))]
-            _ => Clipboard { clipboard: Box::new(ClipboardContext::new().unwrap()) },
+            Ok(_) => Self::new_system(),
+            Err(error) => Self::disabled(ClipboardError::display_handle_unavailable(error)),
         };
 
         Arc::new(Mutex::new(clipboard))
     }
 
-    pub fn get_contents(&mut self, register: &str) -> Result<String> {
-        match register {
+    #[cfg(target_os = "linux")]
+    fn new_x11() -> Self {
+        let clipboard = ProviderState::from_init_result(
+            CLIPBOARD_PROVIDER,
+            "x11",
+            ClipboardContext::new()
+                .map(|clipboard| Box::new(clipboard) as Box<dyn ClipboardProvider>),
+        );
+
+        let selection = ProviderState::from_init_result(
+            PRIMARY_SELECTION_PROVIDER,
+            "x11",
+            X11ClipboardContext::<X11SelectionClipboard>::new()
+                .map(|selection| Box::new(selection) as Box<dyn ClipboardProvider>),
+        );
+
+        Self::with_providers(clipboard, selection)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn new_system() -> Self {
+        Self::with_providers(ProviderState::from_init_result(
+            CLIPBOARD_PROVIDER,
+            "system",
+            ClipboardContext::new()
+                .map(|clipboard| Box::new(clipboard) as Box<dyn ClipboardProvider>),
+        ))
+    }
+
+    #[cfg(target_os = "linux")]
+    fn with_providers(clipboard: ProviderState, selection: ProviderState) -> Self {
+        let clipboard = Self { clipboard, selection };
+        clipboard.warn_if_unavailable();
+        clipboard
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn with_providers(clipboard: ProviderState) -> Self {
+        let clipboard = Self { clipboard };
+        clipboard.warn_if_unavailable();
+        clipboard
+    }
+
+    fn disabled(error: ClipboardError) -> Self {
+        warn!("{error}");
+        Self::empty(error)
+    }
+
+    fn empty(error: ClipboardError) -> Self {
+        Self {
+            clipboard: ProviderState::Unavailable(error.clone()),
             #[cfg(target_os = "linux")]
-            "*" => self.selection.get_contents(),
-            _ => self.clipboard.get_contents(),
+            selection: ProviderState::Unavailable(error),
         }
     }
 
-    pub fn set_contents(&mut self, lines: String, register: &str) -> Result<()> {
-        match register {
-            #[cfg(target_os = "linux")]
-            "*" => self.selection.set_contents(lines),
-            _ => self.clipboard.set_contents(lines),
+    fn warn_if_unavailable(&self) {
+        if !self.has_any_provider() {
+            warn!("clipboard support disabled: no clipboard providers were initialized");
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn has_any_provider(&self) -> bool {
+        self.clipboard.is_available() || self.selection.is_available()
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn has_any_provider(&self) -> bool {
+        self.clipboard.is_available()
+    }
+
+    #[cfg(target_os = "linux")]
+    fn provider_state(&mut self, register: &str) -> (&'static str, &mut ProviderState) {
+        match register {
+            "*" => (PRIMARY_SELECTION_PROVIDER, &mut self.selection),
+            _ => (CLIPBOARD_PROVIDER, &mut self.clipboard),
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn provider_state(&mut self, _register: &str) -> (&'static str, &mut ProviderState) {
+        (CLIPBOARD_PROVIDER, &mut self.clipboard)
+    }
+
+    pub fn get_contents(&mut self, register: &str) -> ClipboardResult<String> {
+        let (provider, state) = self.provider_state(register);
+        state
+            .get_mut(provider, register)?
+            .get_contents()
+            .map_err(|error| ClipboardError::get_contents_failed(provider, register, error))
+    }
+
+    pub fn set_contents(&mut self, lines: String, register: &str) -> ClipboardResult<()> {
+        let (provider, state) = self.provider_state(register);
+        state
+            .get_mut(provider, register)?
+            .set_contents(lines)
+            .map_err(|error| ClipboardError::set_contents_failed(provider, register, error))
+    }
+
+    #[cfg(test)]
+    pub fn from_provider_states_for_test(
+        clipboard: ProviderState,
+        #[cfg(target_os = "linux")] selection: ProviderState,
+    ) -> Self {
+        #[cfg(target_os = "linux")]
+        {
+            Self::with_providers(clipboard, selection)
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            Self::with_providers(clipboard)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "linux")]
+    const TEST_CLIPBOARD_BACKEND: &str = "x11";
+    #[cfg(not(target_os = "linux"))]
+    const TEST_CLIPBOARD_BACKEND: &str = "system";
+
+    struct TestClipboardProvider {
+        contents: String,
+        get_error: Option<&'static str>,
+        set_error: Option<&'static str>,
+    }
+
+    impl TestClipboardProvider {
+        #[cfg(target_os = "linux")]
+        fn with_contents(contents: &str) -> Self {
+            Self { contents: contents.to_string(), get_error: None, set_error: None }
+        }
+
+        fn with_get_error(error: &'static str) -> Self {
+            Self { contents: String::new(), get_error: Some(error), set_error: None }
+        }
+    }
+
+    impl ClipboardProvider for TestClipboardProvider {
+        fn get_contents(&mut self) -> ProviderInitResult<String> {
+            match self.get_error {
+                Some(error) => Err(Box::new(std::io::Error::other(error))),
+                None => Ok(self.contents.clone()),
+            }
+        }
+
+        fn set_contents(&mut self, contents: String) -> ProviderInitResult<()> {
+            match self.set_error {
+                Some(error) => Err(Box::new(std::io::Error::other(error))),
+                None => {
+                    self.contents = contents;
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn init_error(
+        provider: &'static str,
+        backend: &'static str,
+        error: &'static str,
+    ) -> ClipboardError {
+        ClipboardError::provider_initialization_failed(provider, backend, error)
+    }
+
+    #[test]
+    fn total_failure_preserves_initialization_reason() {
+        let mut clipboard = Clipboard::from_provider_states_for_test(
+            ProviderState::unavailable_for_test(init_error(
+                CLIPBOARD_PROVIDER,
+                TEST_CLIPBOARD_BACKEND,
+                "setup failed",
+            )),
+            #[cfg(target_os = "linux")]
+            ProviderState::unavailable_for_test(init_error(
+                PRIMARY_SELECTION_PROVIDER,
+                "x11",
+                "selection setup failed",
+            )),
+        );
+
+        let error = clipboard.get_contents("+").unwrap_err().to_string();
+        assert!(error.contains("clipboard for register + is unavailable"));
+        assert!(error.contains(&format!(
+            "initialization via {TEST_CLIPBOARD_BACKEND} failed: setup failed"
+        )));
+    }
+
+    #[test]
+    fn provider_operation_failures_include_context() {
+        let mut clipboard = Clipboard::from_provider_states_for_test(
+            ProviderState::available_for_test(TestClipboardProvider::with_get_error("read failed")),
+            #[cfg(target_os = "linux")]
+            ProviderState::available_for_test(TestClipboardProvider::with_contents("selection")),
+        );
+
+        let error = clipboard.get_contents("+").unwrap_err().to_string();
+        assert!(error.contains("failed to get contents from clipboard register +"));
+        assert!(error.contains("read failed"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn partial_failure_keeps_available_provider_working() {
+        let mut clipboard = Clipboard::from_provider_states_for_test(
+            ProviderState::available_for_test(TestClipboardProvider::with_contents("copied")),
+            ProviderState::unavailable_for_test(init_error(
+                PRIMARY_SELECTION_PROVIDER,
+                "x11",
+                "selection setup failed",
+            )),
+        );
+
+        assert_eq!(clipboard.get_contents("+").unwrap(), "copied");
+
+        let error = clipboard.get_contents("*").unwrap_err().to_string();
+        assert!(error.contains("primary selection for register * is unavailable"));
+        assert!(error.contains("selection setup failed"));
     }
 }

--- a/src/window/error_window.rs
+++ b/src/window/error_window.rs
@@ -265,9 +265,10 @@ impl State {
                         true
                     }
                     "y" => {
-                        if let Some(clipboard) = self.clipboard.upgrade() {
-                            let _ =
-                                clipboard.lock().unwrap().set_contents(message.to_string(), "+");
+                        if let Some(handle) = self.clipboard.upgrade() {
+                            if let Ok(mut clipboard) = handle.lock() {
+                                let _ = clipboard.set_contents(message.to_string(), "+");
+                            }
                         }
                         true
                     }


### PR DESCRIPTION
fixes https://github.com/neovide/neovide/issues/3442

previously we assumed that clipboard support was always there, so unwrap() was inappropriate meaning that if the clipboard provider failed to initialize, we panicked.

todo: in fact we should ERASE all unwrap() from the codebase if not tests.

so to model the thing we actually have:

  - a clipboard provider that *can* be available
  - or it can be unavailable, with a reason

x11 PRIMARY vs CLIPBOARD selections
see https://specifications.freedesktop.org/clipboard-spec/1.0

x11 display connection is explicit and may fail
see https://www.x.org/archive/X11R7.5/doc/man/man3/XOpenDisplay.3.html

wayland display is an explicit compositor connection and connect can fail
see https://wayland.freedesktop.org/docs/html/apb.html