### PR TITLE
performance: stop retrying invalid fallback entries on shape-cache misses

### DIFF
--- a/src/renderer/fonts/caching_shaper.rs
+++ b/src/renderer/fonts/caching_shaper.rs
@@ -1,4 +1,4 @@
-use std::{num::NonZeroUsize, rc::Rc};
+use std::{collections::HashSet, num::NonZeroUsize, rc::Rc};
 
 use itertools::Itertools;
 use log::{debug, error, info, trace, warn};
@@ -40,6 +40,28 @@ pub struct CachingShaper {
     scale_factor: f32,
     linespace: f32,
     font_info: Option<(Metrics, f32)>,
+}
+
+fn filter_failed_fonts(mut options: FontOptions, font_keys: &HashSet<FontKey>) -> FontOptions {
+    let original_normal = options.normal.clone();
+    let hinting = options.hinting.clone();
+    let edging = options.edging.clone();
+
+    options.normal.retain(|font_desc| {
+        let key = FontKey {
+            font_desc: Some(font_desc.clone()),
+            hinting: hinting.clone(),
+            edging: edging.clone(),
+        };
+
+        !font_keys.contains(&key)
+    });
+
+    if options.normal.is_empty() {
+        options.normal = original_normal;
+    }
+
+    options
 }
 
 impl CachingShaper {
@@ -135,6 +157,9 @@ impl CachingShaper {
                 failed_fonts.iter().join(", ")
             );
         }
+
+        let failed_font_keys = failed_fonts.into_iter().cloned().collect::<HashSet<_>>();
+        let options = filter_failed_fonts(options, &failed_font_keys);
 
         debug!("Font updated to: {options:?}");
         self.options = options;
@@ -464,5 +489,177 @@ impl CachingShaper {
         } else {
             vec![]
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    struct PlatformDefault {
+        guifont: String,
+        failed_family: String,
+        expected: Vec<String>,
+    }
+
+    fn filter_normal_families(guifont: &str, failed_families: Vec<String>) -> Vec<String> {
+        let options = FontOptions::parse(guifont).unwrap();
+        let failed_font_keys = failed_families
+            .into_iter()
+            .map(|family| FontKey {
+                font_desc: Some(FontDescription { family, style: None }),
+                hinting: options.hinting.clone(),
+                edging: options.edging.clone(),
+            })
+            .collect::<HashSet<_>>();
+
+        filter_failed_fonts(options, &failed_font_keys)
+            .normal
+            .into_iter()
+            .map(|font| font.family)
+            .collect()
+    }
+
+    #[cfg(target_os = "linux")]
+    fn platform_default_guifont_case() -> PlatformDefault {
+        PlatformDefault {
+            guifont: "Source Code Pro,DejaVu Sans Mono,Courier New,monospace".to_string(),
+            failed_family: "Source Code Pro".to_string(),
+            expected: vec![
+                "DejaVu Sans Mono".to_string(),
+                "Courier New".to_string(),
+                "monospace".to_string(),
+            ],
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn platform_default_guifont_case() -> PlatformDefault {
+        PlatformDefault {
+            guifont: "SF Mono,Menlo,Monaco,Courier New,monospace".to_string(),
+            failed_family: "SF Mono".to_string(),
+            expected: vec![
+                "Menlo".to_string(),
+                "Monaco".to_string(),
+                "Courier New".to_string(),
+                "monospace".to_string(),
+            ],
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    fn platform_default_guifont_case() -> PlatformDefault {
+        PlatformDefault {
+            guifont: "Cascadia Code,Cascadia Mono,Consolas,Courier New,monospace".to_string(),
+            failed_family: "Cascadia Code".to_string(),
+            expected: vec![
+                "Cascadia Mono".to_string(),
+                "Consolas".to_string(),
+                "Courier New".to_string(),
+                "monospace".to_string(),
+            ],
+        }
+    }
+
+    #[test]
+    fn filters_failed_normal_fonts_and_preserves_order() {
+        let options = FontOptions {
+            normal: vec![
+                FontDescription { family: "Missing".to_string(), style: None },
+                FontDescription { family: "DejaVu Sans Mono".to_string(), style: None },
+                FontDescription { family: "Courier New".to_string(), style: None },
+            ],
+            ..FontOptions::default()
+        };
+
+        let failed_font_keys = HashSet::from([FontKey {
+            font_desc: Some(FontDescription { family: "Missing".to_string(), style: None }),
+            hinting: options.hinting.clone(),
+            edging: options.edging.clone(),
+        }]);
+
+        let filtered = filter_failed_fonts(options, &failed_font_keys);
+
+        assert_eq!(
+            filtered.normal,
+            vec![
+                FontDescription { family: "DejaVu Sans Mono".to_string(), style: None },
+                FontDescription { family: "Courier New".to_string(), style: None },
+            ]
+        );
+    }
+
+    #[test]
+    fn does_not_empty_normal_fonts_when_every_normal_font_fails() {
+        let options = FontOptions {
+            normal: vec![FontDescription { family: "Missing".to_string(), style: None }],
+            ..FontOptions::default()
+        };
+
+        let failed_font_keys = HashSet::from([FontKey {
+            font_desc: Some(FontDescription { family: "Missing".to_string(), style: None }),
+            hinting: options.hinting.clone(),
+            edging: options.edging.clone(),
+        }]);
+
+        let filtered = filter_failed_fonts(options.clone(), &failed_font_keys);
+
+        assert_eq!(filtered.normal, options.normal);
+    }
+
+    #[test]
+    fn filters_failed_font_from_neovim_platform_default_guifont() {
+        let case = platform_default_guifont_case();
+
+        assert_eq!(
+            filter_normal_families(&case.guifont, vec![case.failed_family.clone()]),
+            case.expected
+        );
+    }
+
+    #[test]
+    fn filters_failed_font_from_neovim_linux_default_guifont() {
+        assert_eq!(
+            filter_normal_families(
+                "Source Code Pro,DejaVu Sans Mono,Courier New,monospace",
+                vec!["Source Code Pro".to_string()]
+            ),
+            vec!["DejaVu Sans Mono", "Courier New", "monospace"]
+        );
+    }
+
+    #[test]
+    fn filters_failed_font_from_neovim_macos_default_guifont() {
+        assert_eq!(
+            filter_normal_families(
+                "SF Mono,Menlo,Monaco,Courier New,monospace",
+                vec!["SF Mono".to_string()]
+            ),
+            vec!["Menlo", "Monaco", "Courier New", "monospace"]
+        );
+    }
+
+    #[test]
+    fn filters_failed_font_from_neovim_windows_default_guifont() {
+        assert_eq!(
+            filter_normal_families(
+                "Cascadia Code,Cascadia Mono,Consolas,Courier New,monospace",
+                vec!["Cascadia Code".to_string()]
+            ),
+            vec!["Cascadia Mono", "Consolas", "Courier New", "monospace"]
+        );
+    }
+
+    #[test]
+    fn filters_failed_font_from_neovim_fallback_default_guifont() {
+        assert_eq!(
+            filter_normal_families(
+                "DejaVu Sans Mono,Courier New,monospace",
+                vec!["DejaVu Sans Mono".to_string()]
+            ),
+            vec!["Courier New", "monospace"]
+        );
     }
 }

--- a/src/renderer/fonts/font_loader.rs
+++ b/src/renderer/fonts/font_loader.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashSet,
     fmt::{Display, Formatter},
     num::NonZeroUsize,
     rc::Rc,
@@ -61,6 +62,7 @@ pub struct FontKey {
 pub struct FontLoader {
     font_mgr: FontMgr,
     cache: LruCache<FontKey, Rc<FontPair>>,
+    failed_fonts: HashSet<FontKey>,
     font_size: f32,
     last_resort: Option<Rc<FontPair>>,
 }
@@ -80,6 +82,7 @@ impl FontLoader {
         FontLoader {
             font_mgr: FontMgr::new(),
             cache: LruCache::new(NonZeroUsize::new(20).unwrap()),
+            failed_fonts: HashSet::new(),
             font_size,
             last_resort: None,
         }
@@ -104,11 +107,23 @@ impl FontLoader {
             return Some(cached.clone());
         }
 
-        let loaded_font = self.load(font_key.clone())?;
-        let font_rc = Rc::new(loaded_font);
-        self.cache.put(font_key.clone(), font_rc.clone());
+        if self.failed_fonts.contains(font_key) {
+            return None;
+        }
 
-        Some(font_rc)
+        let font = match self.load(font_key.clone()) {
+            Some(loaded_font) => loaded_font,
+            None => {
+                self.failed_fonts.insert(font_key.clone());
+                return None;
+            }
+        };
+
+        let font = Rc::new(font);
+        self.cache.put(font_key.clone(), font.clone());
+        self.failed_fonts.remove(font_key);
+
+        Some(font)
     }
 
     pub fn load_font_for_character(
@@ -182,5 +197,29 @@ fn font_edging(edging: &FontEdging) -> SkiaEdging {
         FontEdging::AntiAlias => SkiaEdging::AntiAlias,
         FontEdging::Alias => SkiaEdging::Alias,
         FontEdging::SubpixelAntiAlias => SkiaEdging::SubpixelAntiAlias,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn caches_failed_font_keys() {
+        let mut loader = FontLoader::new(14.0);
+        let missing_font = FontKey {
+            font_desc: Some(FontDescription {
+                family: "missing-font-family".to_string(),
+                style: None,
+            }),
+            hinting: FontHinting::default(),
+            edging: FontEdging::default(),
+        };
+
+        assert!(loader.get_or_load(&missing_font).is_none());
+        assert!(loader.failed_fonts.contains(&missing_font));
+
+        assert!(loader.get_or_load(&missing_font).is_none());
+        assert_eq!(loader.failed_fonts.len(), 1);
     }
 }


### PR DESCRIPTION
see https://github.com/neovide/neovide/issues/3457 for more context but mainly apparently linux users were most affected. users who doesnt explicitly set 'guifont' and doesn't have **every** default upstream list font installed could notice some slowness.

font loading is very fast but expensive if we do redundant stuff.

neovim now sends platform-specific default 'guifont' fallback lists.

on affected systems the first entry in that list may not be installed, but Neovide still keeps it in the active fallback chain and probes it again on every shape-cache miss. That turns a normal miss into repeated redundant `load_font` churn before we ever get to a font that can actually render the text.

we now fix that in two ways:

 - remember FontKeys that already failed to load;
 - drop failed normal 'guifont' entries from the cache fallback list after validation;