### PR TITLE
fix: overhaul `build_nvim_command_parts`

### DIFF
--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -103,41 +103,52 @@ fn build_nvim_command_parts(
     mode: OpenMode,
 ) -> (String, Vec<String>) {
     let bin = cmdline_settings.neovim_bin.clone().unwrap_or_else(|| "nvim".to_owned());
-    let mut args = cmdline_settings.neovim_args.clone();
-    if embed {
-        append_embed_arg(&mut args);
-    }
-
-    args.extend(build_open_args(cmdline_settings, mode));
-
-    (bin, args)
-}
-
-fn build_open_args(cmdline_settings: &CmdLineSettings, open_mode: OpenMode) -> Vec<String> {
-    let (files_to_open, tabs) = match open_mode {
-        OpenMode::None => return Vec::new(),
+    let mut initial_args = cmdline_settings.neovim_args.clone();
+    let (mut files, tab) = match mode {
+        OpenMode::None => (Vec::new(), false),
         OpenMode::Startup => (cmdline_settings.files_to_open.clone(), cmdline_settings.tabs),
         OpenMode::Args(args) => (args.files_to_open, args.tabs),
     };
 
-    (tabs && !has_tab_arg(cmdline_settings))
-        .then(|| "-p".to_string())
+    files = handle_wslpaths(files, cmdline_settings.wsl);
+
+    files.extend(
+        initial_args.split_off(
+            initial_args
+                .iter()
+                .position(|a| a == "--")
+                .and_then(|i| if i + 1 < initial_args.len() { Some(i + 1) } else { None })
+                .unwrap_or(initial_args.len()),
+        ),
+    );
+
+    let args = (embed)
+        .then(|| "--embed".to_string())
         .into_iter()
-        .chain(handle_wslpaths(files_to_open, cmdline_settings.wsl))
-        .collect()
+        .chain(
+            (tab && !has_tab_arg(&initial_args))
+            .then(|| "-p".to_string()),
+        )
+        .chain(
+            initial_args
+                .into_iter()
+                .filter(|a| (!embed || **a != "--embed".to_string()) && **a != "--".to_string()),
+        )
+        .chain(
+            (files.len() > 0)
+                .then_some(std::iter::once("--".to_string()).chain(files))
+                .into_iter()
+                .flatten(),
+        )
+        .collect();
+
+    (bin, args)
 }
 
-fn has_tab_arg(cmdline_settings: &CmdLineSettings) -> bool {
-    return cmdline_settings.neovim_args.iter().any(|a| {
-        a.strip_prefix("-p")
-            .is_some_and(|count| count.chars().all(|c| c.is_ascii_digit()))
+fn has_tab_arg(args: &Vec<String>) -> bool {
+    return args.iter().any(|a| {
+        a.strip_prefix("-p").is_some_and(|count| count.chars().all(|c| c.is_ascii_digit()))
     });
-}
-
-fn append_embed_arg(args: &mut Vec<String>) {
-    if !args.iter().any(|arg| arg == "--embed") {
-        args.push("--embed".to_string());
-    }
 }
 
 fn tokio_command_from_spec(spec: CommandSpec) -> TokioCommand {
@@ -299,7 +310,7 @@ mod tests {
 
         let (_, args) = build_nvim_command_parts(&cmdline_settings, true, OpenMode::Startup);
 
-        assert_eq!(args, vec!["--embed", "-p", "./foo.txt", "./bar.md"]);
+        assert_eq!(args, vec!["--embed", "-p", "--", "./foo.txt", "./bar.md"]);
     }
 
     #[test]
@@ -321,7 +332,7 @@ mod tests {
         let (_, args) =
             build_nvim_command_parts(&cmdline_settings, true, OpenMode::Args(open_args));
 
-        assert_eq!(args, vec!["--embed", "/tmp/project"]);
+        assert_eq!(args, vec!["--embed", "--", "/tmp/project"]);
     }
 
     #[test]
@@ -339,7 +350,7 @@ mod tests {
         let (bin, args) = build_nvim_command_parts(&cmdline_settings, true, OpenMode::Startup);
 
         assert_eq!(bin, "ssh");
-        assert_eq!(args, vec!["my-server", "nvim", "--embed"]);
+        assert_eq!(args, vec!["--embed", "my-server", "nvim"]);
     }
 
     #[test]

--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -120,10 +120,18 @@ fn build_open_args(cmdline_settings: &CmdLineSettings, open_mode: OpenMode) -> V
         OpenMode::Args(args) => (args.files_to_open, args.tabs),
     };
 
-    tabs.then(|| "-p".to_string())
+    (tabs && !has_tab_arg(cmdline_settings))
+        .then(|| "-p".to_string())
         .into_iter()
         .chain(handle_wslpaths(files_to_open, cmdline_settings.wsl))
         .collect()
+}
+
+fn has_tab_arg(cmdline_settings: &CmdLineSettings) -> bool {
+    return cmdline_settings.neovim_args.iter().any(|a| {
+        a.strip_prefix("-p")
+            .is_some_and(|count| count.chars().all(|c| c.is_ascii_digit()))
+    });
 }
 
 fn append_embed_arg(args: &mut Vec<String>) {

--- a/src/bridge/command.rs
+++ b/src/bridge/command.rs
@@ -103,36 +103,27 @@ fn build_nvim_command_parts(
     mode: OpenMode,
 ) -> (String, Vec<String>) {
     let bin = cmdline_settings.neovim_bin.clone().unwrap_or_else(|| "nvim".to_owned());
-    let mut initial_args = cmdline_settings.neovim_args.clone();
+    let (nvim_args, nvim_files) = split_args(cmdline_settings.neovim_args.clone());
+
     let (mut files, tab) = match mode {
         OpenMode::None => (Vec::new(), false),
         OpenMode::Startup => (cmdline_settings.files_to_open.clone(), cmdline_settings.tabs),
         OpenMode::Args(args) => (args.files_to_open, args.tabs),
     };
-
     files = handle_wslpaths(files, cmdline_settings.wsl);
-
-    files.extend(
-        initial_args.split_off(
-            initial_args
-                .iter()
-                .position(|a| a == "--")
-                .and_then(|i| if i + 1 < initial_args.len() { Some(i + 1) } else { None })
-                .unwrap_or(initial_args.len()),
-        ),
-    );
+    files.extend(nvim_files);
 
     let args = (embed)
         .then(|| "--embed".to_string())
         .into_iter()
         .chain(
-            (tab && !has_tab_arg(&initial_args))
+            (tab && !has_tab_arg(&nvim_args))
             .then(|| "-p".to_string()),
         )
         .chain(
-            initial_args
+            nvim_args
                 .into_iter()
-                .filter(|a| (!embed || **a != "--embed".to_string()) && **a != "--".to_string()),
+                .filter(|a| !embed || **a != "--embed".to_string()),
         )
         .chain(
             (files.len() > 0)
@@ -143,6 +134,18 @@ fn build_nvim_command_parts(
         .collect();
 
     (bin, args)
+}
+
+fn split_args(mut args: Vec<String>) -> (Vec<String>, Vec<String>) {
+    let separator_pos = args.iter().position(|a| a == "--").and_then(|i| if i + 1 < args.len() { Some(i + 1) } else { None });
+    match separator_pos {
+        Some(pos) => {
+            let files = args.split_off(pos);
+            args.pop();
+            return (args, files)
+        },
+        None => return (args, Vec::new())
+    }
 }
 
 fn has_tab_arg(args: &Vec<String>) -> bool {


### PR DESCRIPTION
Resolves #3459, among other problems.

In this patch, `build_nvim_command_parts` will now:
1) Split off file arguments passed to Neovim after `--`, concatenating them with file arguments passed to Neovide, which:
    a) resolves Neovide hanging when `--` is passed to Neovim, as `--embed` would be opened as a file instead of being parsed as a flag
    b) better respects the order in which file args are passed 
2) Respects user-provided `-p` flag, where before it would get overridden
3) Ensure `--embed` is removed from the user arguments and prepended to the built arguments:
    a) to respect the state of `embed`
    b) as a fix for [#38847](https://github.com/neovim/neovim/issues/38847) upstream

Given a command such as:
```sh
neovide ./file1.txt -- -p2 ./file2.txt -- ./file3.txt
```
Before, this would generate:
```sh
nvim -p2 ./file2.txt -- ./file3.txt ./file1.txt --embed -p # If this command didn't hang, the latter -p would take precedence over -p2
```
Now:
```sh
nvim --embed -p2 ./file2.txt --  ./file1.txt ./file3.txt
```

### Potential Problems
- With 1b, the file arg list would still be different than the user might expect. Since the current implementation doesn't touch file arguments pre-separator, file args passed as e.g. `neovide 1 -- 2 -- 3` would be opened as `2 -- 1 3`. The only solution to this I can see would be to extract *every* file argument from the original command, which would effectively require building Neovim's arg parser in Neovide.
- With 3a, I can't really imagine a scenario in which the user would want to manually pass `--embed`; regardless, this is technically disrespecting the potential wishes of a user.
- 3b is a temporary fix, and as @falcucci has mentioned, effectively camouflages the potential upstream problem. However, despite being a temporary fix, even when it is fixed upstream, the added behavior ensures that `--embed` is not passed as a file argument, so this could be considered a positive side effect. If there's rationale for why `--embed` should *not* be passed as the first argument, please let me know.

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No