### PR TITLE
fix: avoid fullscreen on new tab windows if already set

### DIFF
--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -780,6 +780,10 @@ impl MacosWindowFeature {
         self.simple_fullscreen
     }
 
+    pub fn is_native_fullscreen_enabled(&self) -> bool {
+        self.is_fullscreen
+    }
+
     pub fn show_definition_at_point(
         &self,
         text: &str,

--- a/src/window/window_wrapper.rs
+++ b/src/window/window_wrapper.rs
@@ -1563,6 +1563,9 @@ impl WinitWindowWrapper {
             ..
         } = self.settings.get::<WindowSettings>();
 
+        #[cfg(target_os = "macos")]
+        let fullscreen = self.fullscreen_for_new_window(creating_initial_window, fullscreen);
+
         // Capture per-route launch config before args is consumed into OpenMode.
         // For the initial window (args is None, uses OpenMode::Startup), pull from
         // CmdLineSettings so "New Window" can clone the initial invocation's config.
@@ -2355,6 +2358,45 @@ impl WinitWindowWrapper {
             .or_else(|| {
                 self.route_cores.get(&route_id).map(|route_core| route_core.neovim_handler.clone())
             })
+    }
+
+    #[cfg(target_os = "macos")]
+    fn fullscreen_for_new_window(&self, creating_initial_window: bool, fullscreen: bool) -> bool {
+        if !self.should_handle_tabbed_fullscreen(creating_initial_window, fullscreen) {
+            return fullscreen;
+        }
+
+        // cmd-n creates another top-level NSWindow. if system tabs are enabled,
+        // AppKit then merges that new window into the focused fullscreen
+        // window's tab group. If we also apply the global fullscreen
+        // setting to the newly created window, AppKit tries to perform a
+        // second fullscreen transition for a window that is about to become a
+        // tab in the existing fullscreen group, which triggers
+        // NSWindowStackController assertions. So, we keep the host window fullscreen,
+        // but skip the initial fullscreen transition on the new window to avoid that.
+        let opening_fullscreen_tab = self
+            .get_focused_route()
+            .and_then(|window_id| self.macos_feature_for_window(window_id))
+            .is_some_and(|feature| feature.borrow().is_native_fullscreen_enabled());
+
+        if opening_fullscreen_tab {
+            log::info!("Skipping initial fullscreen for new tab window from fullscreen host");
+            return false;
+        }
+
+        fullscreen
+    }
+
+    #[cfg(target_os = "macos")]
+    fn should_handle_tabbed_fullscreen(
+        &self,
+        creating_initial_window: bool,
+        fullscreen: bool,
+    ) -> bool {
+        !creating_initial_window
+            && fullscreen
+            && native_tab_bar_enabled()
+            && self.settings.get::<CmdLineSettings>().system_native_tabs
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
the second fullscreen transition is what previously made the AppKit assertion wrongly. 

```
Assertion failure in -[NSWindowStackController _enterWindow:intoFullScreenWithWindow:]
```

If the host window is already fullscreen, reapplying the global fullscreen setting to the new window is redundant.

now we just resolve the initial fullscreen state for new windows more carefully: if the new window is being created from a fullscreen native-tab host, we skip the initial fullscreen call for that secondary window and leave the host alone.

since its state is already fullscreen, the new window will be created in a normal state and then transition to fullscreen immediately after.

fixes https://github.com/neovide/neovide/issues/3495
