### PR TITLE
fix: panicking on zero-height grids

### DIFF
--- a/src/editor/grid.rs
+++ b/src/editor/grid.rs
@@ -51,11 +51,11 @@ impl CharacterGrid {
     }
 
     pub fn get_cell(&self, x: usize, y: usize) -> Option<&GridCell> {
-        self.lines[y].characters.get(x)
+        self.row(y).and_then(|row| row.get(x))
     }
 
     pub fn get_cell_mut(&mut self, x: usize, y: usize) -> Option<&mut GridCell> {
-        self.lines[y].characters.get_mut(x)
+        self.row_mut(y).and_then(|row| row.get_mut(x))
     }
 
     pub fn set_all_characters(&mut self, value: GridCell) {
@@ -67,7 +67,11 @@ impl CharacterGrid {
     }
 
     pub fn row(&self, row_index: usize) -> Option<&[GridCell]> {
-        if row_index < self.height { Some(&self.lines[row_index].characters[..]) } else { None }
+        self.lines.get(row_index).map(|line| line.characters.as_slice())
+    }
+
+    fn row_mut(&mut self, row_index: usize) -> Option<&mut [GridCell]> {
+        self.lines.get_mut(row_index).map(|line| line.characters.as_mut_slice())
     }
 
     /// Scroll the region defined by top, bottom, left, and right by rows and columns.
@@ -231,6 +235,22 @@ mod tests {
         *cell = ("bar".to_string(), Some(Arc::new(Style::new(context.none_colors.clone()))));
 
         assert_eq!(character_grid.get_cell_mut(context.x, context.y).unwrap(), &result);
+    }
+
+    #[test]
+    fn get_cell_returns_none_for_zero_height_grid() {
+        let mut character_grid = CharacterGrid::new((10, 0));
+
+        assert_eq!(character_grid.get_cell(0, 0), None);
+        assert_eq!(character_grid.get_cell_mut(0, 0), None);
+    }
+
+    #[test]
+    fn get_cell_returns_none_for_out_of_bounds_row() {
+        let mut character_grid = CharacterGrid::new((4, 2));
+
+        assert_eq!(character_grid.get_cell(0, 2), None);
+        assert_eq!(character_grid.get_cell_mut(0, 2), None);
     }
 
     #[test]

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -735,4 +735,17 @@ mod tests {
 
         assert_eq!(next_start, window.grid.width);
     }
+
+    #[test]
+    fn get_cursor_grid_cell_returns_default_for_zero_height_window() {
+        let window = Window {
+            grid_id: 1,
+            grid: CharacterGrid::new((4, 0)),
+            window_type: WindowType::Editor,
+            anchor_info: None,
+            grid_position: (0.0, 0.0),
+        };
+
+        assert_eq!(window.get_cursor_grid_cell(0, 0), (" ".to_string(), None, false));
+    }
 }

--- a/src/utils/ring_buffer.rs
+++ b/src/utils/ring_buffer.rs
@@ -62,6 +62,16 @@ impl<T: Clone> RingBuffer<T> {
         self.elements.len()
     }
 
+    pub fn get(&self, index: usize) -> Option<&T> {
+        let array_index = self.checked_array_index(index)?;
+        Some(&self.elements[array_index])
+    }
+
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut T> {
+        let array_index = self.checked_array_index(index)?;
+        Some(&mut self.elements[array_index])
+    }
+
     pub fn resize(&mut self, new_size: usize, default_value: T) {
         if new_size > 0 && !self.elements.is_empty() {
             let index = self.get_array_index(0);
@@ -78,6 +88,10 @@ impl<T: Clone> RingBuffer<T> {
     fn get_array_index(&self, index: isize) -> usize {
         let num = self.elements.len() as isize;
         (self.current_index + index).rem_euclid(num) as usize
+    }
+
+    fn checked_array_index(&self, index: usize) -> Option<usize> {
+        (index < self.len()).then(|| self.get_array_index(index as isize))
     }
 
     fn get_bounds<R: RangeBounds<isize>>(&self, range: R) -> Range<isize> {
@@ -177,6 +191,8 @@ mod tests {
         let mut buffer = RingBuffer::<i32>::new(0, 5);
         assert_eq!(buffer.len(), 0);
         assert!(buffer.is_empty());
+        assert_eq!(buffer.get(0), None);
+        assert_eq!(buffer.get_mut(0), None);
         assert_eq!(buffer.iter().size_hint(), (0, Some(0)));
         assert_eq!(buffer.iter_mut().size_hint(), (0, Some(0)));
     }
@@ -207,11 +223,25 @@ mod tests {
         let mut buffer = RingBuffer::<i32>::new(3, 0);
         assert_eq!(buffer.len(), 3);
         assert_eq!(buffer[0], 0);
+        assert_eq!(buffer.get(0), Some(&0));
         assert_eq!(buffer[2], 0);
         buffer.clone_from_iter(&[1, 2, 3]);
         assert!(buffer.iter().eq([1, 2, 3].iter()));
         assert_eq!(buffer[0], 1);
         assert_eq!(buffer[2], 3);
+        assert_eq!(buffer.get(3), None);
+    }
+
+    #[test]
+    fn get_respects_rotation_and_bounds() {
+        let mut buffer = RingBuffer::<i32>::new(3, 0);
+        buffer.clone_from_iter(&[1, 2, 3]);
+        buffer.rotate(1);
+
+        assert_eq!(buffer.get(0), Some(&2));
+        assert_eq!(buffer.get(1), Some(&3));
+        assert_eq!(buffer.get(2), Some(&1));
+        assert_eq!(buffer.get(3), None);
     }
 
     #[test]


### PR DESCRIPTION
zero-height grids happen during relayout. doing modulo by zero in the ring buffer just made it break.


```
Neovide panicked with the message 'attempt to calculate the remainder with a divisor of zero'. (File: src/utils/ring_buffer.rs; Line: 80, Column: 38)
This is a bug and we would love for it to be reported to https://github.com/neovide/neovide/issues
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
