### PR TITLE
fix: set font_changed_last_frame on route after scale factor update

### DIFF
--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -2674,7 +2674,7 @@ impl WinitWindowWrapper {
         #[cfg(target_os = "macos")]
         let macos_feature = self.macos_feature_for_window(window_id);
 
-        let Some(route) = self.routes.get(&window_id) else {
+        let Some(route) = self.routes.get_mut(&window_id) else {
             return;
         };
         let mut renderer = route.window.renderer.borrow_mut();
@@ -2687,6 +2687,7 @@ impl WinitWindowWrapper {
         }
         renderer.handle_os_scale_factor_change(scale_factor);
         skia_renderer.resize();
+        route.state.font_changed_last_frame = true;
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
This seems to fix https://github.com/neovide/neovide/issues/2479 for me.
It seems to be how we handle the user_scale_factor changing, for
example, so seems maybe reasonable? But very unfamiliar with the
codebase so please let me know if this is way off base.

<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix

## Did this PR introduce a breaking change? 
- No, not that I'm aware of.
