### PR TITLE
fix: keypad * mapping (use NumpadMultiply instead of NumpadStar)

### DIFF
--- a/src/window/keyboard_manager.rs
+++ b/src/window/keyboard_manager.rs
@@ -127,7 +127,7 @@ impl KeyboardManager {
         let is_numlock_key = key_event.text.is_some();
         match physical_key_code {
             KeyCode::NumpadDivide => Some("kDivide"),
-            KeyCode::NumpadStar => Some("kMultiply"),
+            KeyCode::NumpadMultiply => Some("kMultiply"),
             KeyCode::NumpadSubtract => Some("kMinus"),
             KeyCode::NumpadAdd => Some("kPlus"),
             KeyCode::NumpadEnter => Some("kEnter"),


### PR DESCRIPTION
Simple one-line fix, no breaking change.

Neovide currently maps KeyCode::NumpadStar to "kMultiply".

According to winit docs:

- NumpadMultiply = keypad "*"
- NumpadStar = telephony "*" key

This causes keypad "\*" to be treated as regular "\*" in Neovim.

Fix: use NumpadMultiply instead.

Resolves #3383.