### PR TITLE
ui2: don't let resize restore hidden grids

### DIFF
--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     bridge::{GridLineCell, GuiOption, NeovimHandler, RedrawEvent, WindowAnchor},
     clipboard::ClipboardHandle,
     profiling::{tracy_named_frame, tracy_zone},
-    renderer::{DrawCommand, WindowDrawCommand},
+    renderer::{DrawCommand, WindowDrawCommand, rendered_window::BASE_GRID_ID},
     running_tracker::RunningTracker,
     settings::Settings,
     units::{GridRect, GridSize},
@@ -457,6 +457,12 @@ impl Editor {
                 (width, height),
                 &mut self.draw_command_batcher,
             );
+            if grid != BASE_GRID_ID {
+                // Non-root multigrid windows can be resized before Neovim tells us where
+                // they actually belong. Keep those placeholder grids hidden until a later
+                // win_pos, win_float_pos, or msg_set_pos explicitly shows them.
+                window.hide(&mut self.draw_command_batcher);
+            }
             self.windows.insert(grid, window);
         }
     }

--- a/src/renderer/rendered_window.rs
+++ b/src/renderer/rendered_window.rs
@@ -15,7 +15,6 @@ use crate::{
     utils::RingBuffer,
 };
 
-#[cfg(target_os = "macos")]
 pub const BASE_GRID_ID: u64 = 1;
 pub const NO_MULTIGRID_GRID_ID: u64 = 0;
 
@@ -653,14 +652,6 @@ impl RenderedWindow {
 
                 self.anchor_info = anchor_info;
                 self.window_type = window_type;
-
-                if self.hidden {
-                    self.hidden = false;
-                    self.position_t = 2.0; // We don't want to animate since the window is becoming visible,
-                    // so we set t to 2.0 to stop animations.
-                    self.grid_start_position = grid_position;
-                    self.grid_destination = grid_position;
-                }
             }
             WindowDrawCommand::DrawLine { row, line } => {
                 tracy_zone!("draw_line_cmd", 0);


### PR DESCRIPTION
*A grid having a size is not the same thing as that grid being visible*.

the experimental [ui2](https://neovim.io/doc/user/lua/#_ui2) just exposed an assumption that we were doing.

fixes #3446

A resize tells us that a grid exists and what size it has. It does not tell us that the grid is actually visible. Those seems to be different states from neovim, and we were treating them as if they were the same.

For a new non-root grid that first appeared through a resize, we would instantiate a window immediately. That construction also gave it a position, and the renderer then treated that position update as if it meant to show that window. That logic only works if every resized grid is supposed to become visible right away.

hidden helper windows can be resized long before neovim decides to place or show them. which seems to be the case now on ui2. so our old behavior could restore a window that neovim still considered hidden, which is why the wrong border and stale helper window would leak on startup and again after resizing.

