### PR TITLE
macos: add system window proxy icon support

### DIFF
--- a/lua/init.lua
+++ b/lua/init.lua
@@ -236,6 +236,52 @@ vim.api.nvim_create_autocmd({ "VimEnter" }, {
     end,
 })
 
+if vim.fn.has("macunix") == 1 then
+    local document_state_group = vim.api.nvim_create_augroup("NeovideDocumentState", { clear = true })
+    local function notify_document_state()
+        local bufnr = vim.api.nvim_get_current_buf()
+        local path = vim.api.nvim_buf_get_name(bufnr)
+        local modified = vim.api.nvim_get_option_value("modified", { buf = bufnr })
+        pcall(rpcnotify, "neovide.document_state", path, modified)
+    end
+
+    local function enable_document_state()
+        vim.api.nvim_create_autocmd({
+            "BufEnter",
+            "BufFilePost",
+            "BufModifiedSet",
+            "BufWritePost",
+        }, {
+            group = document_state_group,
+            callback = notify_document_state,
+        })
+
+        vim.api.nvim_create_autocmd("VimEnter", {
+            group = document_state_group,
+            once = true,
+            nested = true,
+            callback = notify_document_state,
+        })
+
+        if vim.v.vim_did_enter == 1 then
+            notify_document_state()
+        end
+    end
+
+    local function update_document_state()
+        vim.api.nvim_clear_autocmds({ group = document_state_group })
+
+        if vim.g.neovide_proxy_icon then
+            enable_document_state()
+        else
+            pcall(rpcnotify, "neovide.document_state", "", false)
+        end
+    end
+
+    vim.fn.WatchGlobal("neovide_proxy_icon", update_document_state)
+    update_document_state()
+end
+
 -- Create auto command for retrieving exit code from neovim on quit.
 vim.api.nvim_create_autocmd({ "VimLeavePre" }, {
     pattern = "*",

--- a/src/bridge/handler.rs
+++ b/src/bridge/handler.rs
@@ -247,6 +247,18 @@ impl Handler for NeovimHandler {
                 self.send_window_command(WindowCommand::FocusWindow);
             }
             #[cfg(target_os = "macos")]
+            "neovide.document_state" => match parse_document_state_args(&arguments) {
+                Some((path, modified)) => {
+                    self.send_window_command(WindowCommand::DocumentStateChanged {
+                        path,
+                        modified,
+                    });
+                }
+                None => {
+                    warn!("neovide.document_state called with invalid arguments: {arguments:?}")
+                }
+            },
+            #[cfg(target_os = "macos")]
             "neovide.force_click" => match parse_force_click_args(&arguments) {
                 Some((col, row, entity, guifont, kind)) => {
                     self.send_window_command(WindowCommand::TouchpadPressure {
@@ -316,6 +328,15 @@ fn parse_force_click_args(
     let kind = ForceClickKind::from(kind_str);
 
     Some((col, row, entity, guifont, kind))
+}
+
+#[cfg(target_os = "macos")]
+fn parse_document_state_args(arguments: &[Value]) -> Option<(String, bool)> {
+    let [path, modified, ..] = arguments else {
+        return None;
+    };
+
+    Some((path.as_str().unwrap_or("").to_string(), modified.as_bool().unwrap_or(false)))
 }
 
 async fn skip_default_guifont(

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -1025,6 +1025,13 @@ impl MacosWindowFeature {
         self.update_ns_background(opaque, show_border);
     }
 
+    pub fn set_document_state(&self, path: &str, modified: bool) {
+        let represented_path = if path.is_empty() || !Path::new(path).exists() { "" } else { path };
+        let ns_path = NSString::from_str(represented_path);
+        self.ns_window.setRepresentedFilename(&ns_path);
+        self.ns_window.setDocumentEdited(modified);
+    }
+
     pub fn set_title_hidden(&self, title_hidden: bool) {
         let frame = self.settings.get::<CmdLineSettings>().frame;
         let transparent = matches!(frame, Frame::Transparent | Frame::Buttonless);

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -114,6 +114,11 @@ pub enum WindowCommand {
         column: u64,
         text: Option<String>,
     },
+    #[cfg(target_os = "macos")]
+    DocumentStateChanged {
+        path: String,
+        modified: bool,
+    },
     Minimize,
     ThemeChanged(Option<Theme>),
     #[cfg(windows)]

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -132,6 +132,10 @@ pub struct RouteWindow {
     #[cfg(target_os = "macos")]
     pub macos_feature: Option<Rc<RefCell<Box<MacosWindowFeature>>>>,
     pub title: String,
+    #[cfg(target_os = "macos")]
+    pub document_path: String,
+    #[cfg(target_os = "macos")]
+    pub document_modified: bool,
     pub last_applied_window_size: dpi::PhysicalSize<u32>,
     pub last_synced_grid_size: Option<GridSize<u32>>,
 }
@@ -202,6 +206,10 @@ struct RouteCore {
     neovim_handler: NeovimHandler,
     cwd: Option<PathBuf>,
     title: String,
+    #[cfg(target_os = "macos")]
+    document_path: String,
+    #[cfg(target_os = "macos")]
+    document_modified: bool,
     mouse_enabled: bool,
     pending_initial_window_size: Option<WindowSize>,
     last_synced_grid_size: Option<GridSize<u32>>,
@@ -343,6 +351,10 @@ impl WinitWindowWrapper {
                 neovim_handler,
                 cwd: None,
                 title: String::from("Neovide"),
+                #[cfg(target_os = "macos")]
+                document_path: String::new(),
+                #[cfg(target_os = "macos")]
+                document_modified: false,
                 mouse_enabled: true,
                 pending_initial_window_size,
                 last_synced_grid_size: None,
@@ -466,6 +478,21 @@ impl WinitWindowWrapper {
         window.set_ime_allowed(ime_enabled);
     }
 
+    #[cfg(target_os = "macos")]
+    fn apply_document_state(&self, window_id: WindowId) {
+        let Some(route) = self.routes.get(&window_id) else {
+            return;
+        };
+
+        let Some(feature) = self.macos_feature_for_window(window_id) else {
+            return;
+        };
+
+        feature
+            .borrow()
+            .set_document_state(&route.window.document_path, route.window.document_modified);
+    }
+
     pub fn handle_window_command(&mut self, target: EventTarget, command: WindowCommand) {
         tracy_zone!("handle_window_commands", 0);
         if let EventTarget::Route(route_id) = target
@@ -500,6 +527,14 @@ impl WinitWindowWrapper {
                 if let Some(feature) = self.macos_feature_for_window(target_window_id) {
                     feature.borrow().activate_application();
                 }
+            }
+            #[cfg(target_os = "macos")]
+            WindowCommand::DocumentStateChanged { path, modified } => {
+                if let Some(route) = self.routes.get_mut(&target_window_id) {
+                    route.window.document_path = path;
+                    route.window.document_modified = modified;
+                }
+                self.apply_document_state(target_window_id);
             }
             #[cfg(target_os = "macos")]
             WindowCommand::TouchpadPressure { col, row, entity, guifont, kind } => {
@@ -589,6 +624,11 @@ impl WinitWindowWrapper {
         match command {
             WindowCommand::TitleChanged(new_title) => {
                 route_core.title = new_title;
+            }
+            #[cfg(target_os = "macos")]
+            WindowCommand::DocumentStateChanged { path, modified } => {
+                route_core.document_path = path;
+                route_core.document_modified = modified;
             }
             WindowCommand::SetMouseEnabled(mouse_enabled) => {
                 route_core.mouse_enabled = mouse_enabled;
@@ -1493,6 +1533,10 @@ impl WinitWindowWrapper {
         let window_config = create_window(event_loop, maximized, "Neovide", &self.settings, theme);
         let window = Rc::new(window_config.window.clone());
         let mut route_title = String::from("Neovide");
+        #[cfg(target_os = "macos")]
+        let mut route_document_path = String::new();
+        #[cfg(target_os = "macos")]
+        let mut route_document_modified = false;
         let mut route_last_synced_grid_size = None;
         let mut route_inferred_theme = None;
         let mut route_mouse_enabled = true;
@@ -1534,6 +1578,11 @@ impl WinitWindowWrapper {
                 };
                 debug_assert_eq!(route_core.route_id, route_id);
                 route_title = route_core.title;
+                #[cfg(target_os = "macos")]
+                {
+                    route_document_path = route_core.document_path;
+                    route_document_modified = route_core.document_modified;
+                }
                 route_last_synced_grid_size = route_core.last_synced_grid_size;
                 route_inferred_theme = route_core.inferred_theme;
                 route_mouse_enabled = route_core.mouse_enabled;
@@ -1752,6 +1801,10 @@ impl WinitWindowWrapper {
                 #[cfg(target_os = "macos")]
                 macos_feature: Some(Rc::new(RefCell::new(Box::new(macos_feature)))),
                 title: route_title,
+                #[cfg(target_os = "macos")]
+                document_path: route_document_path,
+                #[cfg(target_os = "macos")]
+                document_modified: route_document_modified,
                 last_applied_window_size: saved_inner_size,
                 last_synced_grid_size: route_last_synced_grid_size,
             },
@@ -1764,6 +1817,8 @@ impl WinitWindowWrapper {
             neovim_args: route_launch_config.neovim_args,
         };
         self.routes.insert(window.id(), route);
+        #[cfg(target_os = "macos")]
+        self.apply_document_state(window.id());
         self.apply_theme_for_window(window.id());
         set_active_route_handler(route_id);
         #[cfg(target_os = "macos")]

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -831,6 +831,26 @@ vim.g.neovide_highlight_matching_pair = true
 When enabled, Neovide highlights the matching pair using the system find indicator. The
 default is `false`.
 
+#### Window Proxy Icon (macOS only)
+
+VimScript:
+
+```vim
+let g:neovide_proxy_icon = v:true
+```
+
+Lua:
+
+```lua
+vim.g.neovide_proxy_icon = true
+```
+
+When set to `true` Neovide exposes the current file as a native macOS window proxy icon in the
+title bar and reflects the current buffer's modified state through the standard document-edited
+indicator.
+
+Note: recommended setup is `--frame full` with titles enabled for a cleaner look.
+
 ### Input Settings
 
 #### macOS Option Key is Meta


### PR DESCRIPTION
totally opt-in, driven by the document state, we are using the [NSWindow representedFilename](https://github.com/madsmtm/objc2-generated/blob/2d984f024efbd454dd370a2cd345e0c4e530e665/AppKit/NSWindow.rs#L736-L736) API's to sync the current buffer states.



fixes #3488