### PR TITLE
windows: fix overlapped pipe read crash

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -277,7 +277,19 @@ async fn create_neovim_session(
 async fn run(route_id: RouteId, session: NeovimSession, proxy: EventLoopProxy<EventPayload>) {
     let mut session = session;
 
-    if let Some(process) = session.neovim_process.as_mut() {
+    // On Windows, neovim_process is std::process::Child rather than tokio::process::Child,
+    // because tokio's build_child() is skipped to use NamedPipeServer instead.
+    // Need to wrap the std Child's blocking wait() for use with tokio select
+    #[cfg(target_os = "windows")]
+    let future = session
+        .neovim_process
+        .take()
+        .map(|mut child| tokio::task::spawn_blocking(move || child.wait()));
+
+    #[cfg(not(target_os = "windows"))]
+    let future = session.neovim_process.take().map(|mut child| async move { child.wait().await });
+
+    if let Some(future) = future {
         // We primarily wait for the stdio to finish, but due to bugs,
         // for example, this one in in Neovim 0.9.5
         // https://github.com/neovim/neovim/issues/26743
@@ -286,7 +298,7 @@ async fn run(route_id: RouteId, session: NeovimSession, proxy: EventLoopProxy<Ev
         // data.
         select! {
             _ = &mut session.io_handle => {}
-            _ = process.wait() => {
+            _ = future => {
                 // Wait a little bit more if we detect that Neovim exits before the stream, to
                 // allow us to finish reading from it.
                 log::info!("The Neovim process quit before the IO stream, waiting for a half second");

--- a/src/bridge/session.rs
+++ b/src/bridge/session.rs
@@ -3,6 +3,8 @@
 
 #[cfg(debug_assertions)]
 use core::fmt;
+#[cfg(target_os = "windows")]
+use std::process::Child;
 use std::{
     io::{Error, Result},
     process::Stdio,
@@ -10,10 +12,12 @@ use std::{
 
 use anyhow::Context;
 use nvim_rs::{Handler, error::LoopError, neovim::Neovim};
+#[cfg(not(target_os = "windows"))]
+use tokio::process::Child;
 use tokio::{
     io::{AsyncBufReadExt, AsyncRead, AsyncWrite, BufReader, split},
     net::TcpStream,
-    process::{Child, Command},
+    process::Command,
     spawn,
     task::JoinHandle,
 };
@@ -123,17 +127,57 @@ impl NeovimInstance {
     }
 
     async fn spawn_process(
-        mut cmd: Command,
+        #[cfg(not(target_os = "windows"))] mut cmd: Command,
+        #[cfg(target_os = "windows")] cmd: Command,
     ) -> Result<(BoxedReader, BoxedWriter, Option<BoxedReader>, Option<Child>)> {
         log::debug!("Starting neovim with: {cmd:?}");
+
+        // On Windows, `std::process::Command` creates the parent-side pipe handles
+        // as overlapped. When this is wrapped in `tokio::process::Command`, the
+        // handles are wrapped in `Blocking<ArcFile>`, which results in
+        // `std::sys::pal::windows::handle::Handle::synchronous_read`, being calld
+        // on them. This can cause an abort by design if the read doesn't complete
+        // synchronously.
+        // See [File implementation on Windows has unsound methods](https://github.com/rust-lang/rust/issues/81357).
+        //
+        // Instead, use `std::process::Command` directly to get raw handles, and
+        // wrap them in `NamedPipeServer`, which is designed to work with
+        // overlapped handles.
+        #[cfg(target_os = "windows")]
+        let mut cmd = cmd.into_std();
+
         let mut child =
             cmd.stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped()).spawn()?;
-        let reader =
-            Box::new(child.stdout.take().ok_or_else(|| Error::other("Can't open stdout"))?);
-        let writer = Box::new(child.stdin.take().ok_or_else(|| Error::other("Can't open stdin"))?);
+        let reader_inner = child.stdout.take().ok_or_else(|| Error::other("Can't open stdout"))?;
+        let writer_inner = child.stdin.take().ok_or_else(|| Error::other("Can't open stdin"))?;
+        let stderr_reader_inner =
+            child.stderr.take().ok_or_else(|| Error::other("Can't open stderr"))?;
 
-        let stderr_reader =
-            Box::new(child.stderr.take().ok_or_else(|| Error::other("Can't open stderr"))?);
+        let reader: BoxedReader;
+        let writer: BoxedWriter;
+        let stderr_reader: BoxedReader;
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            reader = Box::new(reader_inner);
+            writer = Box::new(writer_inner);
+            stderr_reader = Box::new(stderr_reader_inner);
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            use std::os::windows::io::IntoRawHandle;
+            use tokio::net::windows::named_pipe::NamedPipeServer;
+            reader = Box::new(unsafe {
+                NamedPipeServer::from_raw_handle(reader_inner.into_raw_handle())
+            }?);
+            writer = Box::new(unsafe {
+                NamedPipeServer::from_raw_handle(writer_inner.into_raw_handle())
+            }?);
+            stderr_reader = Box::new(unsafe {
+                NamedPipeServer::from_raw_handle(stderr_reader_inner.into_raw_handle())
+            }?);
+        }
 
         Ok((reader, writer, Some(stderr_reader), Some(child)))
     }

--- a/src/bridge/session.rs
+++ b/src/bridge/session.rs
@@ -132,17 +132,19 @@ impl NeovimInstance {
     ) -> Result<(BoxedReader, BoxedWriter, Option<BoxedReader>, Option<Child>)> {
         log::debug!("Starting neovim with: {cmd:?}");
 
-        // On Windows, `std::process::Command` creates the parent-side pipe handles
-        // as overlapped. When this is wrapped in `tokio::process::Command`, the
-        // handles are wrapped in `Blocking<ArcFile>`, which results in
-        // `std::sys::pal::windows::handle::Handle::synchronous_read`, being calld
-        // on them. This can cause an abort by design if the read doesn't complete
-        // synchronously.
-        // See [File implementation on Windows has unsound methods](https://github.com/rust-lang/rust/issues/81357).
+        // On Windows, the stdio pipes we get for a spawned child are overlapped
+        // handles. if we pass those handles through tokio's process wrapper, it
+        // turns them into Blocking<ArcFile>, which can eventually call
+        // std::sys::pal::windows::handle::Handle::synchronous_read.
         //
-        // Instead, use `std::process::Command` directly to get raw handles, and
-        // wrap them in `NamedPipeServer`, which is designed to work with
-        // overlapped handles.
+        // Rust intentionally aborts on that path when an overlapped operation is
+        // still pending instead of completing synchronously.
+        //
+        // See https://github.com/rust-lang/rust/issues/81357
+        //
+        // We avoid that path by using std::process::Command directly on
+        // Windows, taking the raw pipe handles, and wrapping them in
+        // NamedPipeServer, which supports overlapped pipe I/O.
         #[cfg(target_os = "windows")]
         let mut cmd = cmd.into_std();
 


### PR DESCRIPTION
<!-- Please note that we accept pull requests from anyone, but that does not mean it will be merged. -->

## What kind of change does this PR introduce?
- Fix: Crash on Windows due to synchronous read of overlapped pipe. Resolves #3404 and possibly #2299.

## Did this PR introduce a breaking change? 
_A breaking change includes anything that breaks backwards compatibility either at compile or run time._
- Not that I'm aware of.
